### PR TITLE
Fix: stale pass windows, Secret RBAC, fetcher logging race

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,11 +27,16 @@ rules:
   - ""
   resources:
   - nodes
-  - secrets
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 - apiGroups:
   - ntn.operators.dev
   resources:

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -26,11 +26,16 @@ rules:
   - ""
   resources:
   - nodes
-  - secrets
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 - apiGroups:
   - ntn.operators.dev
   resources:

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -57,7 +57,7 @@ type SatelliteEphemerisReconciler struct {
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris/finalizers,verbs=update
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=groundstationlifecycles,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile fetches GP data, computes pass predictions, and updates status.
@@ -305,6 +305,11 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 		Message:            "No data to parse due to fetch failure",
 		ObservedGeneration: eph.Generation,
 	})
+
+	// Clear stale pass windows to prevent NTNSlice from using outdated data
+	// for failover readiness decisions.
+	eph.Status.NextPassWindows = nil
+	meta.RemoveStatusCondition(&eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
 
 	if err := r.Status().Update(ctx, eph); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -283,6 +283,49 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 		})
 	})
 
+	Context("When fetch fails with stale pass windows (regression #13)", func() {
+		BeforeEach(func() { createResource() })
+		AfterEach(func() { deleteResource() })
+
+		It("should clear NextPassWindows and remove PassesPredicted on fetch failure", func() {
+			// First: seed status with pass windows and PassesPredicted=True.
+			eph := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, eph)).To(Succeed())
+			eph.Status.SatelliteCount = 100
+			eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{
+				{
+					Satellite: "SAT-1", GroundStation: "gs-01",
+					AOS: metav1.Time{Time: time.Now()}, LOS: metav1.Time{Time: time.Now().Add(time.Hour)},
+					MaxElevation: "45.0",
+				},
+			}
+			meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+				Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue,
+				Reason: "PredictionSucceeded", Message: "1 passes",
+			})
+			Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
+
+			// Verify seeded state.
+			Expect(eph.Status.NextPassWindows).To(HaveLen(1))
+
+			// Now reconcile with a failing fetcher.
+			mock := &mockGPFetcher{err: errors.New("network timeout")}
+			reconciler := newReconciler(mock)
+			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify stale data is cleared.
+			updated := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
+			Expect(updated.Status.NextPassWindows).To(BeEmpty())
+
+			passCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
+			Expect(passCond).To(BeNil(), "PassesPredicted condition should be removed on fetch failure")
+		})
+	})
+
 	Context("When refreshInterval is below minimum", func() {
 		BeforeEach(func() {
 			resource := &ntnv1alpha1.SatelliteEphemeris{

--- a/pkg/ephemeris/gp_fetcher.go
+++ b/pkg/ephemeris/gp_fetcher.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"github.com/go-logr/logr"
 )
 
 // Sentinel errors returned by GPFetcher implementations.
@@ -78,6 +79,9 @@ func NewCelesTrakFetcher(httpClient *http.Client) *CelesTrakFetcher {
 // It uses conditional GET (If-None-Match) when a cached ETag exists.
 // Returns ErrRateLimited on HTTP 403 (CelesTrak bandwidth policy).
 func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	log.V(1).Info("fetching GP data", "url", url)
+	fetchStart := time.Now()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return GPFetchResult{}, fmt.Errorf("creating request: %w", err)
@@ -99,6 +103,7 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 
 	switch resp.StatusCode {
 	case http.StatusNotModified:
+		log.V(2).Info("ETag cache hit (304)", "url", url, "duration", time.Since(fetchStart))
 		var cached []sgp4.OMM
 		if v, ok := f.ommCache.Load(url); ok {
 			cached = v.([]sgp4.OMM)
@@ -131,6 +136,7 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 			f.etagCache.Store(url, newETag)
 		}
 
+		log.V(1).Info("fetch complete", "satellites", len(omms), "bytes", len(body), "duration", time.Since(fetchStart))
 		return GPFetchResult{
 			OMMs:           omms,
 			SatelliteCount: len(omms),

--- a/pkg/ephemeris/spacetrack_fetcher.go
+++ b/pkg/ephemeris/spacetrack_fetcher.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"github.com/go-logr/logr"
 )
 
 // SpaceTrackFetcher implements GPFetcher for Space-Track.org OMM JSON endpoints.
@@ -89,8 +90,11 @@ func (f *SpaceTrackFetcher) Fetch(ctx context.Context, gpURL string) (GPFetchRes
 		return GPFetchResult{}, fmt.Errorf("SpaceTrack credentials not configured; set credentials via Secret reference")
 	}
 
+	log := logr.FromContextOrDiscard(ctx)
+
 	// Login if we don't have a session.
 	if !loggedIn {
+		log.V(1).Info("authenticating with SpaceTrack")
 		if err := f.login(ctx, username, password); err != nil {
 			return GPFetchResult{}, fmt.Errorf("SpaceTrack login failed: %w", err)
 		}
@@ -104,6 +108,7 @@ func (f *SpaceTrackFetcher) Fetch(ctx context.Context, gpURL string) (GPFetchRes
 
 	// On 401, retry login once and re-fetch.
 	if isSessionExpired(err) {
+		log.V(1).Info("session expired, re-authenticating")
 		if loginErr := f.login(ctx, username, password); loginErr != nil {
 			return GPFetchResult{}, fmt.Errorf("SpaceTrack re-login failed: %w", loginErr)
 		}


### PR DESCRIPTION
## Summary

Fixes 4 issues identified from Copilot review + GitHub issue audit.

### 1. Fetcher logging race condition (Copilot PR #12 review)

**Before**: `WithLogger()` mutated struct field without synchronization — race on concurrent `Fetch()`.
**After**: Use `logr.FromContextOrDiscard(ctx)` inside `Fetch()`. No struct field, no race, automatically inherits controller's context logger.

### 2. Stale pass windows on fetch failure (Issue #13)

**Bug**: When GP fetch fails, `handleFetchError` set failure conditions but did NOT clear `status.nextPassWindows`. NTNSlice's `checkSatelliteAvailability` would use outdated pass data, potentially keeping `FailoverReady=True` when data is hours old.
**Fix**: Clear `nextPassWindows` and remove `PassesPredicted` condition in `handleFetchError`.

### 3. Secret RBAC over-permission (Issue #15)

**Before**: `secrets: get;list;watch` — controller only needs `get` (explicit by name).
**After**: `secrets: get` only. Helm chart manager-role.yaml synced with separate rules for nodes vs secrets.

Fixes #13, fixes #15

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [x] Helm lint passes