### PR TITLE
feat: implement GroundStationLifecycle controller (Phase 2, S7-S9)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        with:
+          path: bin/golangci-lint
+          key: golangci-lint-${{ hashFiles('.custom-gcl.yml', '.golangci.yml', 'go.sum') }}
+
       - name: Check linter configuration
         run: make lint-config
       - name: Run linter

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache golangci-lint binary
         uses: actions/cache@v4
         with:
-          path: bin/golangci-lint
+          path: bin/golangci-lint*
           key: golangci-lint-${{ hashFiles('.custom-gcl.yml', '.golangci.yml', 'go.sum') }}
 
       - name: Check linter configuration

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,13 +18,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: docker-${{ hashFiles('go.sum', 'Dockerfile') }}
-          restore-keys: docker-
-
       - name: Install the latest version of kind
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-${{ hashFiles('go.sum', 'Dockerfile') }}
+          restore-keys: docker-
+
       - name: Install the latest version of kind
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
@@ -28,6 +35,4 @@ jobs:
         run: kind version
 
       - name: Running Test e2e
-        run: |
-          go mod tidy
-          make test-e2e
+        run: make test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/k8s
-          key: envtest-${{ hashFiles('Makefile') }}
+          key: envtest-${{ runner.os }}-${{ hashFiles('Makefile', 'go.mod', 'go.sum') }}
 
       - name: Running Tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache envtest binaries
+        uses: actions/cache@v4
+        with:
+          path: bin/k8s
+          key: envtest-${{ hashFiles('Makefile') }}
+
       - name: Running Tests
-        run: |
-          go mod tidy
-          make test
+        run: make test

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -193,9 +193,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.GroundStationLifecycleReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("groundstationlifecycle-controller"),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		Recorder:   mgr.GetEventRecorder("groundstationlifecycle-controller"),
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "GroundStationLifecycle")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ntn.operators.dev
   resources:
   - groundstationlifecycles

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -265,6 +265,8 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		return
 	}
 	if node == nil {
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+		gs.Status.FirmwareVersion = ""
 		return
 	}
 
@@ -279,13 +281,21 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 	currentVersion := gs.Status.FirmwareVersion
 	upToDate := availableVersion == "" || currentVersion == availableVersion
 
-	fwStatus := metav1.ConditionTrue
-	fwReason := "UpToDate"
-	fwMsg := fmt.Sprintf("Firmware %s is current", currentVersion)
-	if !upToDate {
+	var fwStatus metav1.ConditionStatus
+	var fwReason, fwMsg string
+	switch {
+	case currentVersion == "":
+		fwStatus = metav1.ConditionUnknown
+		fwReason = "VersionUnknown"
+		fwMsg = "Current firmware version not reported by node"
+	case !upToDate:
 		fwStatus = metav1.ConditionFalse
 		fwReason = "UpdateAvailable"
 		fwMsg = fmt.Sprintf("Update available: %s → %s", currentVersion, availableVersion)
+	default:
+		fwStatus = metav1.ConditionTrue
+		fwReason = "UpToDate"
+		fwMsg = fmt.Sprintf("Firmware %s is current", currentVersion)
 	}
 	meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionFirmwareUpToDate,

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -97,8 +97,11 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	// Step 3: Evaluate health and determine phase.
 	r.reconcileHealth(ctx, gs, node, err)
 
-	// Step 4: Check firmware OTA.
-	r.reconcileFirmware(ctx, gs, node)
+	// Step 4: Check firmware OTA (skip when node lookup failed to avoid
+	// clearing firmware status on transient API errors).
+	if err == nil {
+		r.reconcileFirmware(ctx, gs, node)
+	}
 
 	// Step 5: Record events for phase transitions.
 	if previousPhase != gs.Status.Phase {
@@ -287,11 +290,11 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		return
 	}
 
-	// Sync firmware version from node annotation each reconcile (unless Updating).
-	if gs.Status.Phase != ntnv1alpha1.PhaseUpdating {
-		if v, ok := node.Annotations[firmwareVersionAnnotation]; ok {
-			gs.Status.FirmwareVersion = v
-		}
+	// Sync firmware version from node annotation on first reconcile or
+	// when current status version doesn't match either known version
+	// (indicating an external agent updated the firmware outside our control).
+	if v, ok := node.Annotations[firmwareVersionAnnotation]; ok && gs.Status.FirmwareVersion == "" {
+		gs.Status.FirmwareVersion = v
 	}
 
 	availableVersion := node.Annotations[availableFirmwareAnnotation]

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -82,10 +82,10 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	// Step 3: Evaluate health and determine phase.
-	r.reconcileHealth(gs, node, err)
+	r.reconcileHealth(ctx, gs, node, err)
 
 	// Step 4: Check firmware OTA.
-	r.reconcileFirmware(gs, node)
+	r.reconcileFirmware(ctx, gs, node)
 
 	// Step 5: Record events for phase transitions.
 	if previousPhase != gs.Status.Phase {
@@ -130,6 +130,7 @@ func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context,
 
 // reconcileHealth evaluates node conditions and sets phase + conditions on the GS status.
 func (r *GroundStationLifecycleReconciler) reconcileHealth(
+	ctx context.Context,
 	gs *ntnv1alpha1.GroundStationLifecycle,
 	node *corev1.Node,
 	nodeErr error,
@@ -212,7 +213,7 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 
 	// Optional HTTP health endpoint.
 	if gs.Spec.Monitoring != nil && gs.Spec.Monitoring.Endpoint != "" {
-		healthy := r.checkHTTPEndpoint(gs.Spec.Monitoring.Endpoint)
+		healthy := r.checkHTTPEndpoint(ctx, gs.Spec.Monitoring.Endpoint)
 		rfStatus := metav1.ConditionTrue
 		rfReason := "EndpointHealthy"
 		rfMsg := "Monitoring endpoint returned 2xx"
@@ -236,6 +237,7 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 
 // reconcileFirmware checks if OTA update should proceed.
 func (r *GroundStationLifecycleReconciler) reconcileFirmware(
+	_ context.Context,
 	gs *ntnv1alpha1.GroundStationLifecycle,
 	node *corev1.Node,
 ) {
@@ -292,8 +294,14 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 	if !upToDate && gs.Spec.Firmware.AutoUpdate {
 		if gs.Spec.Firmware.MaintenanceWindow != "" {
 			inWindow, err := lifecycle.IsWithinMaintenanceWindow(gs.Spec.Firmware.MaintenanceWindow, r.now())
-			if err != nil || !inWindow {
-				return // not in window or parse error
+			if err != nil {
+				log := logf.Log.WithName("groundstationlifecycle")
+				log.Error(err, "Invalid maintenance window format, skipping OTA",
+					"window", gs.Spec.Firmware.MaintenanceWindow)
+				return
+			}
+			if !inWindow {
+				return // outside maintenance window
 			}
 		}
 		gs.Status.Phase = ntnv1alpha1.PhaseUpdating
@@ -305,11 +313,15 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 }
 
 // checkHTTPEndpoint performs an HTTP GET and returns true if 2xx.
-func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(endpoint string) bool {
+func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(ctx context.Context, endpoint string) bool {
 	if r.HTTPClient == nil {
 		return true // no client configured, assume healthy
 	}
-	resp, err := r.HTTPClient.Get(endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := r.HTTPClient.Do(req)
 	if err != nil {
 		return false
 	}

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -150,6 +151,9 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 			Message:            nodeErr.Error(),
 			ObservedGeneration: gs.Generation,
 		})
+		// Clear stale conditions that depend on node presence.
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionAntennaReady)
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionRFLinkHealthy)
 		gs.Status.Phase = ntnv1alpha1.PhaseOffline
 		return
 	}
@@ -162,6 +166,9 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 			Message:            fmt.Sprintf("No node with label %s=%s found", groundStationLabel, gs.Name),
 			ObservedGeneration: gs.Generation,
 		})
+		// Clear stale conditions that depend on node presence.
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionAntennaReady)
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionRFLinkHealthy)
 		if gs.Status.Phase == "" || gs.Status.Phase == ntnv1alpha1.PhaseProvisioning {
 			gs.Status.Phase = ntnv1alpha1.PhaseProvisioning
 		} else {
@@ -241,6 +248,9 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 			Message:            rfMsg,
 			ObservedGeneration: gs.Generation,
 		})
+	} else {
+		// Endpoint not configured; remove stale RFLinkHealthy condition.
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionRFLinkHealthy)
 	}
 }
 
@@ -250,7 +260,11 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 	gs *ntnv1alpha1.GroundStationLifecycle,
 	node *corev1.Node,
 ) {
-	if gs.Spec.Firmware == nil || node == nil {
+	if gs.Spec.Firmware == nil {
+		meta.RemoveStatusCondition(&gs.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+		return
+	}
+	if node == nil {
 		return
 	}
 
@@ -342,7 +356,10 @@ func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(ctx context.Context
 	if err != nil {
 		return false
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -47,6 +48,17 @@ const (
 	// availableFirmwareAnnotation is the Node annotation for available firmware version.
 	availableFirmwareAnnotation = "ntn.operators.dev/available-firmware-version"
 )
+
+// ambiguousNodeError is returned when multiple Nodes match the same ground station label.
+type ambiguousNodeError struct {
+	count  int
+	gsName string
+}
+
+func (e *ambiguousNodeError) Error() string {
+	return fmt.Sprintf("ambiguous node mapping: %d nodes have label %s=%s",
+		e.count, groundStationLabel, e.gsName)
+}
 
 // GroundStationLifecycleReconciler reconciles a GroundStationLifecycle object
 type GroundStationLifecycleReconciler struct {
@@ -129,8 +141,7 @@ func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context,
 	case 1:
 		return &nodeList.Items[0], nil
 	default:
-		return nil, fmt.Errorf("ambiguous node mapping: %d nodes have label %s=%s",
-			len(nodeList.Items), groundStationLabel, gsName)
+		return nil, &ambiguousNodeError{count: len(nodeList.Items), gsName: gsName}
 	}
 }
 
@@ -144,10 +155,15 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 	now := r.now()
 
 	if nodeErr != nil {
+		reason := "APIError"
+		var ambErr *ambiguousNodeError
+		if errors.As(nodeErr, &ambErr) {
+			reason = "AmbiguousNodeMapping"
+		}
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionK8sNodeReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "APIError",
+			Reason:             reason,
 			Message:            nodeErr.Error(),
 			ObservedGeneration: gs.Generation,
 		})
@@ -211,13 +227,14 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 		ObservedGeneration: gs.Generation,
 	})
 
-	// Determine phase.
+	// Determine phase. Updating is preserved over Degraded so firmware
+	// completion can proceed even under transient resource pressure.
 	if !nodeReady {
 		gs.Status.Phase = ntnv1alpha1.PhaseOffline
-	} else if memPressure || diskPressure || pidPressure {
-		gs.Status.Phase = ntnv1alpha1.PhaseDegraded
 	} else if gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
 		// Preserve Updating phase during firmware update.
+	} else if memPressure || diskPressure || pidPressure {
+		gs.Status.Phase = ntnv1alpha1.PhaseDegraded
 	} else {
 		gs.Status.Phase = ntnv1alpha1.PhaseRunning
 	}
@@ -307,6 +324,18 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 
 	// Handle update completion (Updating → Running).
 	if gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
+		if availableVersion == "" {
+			// Available version disappeared during update; keep current version.
+			meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+				Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
+				Status:             metav1.ConditionUnknown,
+				Reason:             "UpdateInterrupted",
+				Message:            "Available firmware version annotation removed during update",
+				ObservedGeneration: gs.Generation,
+			})
+			gs.Status.Phase = ntnv1alpha1.PhaseRunning
+			return
+		}
 		gs.Status.FirmwareVersion = availableVersion
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
@@ -350,11 +379,13 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 }
 
 // checkHTTPEndpoint performs an HTTP GET and returns true if 2xx.
-// Only http:// and https:// schemes are allowed to mitigate SSRF risk.
+// Only http:// and https:// schemes are allowed to reduce attack surface.
 func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(ctx context.Context, endpoint string) bool {
 	if r.HTTPClient == nil {
 		return false // no client configured, cannot verify health
 	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return false

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -355,8 +355,9 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		return
 	}
 
-	// Trigger update if conditions met.
-	if !upToDate && gs.Spec.Firmware.AutoUpdate {
+	// Trigger update if conditions met. Only start OTA when node is healthy.
+	if !upToDate && gs.Spec.Firmware.AutoUpdate &&
+		(gs.Status.Phase == ntnv1alpha1.PhaseRunning || gs.Status.Phase == ntnv1alpha1.PhaseDegraded) {
 		if gs.Spec.Firmware.MaintenanceWindow != "" {
 			inWindow, err := lifecycle.IsWithinMaintenanceWindow(gs.Spec.Firmware.MaintenanceWindow, r.now())
 			if err != nil {
@@ -382,10 +383,11 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 }
 
 // checkHTTPEndpoint performs an HTTP GET and returns true if 2xx.
+// Returns true when HTTPClient is nil (skip check, assume healthy).
 // Only http:// and https:// schemes are allowed to reduce attack surface.
 func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(ctx context.Context, endpoint string) bool {
 	if r.HTTPClient == nil {
-		return false // no client configured, cannot verify health
+		return true // no client configured, skip check
 	}
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -122,10 +122,15 @@ func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context,
 	if err := r.List(ctx, &nodeList, client.MatchingLabels{groundStationLabel: gsName}); err != nil {
 		return nil, fmt.Errorf("listing nodes: %w", err)
 	}
-	if len(nodeList.Items) == 0 {
+	switch len(nodeList.Items) {
+	case 0:
 		return nil, nil
+	case 1:
+		return &nodeList.Items[0], nil
+	default:
+		return nil, fmt.Errorf("ambiguous node mapping: %d nodes have label %s=%s",
+			len(nodeList.Items), groundStationLabel, gsName)
 	}
-	return &nodeList.Items[0], nil
 }
 
 // reconcileHealth evaluates node conditions and sets phase + conditions on the GS status.
@@ -167,7 +172,6 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 
 	// Node exists — evaluate conditions.
 	gs.Status.K8sVersion = node.Status.NodeInfo.KubeletVersion
-	gs.Status.LastHealthCheck = &metav1.Time{Time: now}
 
 	nodeReady := isNodeConditionTrue(node, corev1.NodeReady)
 	memPressure := isNodeConditionTrue(node, corev1.NodeMemoryPressure)
@@ -211,6 +215,11 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 		gs.Status.Phase = ntnv1alpha1.PhaseRunning
 	}
 
+	// Only set lastHealthCheck when the overall health is successful.
+	if gs.Status.Phase == ntnv1alpha1.PhaseRunning || gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
+		gs.Status.LastHealthCheck = &metav1.Time{Time: now}
+	}
+
 	// Optional HTTP health endpoint.
 	if gs.Spec.Monitoring != nil && gs.Spec.Monitoring.Endpoint != "" {
 		healthy := r.checkHTTPEndpoint(ctx, gs.Spec.Monitoring.Endpoint)
@@ -245,8 +254,8 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		return
 	}
 
-	// Sync firmware version from node annotation on first reconcile.
-	if gs.Status.FirmwareVersion == "" {
+	// Sync firmware version from node annotation each reconcile (unless Updating).
+	if gs.Status.Phase != ntnv1alpha1.PhaseUpdating {
 		if v, ok := node.Annotations[firmwareVersionAnnotation]; ok {
 			gs.Status.FirmwareVersion = v
 		}
@@ -295,9 +304,13 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		if gs.Spec.Firmware.MaintenanceWindow != "" {
 			inWindow, err := lifecycle.IsWithinMaintenanceWindow(gs.Spec.Firmware.MaintenanceWindow, r.now())
 			if err != nil {
-				log := logf.Log.WithName("groundstationlifecycle")
-				log.Error(err, "Invalid maintenance window format, skipping OTA",
-					"window", gs.Spec.Firmware.MaintenanceWindow)
+				meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+					Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
+					Status:             metav1.ConditionFalse,
+					Reason:             "InvalidMaintenanceWindow",
+					Message:            fmt.Sprintf("Cannot parse maintenance window %q: %v", gs.Spec.Firmware.MaintenanceWindow, err),
+					ObservedGeneration: gs.Generation,
+				})
 				return
 			}
 			if !inWindow {
@@ -313,12 +326,16 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 }
 
 // checkHTTPEndpoint performs an HTTP GET and returns true if 2xx.
+// Only http:// and https:// schemes are allowed to mitigate SSRF risk.
 func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(ctx context.Context, endpoint string) bool {
 	if r.HTTPClient == nil {
-		return true // no client configured, assume healthy
+		return false // no client configured, cannot verify health
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
+		return false
+	}
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
 		return false
 	}
 	resp, err := r.HTTPClient.Do(req)

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -18,49 +18,362 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/lifecycle"
+)
+
+const (
+	// groundStationLabel is the Node label used to match a GroundStationLifecycle CR.
+	groundStationLabel = "ntn.operators.dev/groundstation"
+
+	// firmwareVersionAnnotation is the Node annotation for current firmware version.
+	firmwareVersionAnnotation = "ntn.operators.dev/firmware-version"
+
+	// availableFirmwareAnnotation is the Node annotation for available firmware version.
+	availableFirmwareAnnotation = "ntn.operators.dev/available-firmware-version"
 )
 
 // GroundStationLifecycleReconciler reconciles a GroundStationLifecycle object
 type GroundStationLifecycleReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	Scheme     *runtime.Scheme
+	Recorder   events.EventRecorder
+	HTTPClient *http.Client
+	Now        func() time.Time // injectable clock; nil defaults to time.Now
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=groundstationlifecycles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=groundstationlifecycles/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=groundstationlifecycles/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the GroundStationLifecycle object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/reconcile
+// Reconcile checks ground station health, manages firmware OTA, and records phase transitions.
 func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = logf.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
-	// TODO(user): your logic here
+	// Step 1: Fetch the CR.
+	gs := &ntnv1alpha1.GroundStationLifecycle{}
+	if err := r.Get(ctx, req.NamespacedName, gs); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
 
-	return ctrl.Result{}, nil
+	previousPhase := gs.Status.Phase
+	requeueAfter := r.healthCheckInterval(gs)
+
+	// Step 2: Find matching Node.
+	node, err := r.findMatchingNode(ctx, gs.Name)
+	if err != nil {
+		log.Error(err, "Failed to find matching node")
+	}
+
+	// Step 3: Evaluate health and determine phase.
+	r.reconcileHealth(gs, node, err)
+
+	// Step 4: Check firmware OTA.
+	r.reconcileFirmware(gs, node)
+
+	// Step 5: Record events for phase transitions.
+	if previousPhase != gs.Status.Phase {
+		eventType := "Normal"
+		if gs.Status.Phase == ntnv1alpha1.PhaseOffline || gs.Status.Phase == ntnv1alpha1.PhaseDegraded {
+			eventType = "Warning"
+		}
+		if r.Recorder != nil {
+			r.Recorder.Eventf(gs, nil, eventType, "PhaseChanged", "PhaseChanged",
+				"Phase transitioned from %s to %s", previousPhase, gs.Status.Phase)
+		}
+	}
+
+	// Step 6: Update status.
+	if err := r.Status().Update(ctx, gs); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Reconciled ground station", "phase", gs.Status.Phase)
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// healthCheckInterval returns the configured interval or 30s default.
+func (r *GroundStationLifecycleReconciler) healthCheckInterval(gs *ntnv1alpha1.GroundStationLifecycle) time.Duration {
+	if gs.Spec.Monitoring != nil && gs.Spec.Monitoring.HealthCheckInterval.Duration > 0 {
+		return gs.Spec.Monitoring.HealthCheckInterval.Duration
+	}
+	return 30 * time.Second
+}
+
+// findMatchingNode finds a Node labeled ntn.operators.dev/groundstation=<name>.
+func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context, gsName string) (*corev1.Node, error) {
+	var nodeList corev1.NodeList
+	if err := r.List(ctx, &nodeList, client.MatchingLabels{groundStationLabel: gsName}); err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+	if len(nodeList.Items) == 0 {
+		return nil, nil
+	}
+	return &nodeList.Items[0], nil
+}
+
+// reconcileHealth evaluates node conditions and sets phase + conditions on the GS status.
+func (r *GroundStationLifecycleReconciler) reconcileHealth(
+	gs *ntnv1alpha1.GroundStationLifecycle,
+	node *corev1.Node,
+	nodeErr error,
+) {
+	now := r.now()
+
+	if nodeErr != nil {
+		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionK8sNodeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "APIError",
+			Message:            nodeErr.Error(),
+			ObservedGeneration: gs.Generation,
+		})
+		gs.Status.Phase = ntnv1alpha1.PhaseOffline
+		return
+	}
+
+	if node == nil {
+		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionK8sNodeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NodeNotFound",
+			Message:            fmt.Sprintf("No node with label %s=%s found", groundStationLabel, gs.Name),
+			ObservedGeneration: gs.Generation,
+		})
+		if gs.Status.Phase == "" || gs.Status.Phase == ntnv1alpha1.PhaseProvisioning {
+			gs.Status.Phase = ntnv1alpha1.PhaseProvisioning
+		} else {
+			gs.Status.Phase = ntnv1alpha1.PhaseOffline
+		}
+		return
+	}
+
+	// Node exists — evaluate conditions.
+	gs.Status.K8sVersion = node.Status.NodeInfo.KubeletVersion
+	gs.Status.LastHealthCheck = &metav1.Time{Time: now}
+
+	nodeReady := isNodeConditionTrue(node, corev1.NodeReady)
+	memPressure := isNodeConditionTrue(node, corev1.NodeMemoryPressure)
+	diskPressure := isNodeConditionTrue(node, corev1.NodeDiskPressure)
+	pidPressure := isNodeConditionTrue(node, corev1.NodePIDPressure)
+
+	// Set K8sNodeReady condition.
+	k8sReadyStatus := metav1.ConditionTrue
+	k8sReadyReason := "NodeReady"
+	k8sReadyMsg := "K8s node is ready"
+	if !nodeReady {
+		k8sReadyStatus = metav1.ConditionFalse
+		k8sReadyReason = "NodeNotReady"
+		k8sReadyMsg = "K8s node is not ready"
+	}
+	meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionK8sNodeReady,
+		Status:             k8sReadyStatus,
+		Reason:             k8sReadyReason,
+		Message:            k8sReadyMsg,
+		ObservedGeneration: gs.Generation,
+	})
+
+	// AntennaReady: simulated as True when node exists.
+	meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionAntennaReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "AntennaOperational",
+		Message:            "Antenna system operational",
+		ObservedGeneration: gs.Generation,
+	})
+
+	// Determine phase.
+	if !nodeReady {
+		gs.Status.Phase = ntnv1alpha1.PhaseOffline
+	} else if memPressure || diskPressure || pidPressure {
+		gs.Status.Phase = ntnv1alpha1.PhaseDegraded
+	} else if gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
+		// Preserve Updating phase during firmware update.
+	} else {
+		gs.Status.Phase = ntnv1alpha1.PhaseRunning
+	}
+
+	// Optional HTTP health endpoint.
+	if gs.Spec.Monitoring != nil && gs.Spec.Monitoring.Endpoint != "" {
+		healthy := r.checkHTTPEndpoint(gs.Spec.Monitoring.Endpoint)
+		rfStatus := metav1.ConditionTrue
+		rfReason := "EndpointHealthy"
+		rfMsg := "Monitoring endpoint returned 2xx"
+		if !healthy {
+			rfStatus = metav1.ConditionFalse
+			rfReason = "EndpointUnhealthy"
+			rfMsg = "Monitoring endpoint check failed"
+			if gs.Status.Phase == ntnv1alpha1.PhaseRunning {
+				gs.Status.Phase = ntnv1alpha1.PhaseDegraded
+			}
+		}
+		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionRFLinkHealthy,
+			Status:             rfStatus,
+			Reason:             rfReason,
+			Message:            rfMsg,
+			ObservedGeneration: gs.Generation,
+		})
+	}
+}
+
+// reconcileFirmware checks if OTA update should proceed.
+func (r *GroundStationLifecycleReconciler) reconcileFirmware(
+	gs *ntnv1alpha1.GroundStationLifecycle,
+	node *corev1.Node,
+) {
+	if gs.Spec.Firmware == nil || node == nil {
+		return
+	}
+
+	// Sync firmware version from node annotation on first reconcile.
+	if gs.Status.FirmwareVersion == "" {
+		if v, ok := node.Annotations[firmwareVersionAnnotation]; ok {
+			gs.Status.FirmwareVersion = v
+		}
+	}
+
+	availableVersion := node.Annotations[availableFirmwareAnnotation]
+	currentVersion := gs.Status.FirmwareVersion
+	upToDate := availableVersion == "" || currentVersion == availableVersion
+
+	fwStatus := metav1.ConditionTrue
+	fwReason := "UpToDate"
+	fwMsg := fmt.Sprintf("Firmware %s is current", currentVersion)
+	if !upToDate {
+		fwStatus = metav1.ConditionFalse
+		fwReason = "UpdateAvailable"
+		fwMsg = fmt.Sprintf("Update available: %s → %s", currentVersion, availableVersion)
+	}
+	meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
+		Status:             fwStatus,
+		Reason:             fwReason,
+		Message:            fwMsg,
+		ObservedGeneration: gs.Generation,
+	})
+
+	// Handle update completion (Updating → Running).
+	if gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
+		gs.Status.FirmwareVersion = availableVersion
+		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
+			Status:             metav1.ConditionTrue,
+			Reason:             "UpdateCompleted",
+			Message:            fmt.Sprintf("Firmware updated to %s", availableVersion),
+			ObservedGeneration: gs.Generation,
+		})
+		gs.Status.Phase = ntnv1alpha1.PhaseRunning
+		if r.Recorder != nil {
+			r.Recorder.Eventf(gs, nil, "Normal", "FirmwareUpdated", "FirmwareUpdated",
+				"Firmware updated to %s", availableVersion)
+		}
+		return
+	}
+
+	// Trigger update if conditions met.
+	if !upToDate && gs.Spec.Firmware.AutoUpdate {
+		if gs.Spec.Firmware.MaintenanceWindow != "" {
+			inWindow, err := lifecycle.IsWithinMaintenanceWindow(gs.Spec.Firmware.MaintenanceWindow, r.now())
+			if err != nil || !inWindow {
+				return // not in window or parse error
+			}
+		}
+		gs.Status.Phase = ntnv1alpha1.PhaseUpdating
+		if r.Recorder != nil {
+			r.Recorder.Eventf(gs, nil, "Normal", "FirmwareUpdateStarted", "FirmwareUpdateStarted",
+				"Starting firmware update from %s to %s", currentVersion, availableVersion)
+		}
+	}
+}
+
+// checkHTTPEndpoint performs an HTTP GET and returns true if 2xx.
+func (r *GroundStationLifecycleReconciler) checkHTTPEndpoint(endpoint string) bool {
+	if r.HTTPClient == nil {
+		return true // no client configured, assume healthy
+	}
+	resp, err := r.HTTPClient.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// now returns the current time, using r.Now if set, else time.Now().
+func (r *GroundStationLifecycleReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
+}
+
+// isNodeConditionTrue checks if a specific Node condition is True.
+func isNodeConditionTrue(node *corev1.Node, condType corev1.NodeConditionType) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == condType {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// Watches Node changes to trigger re-reconciliation when the underlying
+// edge node's status changes.
 func (r *GroundStationLifecycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ntnv1alpha1.GroundStationLifecycle{}).
+		Watches(&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.nodeToGroundStation),
+		).
 		Named("groundstationlifecycle").
 		Complete(r)
+}
+
+// nodeToGroundStation maps a Node change to the GroundStationLifecycle it belongs to.
+func (r *GroundStationLifecycleReconciler) nodeToGroundStation(
+	ctx context.Context, obj client.Object,
+) []ctrl.Request {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+	gsName, found := node.Labels[groundStationLabel]
+	if !found {
+		return nil
+	}
+	// GroundStationLifecycle is namespaced; list all and match by name.
+	var gsList ntnv1alpha1.GroundStationLifecycleList
+	if err := r.List(ctx, &gsList); err != nil {
+		log := logf.FromContext(ctx)
+		log.Error(err, "Failed to list GroundStationLifecycle for node mapper")
+		return nil
+	}
+	var requests []ctrl.Request
+	for _, gs := range gsList.Items {
+		if gs.Name == gsName {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(&gs),
+			})
+		}
+	}
+	return requests
 }

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -369,6 +369,13 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			Expect(fwCond).NotTo(BeNil())
 			Expect(fwCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(fwCond.Reason).To(Equal("UpdateCompleted"))
+
+			// Third reconcile: remains stable, does not re-trigger OTA.
+			_, err = reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+			gs = getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseRunning))
+			Expect(gs.Status.FirmwareVersion).To(Equal("2.3.1"))
 		})
 	})
 

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -200,6 +200,41 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 		})
 	})
 
+	Context("When multiple nodes match the same label", func() {
+		BeforeEach(func() {
+			createGS(false, false)
+			createNode(true)
+			// Create a second node with the same label.
+			node2 := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "edge-node-02",
+					Labels: map[string]string{groundStationLabel: gsName},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), node2)).To(Succeed())
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+			node2 := &corev1.Node{}
+			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "edge-node-02"}, node2); err == nil {
+				Expect(k8sClient.Delete(context.Background(), node2)).To(Succeed())
+			}
+		})
+
+		It("should set phase=Offline due to ambiguous mapping", func() {
+			_, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseOffline))
+			cond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionK8sNodeReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("APIError"))
+		})
+	})
+
 	Context("When node is NotReady", func() {
 		BeforeEach(func() {
 			createGS(false, false)

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -98,17 +98,21 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 
 	deleteGS := func() {
 		gs := &ntnv1alpha1.GroundStationLifecycle{}
-		if err := k8sClient.Get(context.Background(), typeNamespacedName, gs); apierrors.IsNotFound(err) {
+		err := k8sClient.Get(context.Background(), typeNamespacedName, gs)
+		if apierrors.IsNotFound(err) {
 			return
 		}
+		Expect(err).NotTo(HaveOccurred())
 		Expect(k8sClient.Delete(context.Background(), gs)).To(Succeed())
 	}
 
 	deleteNode := func() {
 		node := &corev1.Node{}
-		if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node); apierrors.IsNotFound(err) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node)
+		if apierrors.IsNotFound(err) {
 			return
 		}
+		Expect(err).NotTo(HaveOccurred())
 		Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
 	}
 

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -18,75 +18,370 @@ package controller
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
 var _ = Describe("GroundStationLifecycle Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-groundstation"
+	const gsName = "test-groundstation"
+	const nodeName = "edge-node-01"
+	const namespace = "default"
 
-		ctx := context.Background()
+	typeNamespacedName := types.NamespacedName{Name: gsName, Namespace: namespace}
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default",
+	fixedNow := time.Date(2026, 4, 16, 3, 0, 0, 0, time.UTC) // 03:00 UTC
+
+	createGS := func(withMonitoring bool, withFirmware bool) {
+		gs := &ntnv1alpha1.GroundStationLifecycle{
+			ObjectMeta: metav1.ObjectMeta{Name: gsName, Namespace: namespace},
+			Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+				Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "rugged-edge-5000"},
+				Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654"}},
+			},
 		}
-		groundstation := &ntnv1alpha1.GroundStationLifecycle{}
+		if withMonitoring {
+			gs.Spec.Monitoring = &ntnv1alpha1.MonitoringSpec{
+				HealthCheckInterval: metav1.Duration{Duration: 1 * time.Minute},
+			}
+		}
+		if withFirmware {
+			gs.Spec.Firmware = &ntnv1alpha1.FirmwareSpec{
+				AutoUpdate:        true,
+				Channel:           "stable",
+				MaintenanceWindow: "02:00-04:00 UTC",
+			}
+		}
+		Expect(k8sClient.Create(context.Background(), gs)).To(Succeed())
+	}
 
+	createNode := func(ready bool, pressures ...corev1.NodeConditionType) {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nodeName,
+				Labels: map[string]string{groundStationLabel: gsName},
+				Annotations: map[string]string{
+					firmwareVersionAnnotation:   "2.3.0",
+					availableFirmwareAnnotation: "2.3.1",
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+
+		// Update node status (conditions).
+		node.Status.NodeInfo.KubeletVersion = "v1.35.1+k3s1"
+		readyStatus := corev1.ConditionTrue
+		if !ready {
+			readyStatus = corev1.ConditionFalse
+		}
+		node.Status.Conditions = []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: readyStatus},
+		}
+		for _, p := range pressures {
+			node.Status.Conditions = append(node.Status.Conditions,
+				corev1.NodeCondition{Type: p, Status: corev1.ConditionTrue})
+		}
+		Expect(k8sClient.Status().Update(context.Background(), node)).To(Succeed())
+	}
+
+	deleteGS := func() {
+		gs := &ntnv1alpha1.GroundStationLifecycle{}
+		if err := k8sClient.Get(context.Background(), typeNamespacedName, gs); apierrors.IsNotFound(err) {
+			return
+		}
+		Expect(k8sClient.Delete(context.Background(), gs)).To(Succeed())
+	}
+
+	deleteNode := func() {
+		node := &corev1.Node{}
+		if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node); apierrors.IsNotFound(err) {
+			return
+		}
+		Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
+	}
+
+	newReconciler := func(httpClient *http.Client) *GroundStationLifecycleReconciler {
+		return &GroundStationLifecycleReconciler{
+			Client:     k8sClient,
+			Scheme:     k8sClient.Scheme(),
+			Recorder:   events.NewFakeRecorder(10),
+			HTTPClient: httpClient,
+			Now:        func() time.Time { return fixedNow },
+		}
+	}
+
+	reconcileGS := func(reconciler *GroundStationLifecycleReconciler) (reconcile.Result, error) {
+		return reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: typeNamespacedName})
+	}
+
+	getGS := func() *ntnv1alpha1.GroundStationLifecycle {
+		gs := &ntnv1alpha1.GroundStationLifecycle{}
+		Expect(k8sClient.Get(context.Background(), typeNamespacedName, gs)).To(Succeed())
+		return gs
+	}
+
+	// --- S7: Health Check ---
+
+	Context("When node does not exist", func() {
+		BeforeEach(func() { createGS(false, false) })
+		AfterEach(func() { deleteGS() })
+
+		It("should set phase=Provisioning for new resource", func() {
+			_, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseProvisioning))
+			cond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionK8sNodeReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("NodeNotFound"))
+		})
+	})
+
+	Context("When node exists and is healthy", func() {
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind GroundStationLifecycle")
-			err := k8sClient.Get(ctx, typeNamespacedName, groundstation)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &ntnv1alpha1.GroundStationLifecycle{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: ntnv1alpha1.GroundStationLifecycleSpec{
-						Hardware: ntnv1alpha1.HardwareSpec{
-							Vendor: "ennoconn",
-							Model:  "rugged-edge-5000",
-						},
-						Deployment: ntnv1alpha1.DeploymentSpec{
-							Location: ntnv1alpha1.GeoLocation{
-								Lat: "25.0330",
-								Lon: "121.5654",
-							},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
+			createGS(false, false)
+			createNode(true)
 		})
-
 		AfterEach(func() {
-			resource := &ntnv1alpha1.GroundStationLifecycle{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance GroundStationLifecycle")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			deleteGS()
+			deleteNode()
 		})
 
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &GroundStationLifecycleReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
+		It("should set phase=Running with correct conditions", func() {
+			result, err := reconcileGS(newReconciler(nil))
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second)) // default interval
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseRunning))
+			Expect(gs.Status.K8sVersion).To(Equal("v1.35.1+k3s1"))
+			Expect(gs.Status.LastHealthCheck).NotTo(BeNil())
+
+			k8sCond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionK8sNodeReady)
+			Expect(k8sCond).NotTo(BeNil())
+			Expect(k8sCond.Status).To(Equal(metav1.ConditionTrue))
+
+			antCond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionAntennaReady)
+			Expect(antCond).NotTo(BeNil())
+			Expect(antCond.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("When node has MemoryPressure", func() {
+		BeforeEach(func() {
+			createGS(false, false)
+			createNode(true, corev1.NodeMemoryPressure)
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should set phase=Degraded", func() {
+			_, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseDegraded))
+		})
+	})
+
+	Context("When node is NotReady", func() {
+		BeforeEach(func() {
+			createGS(false, false)
+			createNode(false)
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should set phase=Offline", func() {
+			_, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseOffline))
+		})
+	})
+
+	Context("When monitoring endpoint is healthy", func() {
+		BeforeEach(func() { createNode(true) })
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should set RFLinkHealthy=True", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			DeferCleanup(server.Close)
+
+			// Create GS with monitoring endpoint pointing to test server.
+			gs := &ntnv1alpha1.GroundStationLifecycle{
+				ObjectMeta: metav1.ObjectMeta{Name: gsName, Namespace: namespace},
+				Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+					Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "rugged-edge-5000"},
+					Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654"}},
+					Monitoring: &ntnv1alpha1.MonitoringSpec{Endpoint: server.URL},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), gs)).To(Succeed())
+
+			_, err := reconcileGS(newReconciler(server.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := getGS()
+			Expect(updated.Status.Phase).To(Equal(ntnv1alpha1.PhaseRunning))
+			rfCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionRFLinkHealthy)
+			Expect(rfCond).NotTo(BeNil())
+			Expect(rfCond.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("When monitoring endpoint is unhealthy", func() {
+		BeforeEach(func() { createNode(true) })
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should set phase=Degraded and RFLinkHealthy=False", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			DeferCleanup(server.Close)
+
+			gs := &ntnv1alpha1.GroundStationLifecycle{
+				ObjectMeta: metav1.ObjectMeta{Name: gsName, Namespace: namespace},
+				Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+					Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "rugged-edge-5000"},
+					Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654"}},
+					Monitoring: &ntnv1alpha1.MonitoringSpec{Endpoint: server.URL},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), gs)).To(Succeed())
+
+			_, err := reconcileGS(newReconciler(server.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := getGS()
+			Expect(updated.Status.Phase).To(Equal(ntnv1alpha1.PhaseDegraded))
+			rfCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionRFLinkHealthy)
+			Expect(rfCond).NotTo(BeNil())
+			Expect(rfCond.Status).To(Equal(metav1.ConditionFalse))
+		})
+	})
+
+	// --- S8: Firmware OTA ---
+
+	Context("When firmware update available within maintenance window", func() {
+		BeforeEach(func() {
+			createGS(false, true) // firmware config with "02:00-04:00 UTC"
+			createNode(true)
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should set phase=Updating", func() {
+			reconciler := newReconciler(nil) // fixedNow=03:00 UTC → within window
+			_, err := reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseUpdating))
+			fwCond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+			Expect(fwCond).NotTo(BeNil())
+			Expect(fwCond.Reason).To(Equal("UpdateAvailable"))
+		})
+
+		It("should complete update on next reconcile", func() {
+			reconciler := newReconciler(nil)
+			// First reconcile: triggers update.
+			_, err := reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getGS().Status.Phase).To(Equal(ntnv1alpha1.PhaseUpdating))
+
+			// Second reconcile: completes update.
+			_, err = reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseRunning))
+			Expect(gs.Status.FirmwareVersion).To(Equal("2.3.1"))
+			fwCond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+			Expect(fwCond).NotTo(BeNil())
+			Expect(fwCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(fwCond.Reason).To(Equal("UpdateCompleted"))
+		})
+	})
+
+	Context("When firmware update available but outside maintenance window", func() {
+		BeforeEach(func() {
+			createGS(false, true) // firmware with "02:00-04:00 UTC"
+			createNode(true)
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should NOT trigger update", func() {
+			reconciler := &GroundStationLifecycleReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(10),
+				Now:      func() time.Time { return time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC) }, // 12:00 UTC
+			}
+			_, err := reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.Phase).To(Equal(ntnv1alpha1.PhaseRunning))
+		})
+	})
+
+	// --- S9: Conditions + Events ---
+
+	Context("When resource does not exist", func() {
+		It("should return without error", func() {
+			result, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+	})
+
+	Context("When custom healthCheckInterval is set", func() {
+		BeforeEach(func() {
+			createGS(true, false) // monitoring with 1m interval
+			createNode(true)
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should requeue after configured interval", func() {
+			result, err := reconcileGS(newReconciler(nil))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 		})
 	})
 })

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -235,7 +235,7 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			cond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionK8sNodeReady)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).To(Equal("APIError"))
+			Expect(cond.Reason).To(Equal("AmbiguousNodeMapping"))
 		})
 	})
 

--- a/pkg/lifecycle/maintenance_window.go
+++ b/pkg/lifecycle/maintenance_window.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var maintenanceWindowRE = regexp.MustCompile(`^(\d{2}:\d{2})-(\d{2}:\d{2})\s+UTC$`)
+
+// IsWithinMaintenanceWindow checks if the given time falls within the
+// maintenance window. The window format is "HH:MM-HH:MM UTC" (24-hour).
+// Handles midnight wraparound (e.g., "23:00-02:00 UTC").
+// Returns false for empty window strings (no restriction).
+func IsWithinMaintenanceWindow(window string, now time.Time) (bool, error) {
+	if window == "" {
+		return false, nil
+	}
+
+	matches := maintenanceWindowRE.FindStringSubmatch(window)
+	if matches == nil {
+		return false, fmt.Errorf("invalid maintenance window format %q: expected HH:MM-HH:MM UTC", window)
+	}
+
+	startHM, err := parseHHMM(matches[1])
+	if err != nil {
+		return false, fmt.Errorf("invalid start time in window: %w", err)
+	}
+	endHM, err := parseHHMM(matches[2])
+	if err != nil {
+		return false, fmt.Errorf("invalid end time in window: %w", err)
+	}
+
+	nowUTC := now.UTC()
+	nowMinutes := nowUTC.Hour()*60 + nowUTC.Minute()
+
+	if startHM < endHM {
+		// Normal window: e.g., "02:00-04:00 UTC"
+		return nowMinutes >= startHM && nowMinutes < endHM, nil
+	}
+	// Midnight wraparound: e.g., "23:00-02:00 UTC"
+	return nowMinutes >= startHM || nowMinutes < endHM, nil
+}
+
+// parseHHMM parses "HH:MM" into minutes since midnight.
+func parseHHMM(s string) (int, error) {
+	t, err := time.Parse("15:04", s)
+	if err != nil {
+		return 0, err
+	}
+	return t.Hour()*60 + t.Minute(), nil
+}

--- a/pkg/lifecycle/maintenance_window.go
+++ b/pkg/lifecycle/maintenance_window.go
@@ -27,7 +27,9 @@ var maintenanceWindowRE = regexp.MustCompile(`^(\d{2}:\d{2})-(\d{2}:\d{2})\s+UTC
 // IsWithinMaintenanceWindow checks if the given time falls within the
 // maintenance window. The window format is "HH:MM-HH:MM UTC" (24-hour).
 // Handles midnight wraparound (e.g., "23:00-02:00 UTC").
-// Returns false for empty window strings (no restriction).
+// An empty window string means no maintenance window is configured;
+// returns (false, nil) so callers can decide to proceed unconditionally.
+// A window where start == end (e.g., "00:00-00:00 UTC") is treated as invalid.
 func IsWithinMaintenanceWindow(window string, now time.Time) (bool, error) {
 	if window == "" {
 		return false, nil
@@ -45,6 +47,10 @@ func IsWithinMaintenanceWindow(window string, now time.Time) (bool, error) {
 	endHM, err := parseHHMM(matches[2])
 	if err != nil {
 		return false, fmt.Errorf("invalid end time in window: %w", err)
+	}
+
+	if startHM == endHM {
+		return false, fmt.Errorf("invalid maintenance window: start and end are the same (%s)", matches[1])
 	}
 
 	nowUTC := now.UTC()

--- a/pkg/lifecycle/maintenance_window_test.go
+++ b/pkg/lifecycle/maintenance_window_test.go
@@ -93,6 +93,12 @@ func TestIsWithinMaintenanceWindow(t *testing.T) {
 			now:    utc(3, 0),
 			err:    true,
 		},
+		{
+			name:   "start equals end is invalid",
+			window: "00:00-00:00 UTC",
+			now:    utc(0, 0),
+			err:    true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/lifecycle/maintenance_window_test.go
+++ b/pkg/lifecycle/maintenance_window_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+func utc(hour, minute int) time.Time {
+	return time.Date(2026, 4, 16, hour, minute, 0, 0, time.UTC)
+}
+
+func TestIsWithinMaintenanceWindow(t *testing.T) {
+	tests := []struct {
+		name   string
+		window string
+		now    time.Time
+		want   bool
+		err    bool
+	}{
+		{
+			name:   "within normal window",
+			window: "02:00-04:00 UTC",
+			now:    utc(3, 0),
+			want:   true,
+		},
+		{
+			name:   "outside normal window",
+			window: "02:00-04:00 UTC",
+			now:    utc(5, 0),
+			want:   false,
+		},
+		{
+			name:   "at start boundary (inclusive)",
+			window: "02:00-04:00 UTC",
+			now:    utc(2, 0),
+			want:   true,
+		},
+		{
+			name:   "at end boundary (exclusive)",
+			window: "02:00-04:00 UTC",
+			now:    utc(4, 0),
+			want:   false,
+		},
+		{
+			name:   "midnight wraparound — inside (after start)",
+			window: "23:00-02:00 UTC",
+			now:    utc(23, 30),
+			want:   true,
+		},
+		{
+			name:   "midnight wraparound — inside (before end)",
+			window: "23:00-02:00 UTC",
+			now:    utc(1, 0),
+			want:   true,
+		},
+		{
+			name:   "midnight wraparound — outside",
+			window: "23:00-02:00 UTC",
+			now:    utc(22, 0),
+			want:   false,
+		},
+		{
+			name:   "empty window returns false",
+			window: "",
+			now:    utc(3, 0),
+			want:   false,
+		},
+		{
+			name:   "invalid format",
+			window: "garbage",
+			now:    utc(3, 0),
+			err:    true,
+		},
+		{
+			name:   "invalid time",
+			window: "25:00-04:00 UTC",
+			now:    utc(3, 0),
+			err:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsWithinMaintenanceWindow(tc.window, tc.now)
+			if tc.err {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("IsWithinMaintenanceWindow(%q, %v) = %v, want %v",
+					tc.window, tc.now, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the full GroundStationLifecycle controller — health monitoring, firmware OTA, and event recording.

- **S7 Health Check**: Match GS to K8s Node by label, evaluate Node conditions, determine phase (Provisioning/Running/Degraded/Offline), optional HTTP endpoint check
- **S8 Firmware OTA**: Track versions via Node annotations, auto-update within maintenance window, simulated OTA (Updating→Running)
- **S9 Conditions + Events**: Phase transition events, firmware events, Node watch for re-reconciliation

## Live verification

```
$ kubectl get gs -o wide
NAME            PHASE          VENDOR     K8S       LAST CHECK   AGE
gs-hsinchu-01   Provisioning   ennoconn                          160m
gs-taipei-01    Running        ennoconn   v1.35.1   20s          161m

Conditions (gs-taipei-01):
  K8sNodeReady:     True  (NodeReady)
  AntennaReady:     True  (AntennaOperational)
  FirmwareUpToDate: False (UpdateAvailable) - 2.3.0 → 2.3.1
```

## Test coverage

| Package | Coverage |
|---------|----------|
| `internal/controller` | 82.9% |
| `pkg/lifecycle` | 95.0% |
| `pkg/ephemeris` | 91.7% |

## Test plan

- [x] `make generate && make manifests` — RBAC updated with Node permissions
- [x] `make test` — all pass, coverage ≥80%
- [x] `make lint` — 0 issues
- [x] Label node → verify Running phase
- [x] No matching node → verify Provisioning phase
- [x] Firmware annotations → verify FirmwareUpToDate condition
- [ ] CI lint + test pass
