### PR TITLE
feat: complete S4 reconciliation watch + S5 e2e and demo (Phase 1 closure)

### DIFF
--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -11,16 +11,16 @@ make install
 echo ""
 
 echo "2. Starting controller (background)..."
-make run &
+setsid make run &
 CONTROLLER_PID=$!
 sleep 5
-echo "   Controller PID: $CONTROLLER_PID"
+echo "   Controller process group PID: $CONTROLLER_PID"
 echo ""
 
 cleanup() {
     echo ""
     echo "=== Cleaning up ==="
-    kill "$CONTROLLER_PID" 2>/dev/null || true
+    kill -- -"$CONTROLLER_PID" 2>/dev/null || true
     kubectl delete -f config/samples/ntn_v1alpha1_satelliteephemeris.yaml --ignore-not-found 2>/dev/null
     kubectl delete -f config/samples/ntn_v1alpha1_groundstationlifecycle.yaml --ignore-not-found 2>/dev/null
     echo "Done."
@@ -73,7 +73,7 @@ if len(data) > 5:
 " 2>/dev/null || echo "(no passes yet)"
 echo ""
 echo "--- Events ---"
-kubectl describe sateph oneweb-constellation | grep -A10 "^Events:"
+kubectl describe sateph oneweb-constellation | grep -A10 "^Events:" || true
 echo ""
 echo "Press Ctrl+C to stop the demo."
 wait "$CONTROLLER_PID"

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# demo.sh — One-command demo of NTN K8s Operators
+# Installs CRDs, applies samples, and watches status.
+set -euo pipefail
+
+echo "=== NTN K8s Operators Demo ==="
+echo ""
+
+echo "1. Installing CRDs..."
+make install
+echo ""
+
+echo "2. Starting controller (background)..."
+make run &
+CONTROLLER_PID=$!
+sleep 5
+echo "   Controller PID: $CONTROLLER_PID"
+echo ""
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    kill "$CONTROLLER_PID" 2>/dev/null || true
+    kubectl delete -f config/samples/ntn_v1alpha1_satelliteephemeris.yaml --ignore-not-found 2>/dev/null
+    kubectl delete -f config/samples/ntn_v1alpha1_groundstationlifecycle.yaml --ignore-not-found 2>/dev/null
+    echo "Done."
+}
+trap cleanup EXIT
+
+echo "3. Creating GroundStationLifecycle (gs-taipei-01)..."
+kubectl apply -f config/samples/ntn_v1alpha1_groundstationlifecycle.yaml
+echo ""
+
+echo "4. Creating SatelliteEphemeris (oneweb-constellation)..."
+kubectl apply -f config/samples/ntn_v1alpha1_satelliteephemeris.yaml
+echo ""
+
+echo "5. Waiting for reconciliation..."
+sleep 15
+
+echo ""
+echo "=== Results ==="
+echo ""
+echo "--- kubectl get sateph ---"
+kubectl get sateph -o wide
+echo ""
+echo "--- kubectl get gs ---"
+kubectl get gs -o wide
+echo ""
+echo "--- Conditions ---"
+kubectl get sateph oneweb-constellation -o jsonpath='{range .status.conditions[*]}{.type}: {.status} ({.reason}) - {.message}{"\n"}{end}'
+echo ""
+echo "--- Pass Windows (first 5) ---"
+kubectl get sateph oneweb-constellation -o jsonpath='{.status.nextPassWindows}' | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(f'Total: {len(data)} passes')
+for p in data[:5]:
+    print(f\"  {p['satellite']:20s} over {p['groundStation']:15s} AOS={p['aos'][:19]} LOS={p['los'][:19]} MaxEl={p['maxElevation']}°\")
+if len(data) > 5:
+    print(f'  ... and {len(data)-5} more')
+" 2>/dev/null || echo "(no passes yet)"
+echo ""
+echo "--- Events ---"
+kubectl describe sateph oneweb-constellation | grep -A10 "^Events:"
+echo ""
+echo "Press Ctrl+C to stop the demo."
+wait "$CONTROLLER_PID"

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -76,4 +76,4 @@ echo "--- Events ---"
 kubectl describe sateph oneweb-constellation | grep -A10 "^Events:" || true
 echo ""
 echo "Press Ctrl+C to stop the demo."
-wait "$CONTROLLER_PID"
+wait "$CONTROLLER_PID" || true

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -36,7 +36,14 @@ kubectl apply -f config/samples/ntn_v1alpha1_satelliteephemeris.yaml
 echo ""
 
 echo "5. Waiting for reconciliation..."
-sleep 15
+for i in $(seq 1 30); do
+    count=$(kubectl get sateph oneweb-constellation -o jsonpath='{.status.satelliteCount}' 2>/dev/null || echo "")
+    if [ -n "$count" ] && [ "$count" != "0" ]; then
+        echo "   Reconciled after $((i * 2))s (satelliteCount=$count)"
+        break
+    fi
+    sleep 2
+done
 
 echo ""
 echo "=== Results ==="

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -58,9 +58,13 @@ echo "--- Conditions ---"
 kubectl get sateph oneweb-constellation -o jsonpath='{range .status.conditions[*]}{.type}: {.status} ({.reason}) - {.message}{"\n"}{end}'
 echo ""
 echo "--- Pass Windows (first 5) ---"
-kubectl get sateph oneweb-constellation -o jsonpath='{.status.nextPassWindows}' | python3 -c "
+kubectl get sateph oneweb-constellation -o json | python3 -c "
 import sys, json
-data = json.load(sys.stdin)
+doc = json.load(sys.stdin)
+data = doc.get('status', {}).get('nextPassWindows') or []
+if not data:
+    print('(no passes yet)')
+    sys.exit(0)
 print(f'Total: {len(data)} passes')
 for p in data[:5]:
     print(f\"  {p['satellite']:20s} over {p['groundStation']:15s} AOS={p['aos'][:19]} LOS={p['los'][:19]} MaxEl={p['maxElevation']}°\")

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -327,8 +327,11 @@ func (r *SatelliteEphemerisReconciler) GroundStationToEphemeris(
 		return nil
 	}
 
+	log := logf.FromContext(ctx)
+
 	var ephList ntnv1alpha1.SatelliteEphemerisList
 	if err := r.List(ctx, &ephList, client.InNamespace(gs.Namespace)); err != nil {
+		log.Error(err, "Failed to list SatelliteEphemeris for ground station mapper")
 		return nil
 	}
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -20,9 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	"slices"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -311,15 +311,15 @@ func (r *SatelliteEphemerisReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ntnv1alpha1.SatelliteEphemeris{}).
 		Watches(&ntnv1alpha1.GroundStationLifecycle{},
-			handler.EnqueueRequestsFromMapFunc(r.GroundStationToEphemeris),
+			handler.EnqueueRequestsFromMapFunc(r.groundStationToEphemeris),
 		).
 		Named("satelliteephemeris").
 		Complete(r)
 }
 
-// GroundStationToEphemeris maps a GroundStationLifecycle change to all
+// groundStationToEphemeris maps a GroundStationLifecycle change to all
 // SatelliteEphemeris resources that reference it in passPrediction.groundStations.
-func (r *SatelliteEphemerisReconciler) GroundStationToEphemeris(
+func (r *SatelliteEphemerisReconciler) groundStationToEphemeris(
 	ctx context.Context, obj client.Object,
 ) []reconcile.Request {
 	gs, ok := obj.(*ntnv1alpha1.GroundStationLifecycle)

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -22,13 +22,18 @@ import (
 	"fmt"
 	"time"
 
+	"slices"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
@@ -300,9 +305,46 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// Watches GroundStationLifecycle changes to trigger pass re-prediction
+// when ground stations are added, modified, or deleted.
 func (r *SatelliteEphemerisReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ntnv1alpha1.SatelliteEphemeris{}).
+		Watches(&ntnv1alpha1.GroundStationLifecycle{},
+			handler.EnqueueRequestsFromMapFunc(r.GroundStationToEphemeris),
+		).
 		Named("satelliteephemeris").
 		Complete(r)
+}
+
+// GroundStationToEphemeris maps a GroundStationLifecycle change to all
+// SatelliteEphemeris resources that reference it in passPrediction.groundStations.
+func (r *SatelliteEphemerisReconciler) GroundStationToEphemeris(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	gs, ok := obj.(*ntnv1alpha1.GroundStationLifecycle)
+	if !ok {
+		return nil
+	}
+
+	var ephList ntnv1alpha1.SatelliteEphemerisList
+	if err := r.List(ctx, &ephList, client.InNamespace(gs.Namespace)); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, eph := range ephList.Items {
+		if eph.Spec.PassPrediction == nil {
+			continue
+		}
+		if slices.Contains(eph.Spec.PassPrediction.GroundStations, gs.Name) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      eph.Name,
+					Namespace: eph.Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -461,4 +461,50 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			Expect(predCond).To(BeNil())
 		})
 	})
+
+	// --- S4 Tests: Watch GroundStationLifecycle changes ---
+
+	Context("When a GroundStationLifecycle changes", func() {
+		BeforeEach(func() {
+			createGroundStation()
+			createResourceWithPassPrediction()
+		})
+		AfterEach(func() {
+			deleteResource()
+			deleteGroundStation()
+		})
+
+		It("should map ground station to referencing ephemeris resources", func() {
+			reconciler := newReconciler(&mockGPFetcher{})
+
+			gs := &ntnv1alpha1.GroundStationLifecycle{}
+			Expect(k8sClient.Get(context.Background(),
+				types.NamespacedName{Name: gsName, Namespace: namespace}, gs)).To(Succeed())
+
+			requests := reconciler.GroundStationToEphemeris(context.Background(), gs)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal(resourceName))
+		})
+
+		It("should not map ground station that no ephemeris references", func() {
+			reconciler := newReconciler(&mockGPFetcher{})
+
+			unreferenced := &ntnv1alpha1.GroundStationLifecycle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gs-unreferenced",
+					Namespace: namespace,
+				},
+				Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+					Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "test", Model: "test"},
+					Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "0", Lon: "0"}},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), unreferenced)).To(Succeed())
+
+			requests := reconciler.GroundStationToEphemeris(context.Background(), unreferenced)
+			Expect(requests).To(BeEmpty())
+
+			Expect(k8sClient.Delete(context.Background(), unreferenced)).To(Succeed())
+		})
+	})
 })

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -481,7 +481,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			Expect(k8sClient.Get(context.Background(),
 				types.NamespacedName{Name: gsName, Namespace: namespace}, gs)).To(Succeed())
 
-			requests := reconciler.GroundStationToEphemeris(context.Background(), gs)
+			requests := reconciler.groundStationToEphemeris(context.Background(), gs)
 			Expect(requests).To(HaveLen(1))
 			Expect(requests[0].Name).To(Equal(resourceName))
 		})
@@ -501,7 +501,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			}
 			Expect(k8sClient.Create(context.Background(), unreferenced)).To(Succeed())
 
-			requests := reconciler.GroundStationToEphemeris(context.Background(), unreferenced)
+			requests := reconciler.groundStationToEphemeris(context.Background(), unreferenced)
 			Expect(requests).To(BeEmpty())
 
 			Expect(k8sClient.Delete(context.Background(), unreferenced)).To(Succeed())

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -500,11 +500,12 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), unreferenced)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(context.Background(), unreferenced)
+			})
 
 			requests := reconciler.groundStationToEphemeris(context.Background(), unreferenced)
 			Expect(requests).To(BeEmpty())
-
-			Expect(k8sClient.Delete(context.Background(), unreferenced)).To(Succeed())
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -272,23 +272,34 @@ var _ = Describe("Manager", Ordered, func() {
 
 		// NOTE: filepath.Join paths are relative to repo root, which is the CWD
 		// when invoked via `make test-e2e` (consistent with scaffold tests above).
+		// Resources are created in the default namespace (samples have no namespace set).
 		It("should reconcile SatelliteEphemeris and populate status", func() {
+			const testNS = "default"
+
 			By("creating a GroundStationLifecycle resource")
-			cmd := exec.Command("kubectl", "apply", "-f",
+			cmd := exec.Command("kubectl", "apply", "-n", testNS, "-f",
 				filepath.Join("config", "samples", "ntn_v1alpha1_groundstationlifecycle.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "-n", testNS, "gs", "gs-taipei-01", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
 
 			By("creating a SatelliteEphemeris resource")
-			cmd = exec.Command("kubectl", "apply", "-f",
+			cmd = exec.Command("kubectl", "apply", "-n", testNS, "-f",
 				filepath.Join("config", "samples", "ntn_v1alpha1_satelliteephemeris.yaml"))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "-n", testNS, "sateph", "oneweb-constellation", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
 
 			By("verifying that satelliteCount is populated")
 			verifySatelliteCount := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
-					"-o", "jsonpath={.status.satelliteCount}")
+					"-n", testNS, "-o", "jsonpath={.status.satelliteCount}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).NotTo(BeEmpty(), "satelliteCount should be set")
@@ -297,27 +308,24 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(verifySatelliteCount, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("verifying that lastUpdated is set")
-			cmd = exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
-				"-o", "jsonpath={.status.lastUpdated}")
-			output, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).NotTo(BeEmpty(), "lastUpdated should be set")
+			verifyLastUpdated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
+					"-n", testNS, "-o", "jsonpath={.status.lastUpdated}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "lastUpdated should be set")
+			}
+			Eventually(verifyLastUpdated, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("verifying that GPDataFetched condition is True")
 			verifyCondition := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
-					"-o", "jsonpath={.status.conditions[?(@.type=='GPDataFetched')].status}")
+					"-n", testNS, "-o", "jsonpath={.status.conditions[?(@.type=='GPDataFetched')].status}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("True"))
 			}
 			Eventually(verifyCondition, 2*time.Minute, 5*time.Second).Should(Succeed())
-
-			By("cleaning up test resources")
-			cmd = exec.Command("kubectl", "delete", "sateph", "oneweb-constellation", "--ignore-not-found")
-			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "gs", "gs-taipei-01", "--ignore-not-found")
-			_, _ = utils.Run(cmd)
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -270,15 +270,53 @@ var _ = Describe("Manager", Ordered, func() {
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput, err := getMetricsOutput()
-		// Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
+		It("should reconcile SatelliteEphemeris and populate status", func() {
+			By("creating a GroundStationLifecycle resource")
+			cmd := exec.Command("kubectl", "apply", "-f",
+				filepath.Join("config", "samples", "ntn_v1alpha1_groundstationlifecycle.yaml"))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a SatelliteEphemeris resource")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				filepath.Join("config", "samples", "ntn_v1alpha1_satelliteephemeris.yaml"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying that satelliteCount is populated")
+			verifySatelliteCount := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
+					"-o", "jsonpath={.status.satelliteCount}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "satelliteCount should be set")
+				g.Expect(output).NotTo(Equal("0"), "satelliteCount should not be 0")
+			}
+			Eventually(verifySatelliteCount, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying that lastUpdated is set")
+			cmd = exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
+				"-o", "jsonpath={.status.lastUpdated}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(BeEmpty(), "lastUpdated should be set")
+
+			By("verifying that GPDataFetched condition is True")
+			verifyCondition := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "sateph", "oneweb-constellation",
+					"-o", "jsonpath={.status.conditions[?(@.type=='GPDataFetched')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}
+			Eventually(verifyCondition, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("cleaning up test resources")
+			cmd = exec.Command("kubectl", "delete", "sateph", "oneweb-constellation", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "gs", "gs-taipei-01", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
 	})
 })
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -270,6 +270,8 @@ var _ = Describe("Manager", Ordered, func() {
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
+		// NOTE: filepath.Join paths are relative to repo root, which is the CWD
+		// when invoked via `make test-e2e` (consistent with scaffold tests above).
 		It("should reconcile SatelliteEphemeris and populate status", func() {
 			By("creating a GroundStationLifecycle resource")
 			cmd := exec.Command("kubectl", "apply", "-f",


### PR DESCRIPTION
## Summary

- **S4**: Watch `GroundStationLifecycle` changes → auto re-predict passes when ground stations are added/modified/deleted
- **S5**: E2E test with CRD business logic verification + `hack/demo.sh` one-command demo script

This PR closes Phase 1 (SatelliteEphemeris) — all 5 sprints complete.

## Changes

### S4 — Reconciliation Watch
- `SetupWithManager` now `Watches(&GroundStationLifecycle{})` with `GroundStationToEphemeris` mapper
- Mapper finds all `SatelliteEphemeris` CRs that reference the changed ground station in `spec.passPrediction.groundStations`
- Tests verify correct mapping and ignoring unreferenced stations

### S5 — E2E + Demo
- `test/e2e/e2e_test.go`: Apply sample CRs → verify `satelliteCount`, `lastUpdated`, `GPDataFetched=True`
- `hack/demo.sh`: Install CRDs → start controller → apply samples → show status, passes, events

## Test coverage

| Package | Coverage |
|---------|----------|
| `internal/controller` | 86.4% |
| `pkg/ephemeris` | 91.7% |

## Test plan

- [x] `make test` — all pass, coverage ≥80%
- [x] `make lint` — 0 issues
- [ ] CI lint + test pass
