### PR TITLE
fix: pin all CI/tooling versions for supply-chain hardening (#17)

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -8,4 +8,4 @@ plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
-    version: latest
+    version: v0.10.1

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -84,7 +84,7 @@ fi
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   echo "Installing kubectl..."
-  KUBECTL_VERSION=$(curl -Ls https://dl.k8s.io/release/stable.txt)
+  KUBECTL_VERSION="v1.32.3"
   curl -fLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
   chmod +x /usr/local/bin/kubectl
   echo "kubectl installed successfully"

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -50,7 +50,7 @@ echo "------------------------------------"
 # Install kind
 if ! command -v kind &> /dev/null; then
   echo "Installing kind..."
-  curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${ARCH}"
   chmod +x /usr/local/bin/kind
   echo "kind installed successfully"
 fi
@@ -67,7 +67,7 @@ fi
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
   echo "Installing kubebuilder..."
-  curl -Lo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  curl -Lo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/v4.6.0/linux/${ARCH}"
   chmod +x /usr/local/bin/kubebuilder
   echo "kubebuilder installed successfully"
 fi

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -50,7 +50,7 @@ echo "------------------------------------"
 # Install kind
 if ! command -v kind &> /dev/null; then
   echo "Installing kind..."
-  curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${ARCH}"
+  curl -fLo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${ARCH}"
   chmod +x /usr/local/bin/kind
   echo "kind installed successfully"
 fi
@@ -67,7 +67,7 @@ fi
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
   echo "Installing kubebuilder..."
-  curl -Lo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/v4.6.0/linux/${ARCH}"
+  curl -fLo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/v4.6.0/linux/${ARCH}"
   chmod +x /usr/local/bin/kubebuilder
   echo "kubebuilder installed successfully"
 fi
@@ -85,7 +85,7 @@ fi
 if ! command -v kubectl &> /dev/null; then
   echo "Installing kubectl..."
   KUBECTL_VERSION=$(curl -Ls https://dl.k8s.io/release/stable.txt)
-  curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  curl -fLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
   chmod +x /usr/local/bin/kubectl
   echo "kubectl installed successfully"
 fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Cache golangci-lint binary
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: bin/golangci-lint*
           key: golangci-lint-${{ hashFiles('.custom-gcl.yml', '.golangci.yml', 'go.sum') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Cache golangci-lint binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: bin/golangci-lint*
           key: golangci-lint-${{ hashFiles('.custom-gcl.yml', '.golangci.yml', 'go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Setup ko
-        uses: ko-build/setup-ko@v0.9.0
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Login to GHCR
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     name: Build and Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -29,7 +29,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup ko
-        uses: ko-build/setup-ko@v0.9
+        uses: ko-build/setup-ko@v0.9.0
 
       - name: Login to GHCR
         uses: docker/login-action@v4.1.0
@@ -56,9 +56,13 @@ jobs:
           HELM_VERSION: v3.17.4
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
-          tar -xzf /tmp/helm.tar.gz -C /tmp
-          sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          TMPDIR="$(mktemp -d)"
+          trap 'rm -rf "$TMPDIR"' EXIT
+          curl -fsSL -o "$TMPDIR/helm.tar.gz" "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -fsSL -o "$TMPDIR/helm.tar.gz.sha256" "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256"
+          echo "$(cat "$TMPDIR/helm.tar.gz.sha256")  $TMPDIR/helm.tar.gz" | sha256sum -c -
+          tar -xzf "$TMPDIR/helm.tar.gz" -C "$TMPDIR"
+          sudo mv "$TMPDIR/linux-amd64/helm" /usr/local/bin/helm
           helm version
 
       - name: Update Chart version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
 
@@ -32,7 +32,7 @@ jobs:
         uses: ko-build/setup-ko@v0.9
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,9 +52,13 @@ jobs:
             --bare
 
       - name: Install Helm
+        env:
+          HELM_VERSION: v3.17.4
         run: |
           set -euo pipefail
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl -fsSL -o /tmp/helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          tar -xzf /tmp/helm.tar.gz -C /tmp
+          sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
           helm version
 
       - name: Update Chart version
@@ -68,7 +72,7 @@ jobs:
           helm push ntn-operators-${{ steps.version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test-chart:
     name: Helm lint + deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -43,7 +43,7 @@ jobs:
         run: make install-helm
 
       - name: Lint Helm Chart
-        run: helm lint ./dist/chart
+        run: ./bin/helm lint ./dist/chart
 
       - name: Deploy manager via Helm
         run: make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set manager.image.pullPolicy=Never"

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   test-e2e:
     name: E2E on Kind
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Cache envtest binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: bin/k8s
           key: envtest-${{ runner.os }}-${{ hashFiles('Makefile', 'go.mod', 'go.sum') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     name: Unit + envtest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/Makefile
+++ b/Makefile
@@ -293,11 +293,14 @@ HELM_VERSION ?= v3.17.4
 .PHONY: install-helm
 install-helm: ## Install Helm (pinned version).
 	@command -v $(HELM) >/dev/null 2>&1 || { \
-		echo "Installing Helm $(HELM_VERSION)..." && \
-		curl -fsSL -o /tmp/helm.tar.gz "https://get.helm.sh/helm-$(HELM_VERSION)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" && \
-		tar -xzf /tmp/helm.tar.gz -C /tmp && \
-		sudo mv /tmp/"$$(uname -s | tr '[:upper:]' '[:lower:]')"-amd64/helm /usr/local/bin/helm && \
-		rm -rf /tmp/helm.tar.gz /tmp/"$$(uname -s | tr '[:upper:]' '[:lower:]')"-*; \
+		HELM_OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
+		HELM_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+		HELM_TMPDIR=$$(mktemp -d) && \
+		echo "Installing Helm $(HELM_VERSION) ($${HELM_OS}/$${HELM_ARCH})..." && \
+		curl -fsSL -o "$${HELM_TMPDIR}/helm.tar.gz" "https://get.helm.sh/helm-$(HELM_VERSION)-$${HELM_OS}-$${HELM_ARCH}.tar.gz" && \
+		tar -xzf "$${HELM_TMPDIR}/helm.tar.gz" -C "$${HELM_TMPDIR}" && \
+		sudo mv "$${HELM_TMPDIR}/$${HELM_OS}-$${HELM_ARCH}/helm" /usr/local/bin/helm && \
+		rm -rf "$${HELM_TMPDIR}"; \
 	}
 
 .PHONY: helm-deploy

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ HELM_EXTRA_ARGS ?=
 HELM_VERSION ?= v3.17.4
 .PHONY: install-helm
 install-helm: $(LOCALBIN) ## Install Helm (pinned version).
-	@test -x "$(HELM)" || { \
+	@command -v "$(HELM)" > /dev/null 2>&1 || { \
 		HELM_OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
 		HELM_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
 		HELM_TMPDIR=$$(mktemp -d) && \

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ CRDOC ?= $(LOCALBIN)/crdoc
 
 .PHONY: docs
 docs: ## Generate API reference documentation from CRDs.
-	@command -v $(CRDOC) >/dev/null 2>&1 || GOBIN="$(LOCALBIN)" go install fybrik.io/crdoc@latest
+	@command -v $(CRDOC) >/dev/null 2>&1 || GOBIN="$(LOCALBIN)" go install fybrik.io/crdoc@v0.6.4
 	$(CRDOC) --resources config/crd/bases --output docs/api-reference.md
 
 ##@ ko Build
@@ -289,11 +289,15 @@ HELM_CHART_DIR ?= dist/chart
 ## Additional arguments to pass to helm commands
 HELM_EXTRA_ARGS ?=
 
+HELM_VERSION ?= v3.17.4
 .PHONY: install-helm
-install-helm: ## Install the latest version of Helm.
+install-helm: ## Install Helm (pinned version).
 	@command -v $(HELM) >/dev/null 2>&1 || { \
-		echo "Installing Helm..." && \
-		curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash; \
+		echo "Installing Helm $(HELM_VERSION)..." && \
+		curl -fsSL -o /tmp/helm.tar.gz "https://get.helm.sh/helm-$(HELM_VERSION)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" && \
+		tar -xzf /tmp/helm.tar.gz -C /tmp && \
+		sudo mv /tmp/"$$(uname -s | tr '[:upper:]' '[:lower:]')"-amd64/helm /usr/local/bin/helm && \
+		rm -rf /tmp/helm.tar.gz /tmp/"$$(uname -s | tr '[:upper:]' '[:lower:]')"-*; \
 	}
 
 .PHONY: helm-deploy

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ HELM_EXTRA_ARGS ?=
 HELM_VERSION ?= v3.17.4
 .PHONY: install-helm
 install-helm: $(LOCALBIN) ## Install Helm (pinned version).
-	@command -v "$(HELM)" > /dev/null 2>&1 || { \
+	@{ command -v "$(HELM)" > /dev/null 2>&1 && "$(HELM)" version --short 2>/dev/null | grep -q "$(HELM_VERSION)"; } || { \
 		HELM_OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
 		HELM_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
 		HELM_TMPDIR=$$(mktemp -d) && \

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ ko-push: ## Build and push multi-arch image with ko.
 ##@ Helm Deployment
 
 ## Helm binary to use for deploying the chart
-HELM ?= helm
+HELM ?= $(LOCALBIN)/helm
 ## Namespace to deploy the Helm release
 HELM_NAMESPACE ?= ntn-operators-system
 ## Name of the Helm release
@@ -291,16 +291,18 @@ HELM_EXTRA_ARGS ?=
 
 HELM_VERSION ?= v3.17.4
 .PHONY: install-helm
-install-helm: ## Install Helm (pinned version).
-	@command -v $(HELM) >/dev/null 2>&1 || { \
+install-helm: $(LOCALBIN) ## Install Helm (pinned version).
+	@test -x "$(HELM)" || { \
 		HELM_OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
 		HELM_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
 		HELM_TMPDIR=$$(mktemp -d) && \
+		trap "rm -rf \"$${HELM_TMPDIR}\"" EXIT && \
 		echo "Installing Helm $(HELM_VERSION) ($${HELM_OS}/$${HELM_ARCH})..." && \
 		curl -fsSL -o "$${HELM_TMPDIR}/helm.tar.gz" "https://get.helm.sh/helm-$(HELM_VERSION)-$${HELM_OS}-$${HELM_ARCH}.tar.gz" && \
+		curl -fsSL -o "$${HELM_TMPDIR}/helm.tar.gz.sha256" "https://get.helm.sh/helm-$(HELM_VERSION)-$${HELM_OS}-$${HELM_ARCH}.tar.gz.sha256" && \
+		echo "$$(cat $${HELM_TMPDIR}/helm.tar.gz.sha256)  $${HELM_TMPDIR}/helm.tar.gz" | sha256sum -c - && \
 		tar -xzf "$${HELM_TMPDIR}/helm.tar.gz" -C "$${HELM_TMPDIR}" && \
-		sudo mv "$${HELM_TMPDIR}/$${HELM_OS}-$${HELM_ARCH}/helm" /usr/local/bin/helm && \
-		rm -rf "$${HELM_TMPDIR}"; \
+		mv "$${HELM_TMPDIR}/$${HELM_OS}-$${HELM_ARCH}/helm" "$(HELM)"; \
 	}
 
 .PHONY: helm-deploy

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -186,7 +186,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
 					Provider: ntnv1alpha1.ProviderRef{Type: "oai"},
 					NTN: ntnv1alpha1.NTNParams{
-						EphemerisECEF: ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
 					},
 				},
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -218,13 +218,13 @@ var _ = Describe("Manager", Ordered, func() {
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
+				"--image=curlimages/curl:8.12.1",
 				"--overrides",
 				fmt.Sprintf(`{
 					"spec": {
 						"containers": [{
 							"name": "curl",
-							"image": "curlimages/curl:latest",
+							"image": "curlimages/curl:8.12.1",
 							"command": ["/bin/sh", "-c"],
 							"args": [
 								"for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"


### PR DESCRIPTION
## Problem
Floating versions (`@v4`, `@latest`, `curl|bash`) reduce reproducibility and increase supply-chain risk.

## Fix
- GitHub Actions: pin to minor versions (checkout@v6.0.2, setup-go@v6.4.0, etc.)
- Go installs: pin crdoc@v0.6.4
- Helm: replace curl|bash with pinned tarball (v3.17.4)

## TDD
Test script verifies no floating versions or curl|bash patterns remain.

Fixes #17