### PR TITLE
fix: firmware version sync drift + UpdateInterrupted → Degraded (#14)

### DIFF
--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -343,10 +343,9 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		return
 	}
 
-	// Sync firmware version from node annotation on first reconcile or
-	// when current status version doesn't match either known version
-	// (indicating an external agent updated the firmware outside our control).
-	if v, ok := node.Annotations[firmwareVersionAnnotation]; ok && gs.Status.FirmwareVersion == "" {
+	// Always sync firmware version from node annotation so that external
+	// agent changes (outside of our OTA cycle) are reflected in status.
+	if v, ok := node.Annotations[firmwareVersionAnnotation]; ok {
 		gs.Status.FirmwareVersion = v
 	}
 
@@ -412,7 +411,7 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 				Message:            "Available firmware version annotation removed during update",
 				ObservedGeneration: gs.Generation,
 			})
-			gs.Status.Phase = ntnv1alpha1.PhaseRunning
+			gs.Status.Phase = ntnv1alpha1.PhaseDegraded
 			gs.Status.FirmwareUpdateStarted = nil
 			return
 		}

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -283,12 +283,16 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 		ObservedGeneration: gs.Generation,
 	})
 
-	// Determine phase. Updating is preserved over Degraded so firmware
-	// completion can proceed even under transient resource pressure.
+	// Determine phase. Updating and firmware-uncertain Degraded are preserved
+	// so firmware lifecycle can proceed even under transient resource pressure.
+	fwCond := meta.FindStatusCondition(gs.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+	firmwareUncertain := fwCond != nil && (fwCond.Reason == "UpdateInterrupted" || fwCond.Reason == "UpdateTimedOut")
 	if !nodeReady {
 		gs.Status.Phase = ntnv1alpha1.PhaseOffline
 	} else if gs.Status.Phase == ntnv1alpha1.PhaseUpdating {
 		// Preserve Updating phase during firmware update.
+	} else if gs.Status.Phase == ntnv1alpha1.PhaseDegraded && firmwareUncertain {
+		// Preserve Degraded when firmware state is uncertain.
 	} else if memPressure || diskPressure || pidPressure {
 		gs.Status.Phase = ntnv1alpha1.PhaseDegraded
 	} else {

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -459,6 +459,78 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 		})
 	})
 
+	Context("Firmware version sync from node agent (external change)", func() {
+		BeforeEach(func() {
+			createGS(false, true)
+			createNode(true) // uses hardcoded firmware-version=2.3.0, available=2.3.1
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should pick up firmware version changed externally by node agent", func() {
+			reconciler := newReconciler(nil)
+			_, err := reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			gs := getGS()
+			Expect(gs.Status.FirmwareVersion).To(Equal("2.3.0"))
+
+			// Node agent externally updates firmware to 3.0.0.
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			node.Annotations[firmwareVersionAnnotation] = "3.0.0"
+			node.Annotations[availableFirmwareAnnotation] = "3.0.0"
+			Expect(k8sClient.Update(context.Background(), node)).To(Succeed())
+
+			// Next reconcile should sync to 3.0.0.
+			_, err = reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			gs = getGS()
+			Expect(gs.Status.FirmwareVersion).To(Equal("3.0.0"))
+		})
+	})
+
+	Context("Firmware update interrupted (available version annotation removed)", func() {
+		BeforeEach(func() {
+			createGS(false, true)
+			createNode(true) // firmware-version=2.3.0, available=2.3.1
+		})
+		AfterEach(func() {
+			deleteGS()
+			deleteNode()
+		})
+
+		It("should transition to Degraded (not Running) on interruption", func() {
+			// Pre-set to Updating.
+			gs := &ntnv1alpha1.GroundStationLifecycle{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, gs)).To(Succeed())
+			gs.Status.Phase = ntnv1alpha1.PhaseUpdating
+			gs.Status.FirmwareVersion = "2.3.0"
+			gs.Status.FirmwareUpdateStarted = &metav1.Time{Time: fixedNow.Add(-5 * time.Minute)}
+			Expect(k8sClient.Status().Update(context.Background(), gs)).To(Succeed())
+
+			// Remove available-firmware annotation (simulates interruption).
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			delete(node.Annotations, availableFirmwareAnnotation)
+			Expect(k8sClient.Update(context.Background(), node)).To(Succeed())
+
+			reconciler := newReconciler(nil)
+			_, err := reconcileGS(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := getGS()
+			Expect(updated.Status.Phase).To(Equal(ntnv1alpha1.PhaseDegraded))
+
+			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionFirmwareUpToDate)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("UpdateInterrupted"))
+		})
+	})
+
 	Context("Firmware update timeout", func() {
 		BeforeEach(func() {
 			createGS(false, true)


### PR DESCRIPTION
## Two remaining gaps from issue #14

### 1. Firmware version only synced when empty (line 349)

**Before**: `if v, ok := node.Annotations[...]; ok && gs.Status.FirmwareVersion == ""`
**Problem**: If node agent changes firmware outside of OTA cycle, controller never notices.
**After**: `if v, ok := node.Annotations[...]; ok` — syncs on every reconcile.

### 2. UpdateInterrupted → Running (line 415)

**Before**: When available-firmware annotation disappears during update, Phase goes to `Running`.
**Problem**: Firmware may be in inconsistent state (half-updated).
**After**: Phase goes to `Degraded`, signaling the firmware state is uncertain.

## TDD
- Test: external agent changes firmware 2.3.0 → 3.0.0, next reconcile picks up 3.0.0
- Test: UpdateInterrupted transitions to Degraded with correct condition

Fixes #14