### PR TITLE
api: restrict provider enum to ocudu only (#11)

### DIFF
--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -37,8 +37,8 @@ type NTNCellConfigSpec struct {
 
 // ProviderRef identifies the NTN backend provider.
 type ProviderRef struct {
-	// type is the provider type.
-	// +kubebuilder:validation:Enum=ocudu;oai;aalyria
+	// type is the provider type. Currently only "ocudu" is supported.
+	// +kubebuilder:validation:Enum=ocudu
 	Type string `json:"type"`
 
 	// namespace where the provider resources (e.g., OCUDU gNB) are deployed.
@@ -150,7 +150,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NTNCellConfig manages NTN-specific radio parameters for a gNB cell,
-// delegating configuration to the specified NTN backend provider (OCUDU, OAI, Aalyria).
+// delegating configuration to the specified NTN backend provider.
 type NTNCellConfig struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -34,7 +34,7 @@ spec:
       openAPIV3Schema:
         description: |-
           NTNCellConfig manages NTN-specific radio parameters for a gNB cell,
-          delegating configuration to the specified NTN backend provider (OCUDU, OAI, Aalyria).
+          delegating configuration to the specified NTN backend provider.
         properties:
           apiVersion:
             description: |-
@@ -160,11 +160,10 @@ spec:
                       gNB) are deployed.
                     type: string
                   type:
-                    description: type is the provider type.
+                    description: type is the provider type. Currently only "ocudu"
+                      is supported.
                     enum:
                     - ocudu
-                    - oai
-                    - aalyria
                     type: string
                 required:
                 - type

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -1,12 +1,8 @@
-{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
-    "helm.sh/resource-policy": keep
-    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntncellconfigs.ntn.operators.dev
 spec:
@@ -38,7 +34,7 @@ spec:
       openAPIV3Schema:
         description: |-
           NTNCellConfig manages NTN-specific radio parameters for a gNB cell,
-          delegating configuration to the specified NTN backend provider (OCUDU, OAI, Aalyria).
+          delegating configuration to the specified NTN backend provider.
         properties:
           apiVersion:
             description: |-
@@ -164,11 +160,10 @@ spec:
                       gNB) are deployed.
                     type: string
                   type:
-                    description: type is the provider type.
+                    description: type is the provider type. Currently only "ocudu"
+                      is supported.
                     enum:
                     - ocudu
-                    - oai
-                    - aalyria
                     type: string
                 required:
                 - type
@@ -256,4 +251,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -164,10 +164,10 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		})
 	})
 
-	Context("When provider type is unsupported", func() {
-		BeforeEach(func() {
+	Context("CRD validation: provider type enum", func() {
+		It("should reject creation with unsupported provider type", func() {
 			cr := &ntnv1alpha1.NTNCellConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid-provider", Namespace: namespace},
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
 					Provider: ntnv1alpha1.ProviderRef{Type: "aalyria"},
 					NTN: ntnv1alpha1.NTNParams{
@@ -175,25 +175,23 @@ var _ = Describe("NTNCellConfig Controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+			err := k8sClient.Create(context.Background(), cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("provider"))
 		})
-		AfterEach(func() { deleteCR() })
 
-		It("should set ConfigApplied=False with UnsupportedProvider", func() {
-			mock := &provider.MockProvider{}
-			reconciler := newReconciler(mock)
-
-			_, err := reconcileWithFinalizer(reconciler)
-			Expect(err).NotTo(HaveOccurred())
-
-			updated := &ntnv1alpha1.NTNCellConfig{}
-			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
-
-			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionConfigApplied)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).To(Equal("UnsupportedProvider"))
-			Expect(mock.ApplyCalls).To(Equal(0))
+		It("should reject oai provider type", func() {
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid-oai", Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "oai"},
+					NTN: ntnv1alpha1.NTNParams{
+						EphemerisECEF: ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+					},
+				},
+			}
+			err := k8sClient.Create(context.Background(), cr)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 	})
 
 	Context("CRD validation: provider type enum", func() {
-		It("should reject creation with unsupported provider type", func() {
+		It("should reject creation with unsupported provider type aalyria", func() {
 			cr := &ntnv1alpha1.NTNCellConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "invalid-provider", Namespace: namespace},
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
@@ -177,7 +177,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			}
 			err := k8sClient.Create(context.Background(), cr)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("provider"))
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected Invalid API error, got: %v", err)
 		})
 
 		It("should reject oai provider type", func() {
@@ -192,6 +192,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			}
 			err := k8sClient.Create(context.Background(), cr)
 			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected Invalid API error, got: %v", err)
 		})
 	})
 

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -28,8 +28,6 @@ import (
 //
 // Implementations:
 //   - OCUDU: generates geo_ntn.yml and writes to a ConfigMap (future: Helm values overlay / O1 NETCONF)
-//   - OAI: generates OAI NTN config via oai-operators Helm (planned)
-//   - Aalyria: applies config via Spacetime gRPC API, pin v21.0 (planned)
 type NTNProvider interface {
 	// ApplyCellConfig applies NTN radio parameters to the backend.
 	// crName is the NTNCellConfig CR name (used to scope resources like ConfigMaps).


### PR DESCRIPTION
## Summary
- Restrict `ProviderRef.Type` enum from `ocudu;oai;aalyria` to `ocudu` only
- CRD validation now prevents creating CRs with unsupported provider types at admission time
- Updated tests to verify CRD rejects `oai`/`aalyria`
- Regenerated CRD manifests and Helm chart

Closes #11

## Test plan
- [x] CRD rejects `aalyria` provider type at creation
- [x] CRD rejects `oai` provider type at creation
- [x] All 66 controller tests pass