### PR TITLE
fix: ConfigMapNameFor hash suffix prevents truncation collisions (#9)

### DIFF
--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -18,6 +18,8 @@ package ocudu
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,12 +40,16 @@ const ConfigMapPrefix = "ocudu-ntn-"
 const maxK8sNameLen = 253
 
 // ConfigMapNameFor returns the ConfigMap name for a given NTNCellConfig CR name.
-// If the resulting name exceeds K8s limits, it is truncated and trailing
-// invalid characters ('-', '.') are stripped to produce a valid DNS-1123 name.
+// If the resulting name exceeds K8s limits, it is truncated with a 8-char hash
+// suffix to prevent collisions between different long CR names.
 func ConfigMapNameFor(crName string) string {
 	name := ConfigMapPrefix + crName
 	if len(name) > maxK8sNameLen {
-		name = strings.TrimRight(name[:maxK8sNameLen], "-.")
+		h := sha256.Sum256([]byte(name))
+		suffix := hex.EncodeToString(h[:4]) // 8 hex chars
+		// Truncate to leave room for "-" + 8-char hash
+		truncLen := maxK8sNameLen - 9 // 253 - 9 = 244
+		name = strings.TrimRight(name[:truncLen], "-.") + "-" + suffix
 	}
 	return name
 }

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -248,3 +248,18 @@ func TestGetCellStatus_MissingGeoNtn(t *testing.T) {
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+func TestConfigMapNameFor_NoCollision(t *testing.T) {
+	// Two different long names that share a 243-char prefix should produce
+	// different ConfigMap names (hash suffix prevents collision).
+	base := strings.Repeat("a", 245)
+	nameA := ConfigMapNameFor(base + "-alpha")
+	nameB := ConfigMapNameFor(base + "-bravo")
+
+	if nameA == nameB {
+		t.Errorf("collision: different CR names produced same ConfigMap name %q", nameA)
+	}
+	if len(nameA) > maxK8sNameLen {
+		t.Errorf("name exceeds K8s limit: %d", len(nameA))
+	}
+}


### PR DESCRIPTION
## Problem
`ConfigMapNameFor("ocudu-ntn-" + crName)` truncates to 253 chars without uniqueness. Two long CR names sharing a prefix produce identical ConfigMap names.

## Fix
Append 8-char SHA256 hash suffix when truncation occurs.

## TDD
- RED: `TestConfigMapNameFor_NoCollision` proves collision
- GREEN: hash suffix makes names unique

Fixes #9