### PR TITLE
feat: add ephemerisRef to NTNCellConfig (#20)

### DIFF
--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -40,6 +40,7 @@ type NTNCellConfigSpec struct {
 	// ephemeris data for dynamic NTN parameter updates; currently this field
 	// only triggers reconciliation. The static ephemeris in spec.ntn
 	// (ephemerisECEF or ephemerisOrbital) remains required.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`
 }

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -33,6 +33,13 @@ type NTNCellConfigSpec struct {
 	// cellOverrides allows fine-tuning PUCCH, PDSCH, PRACH, and RRC parameters.
 	// +optional
 	CellOverrides *CellOverrides `json:"cellOverrides,omitempty"`
+
+	// ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
+	// whose ephemeris data will be used for dynamic NTN parameter updates.
+	// When set, the controller watches the referenced SatelliteEphemeris and
+	// re-reconciles when its status changes.
+	// +optional
+	EphemerisRef string `json:"ephemerisRef,omitempty"`
 }
 
 // ProviderRef identifies the NTN backend provider.

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -34,10 +34,12 @@ type NTNCellConfigSpec struct {
 	// +optional
 	CellOverrides *CellOverrides `json:"cellOverrides,omitempty"`
 
-	// ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
-	// whose ephemeris data will be used for dynamic NTN parameter updates.
-	// When set, the controller watches the referenced SatelliteEphemeris and
-	// re-reconciles when it is updated.
+	// ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
+	// When set, the controller re-reconciles this NTNCellConfig whenever the
+	// referenced SatelliteEphemeris is updated. Future work will consume the
+	// ephemeris data for dynamic NTN parameter updates; currently this field
+	// only triggers reconciliation. The static ephemeris in spec.ntn
+	// (ephemerisECEF or ephemerisOrbital) remains required.
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`
 }

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -37,7 +37,7 @@ type NTNCellConfigSpec struct {
 	// ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
 	// whose ephemeris data will be used for dynamic NTN parameter updates.
 	// When set, the controller watches the referenced SatelliteEphemeris and
-	// re-reconciles when its status changes.
+	// re-reconciles when it is updated.
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`
 }

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -75,6 +75,13 @@ spec:
                       in ms.
                     type: integer
                 type: object
+              ephemerisRef:
+                description: |-
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
+                  whose ephemeris data will be used for dynamic NTN parameter updates.
+                  When set, the controller watches the referenced SatelliteEphemeris and
+                  re-reconciles when its status changes.
+                type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS
                   38.213 / OCUDU geo_ntn.yml.

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -83,6 +83,7 @@ spec:
                   ephemeris data for dynamic NTN parameter updates; currently this field
                   only triggers reconciliation. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required.
+                minLength: 1
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -77,10 +77,12 @@ spec:
                 type: object
               ephemerisRef:
                 description: |-
-                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
-                  whose ephemeris data will be used for dynamic NTN parameter updates.
-                  When set, the controller watches the referenced SatelliteEphemeris and
-                  re-reconciles when it is updated.
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
+                  When set, the controller re-reconciles this NTNCellConfig whenever the
+                  referenced SatelliteEphemeris is updated. Future work will consume the
+                  ephemeris data for dynamic NTN parameter updates; currently this field
+                  only triggers reconciliation. The static ephemeris in spec.ntn
+                  (ephemerisECEF or ephemerisOrbital) remains required.
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -80,7 +80,7 @@ spec:
                   ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
                   whose ephemeris data will be used for dynamic NTN parameter updates.
                   When set, the controller watches the referenced SatelliteEphemeris and
-                  re-reconciles when its status changes.
+                  re-reconciles when it is updated.
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -75,6 +75,13 @@ spec:
                       in ms.
                     type: integer
                 type: object
+              ephemerisRef:
+                description: |-
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
+                  whose ephemeris data will be used for dynamic NTN parameter updates.
+                  When set, the controller watches the referenced SatelliteEphemeris and
+                  re-reconciles when its status changes.
+                type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS
                   38.213 / OCUDU geo_ntn.yml.

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -83,6 +83,7 @@ spec:
                   ephemeris data for dynamic NTN parameter updates; currently this field
                   only triggers reconciliation. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required.
+                minLength: 1
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -77,10 +77,12 @@ spec:
                 type: object
               ephemerisRef:
                 description: |-
-                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
-                  whose ephemeris data will be used for dynamic NTN parameter updates.
-                  When set, the controller watches the referenced SatelliteEphemeris and
-                  re-reconciles when it is updated.
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
+                  When set, the controller re-reconciles this NTNCellConfig whenever the
+                  referenced SatelliteEphemeris is updated. Future work will consume the
+                  ephemeris data for dynamic NTN parameter updates; currently this field
+                  only triggers reconciliation. The static ephemeris in spec.ntn
+                  (ephemerisECEF or ephemerisOrbital) remains required.
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -80,7 +80,7 @@ spec:
                   ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace
                   whose ephemeris data will be used for dynamic NTN parameter updates.
                   When set, the controller watches the referenced SatelliteEphemeris and
-                  re-reconciles when its status changes.
+                  re-reconciles when it is updated.
                 type: string
               ntn:
                 description: ntn contains NTN-specific radio parameters per 3GPP TS

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -24,10 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +53,7 @@ type NTNCellConfigReconciler struct {
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
@@ -232,9 +236,46 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// Watches SatelliteEphemeris changes to trigger re-reconciliation
+// when a referenced ephemeris is updated.
 func (r *NTNCellConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ntnv1alpha1.NTNCellConfig{}).
+		Watches(&ntnv1alpha1.SatelliteEphemeris{},
+			handler.EnqueueRequestsFromMapFunc(r.ephemerisToNTNCellConfig),
+		).
 		Named("ntncellconfig").
 		Complete(r)
+}
+
+// ephemerisToNTNCellConfig maps a SatelliteEphemeris change to all
+// NTNCellConfig resources that reference it via spec.ephemerisRef.
+func (r *NTNCellConfigReconciler) ephemerisToNTNCellConfig(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	eph, ok := obj.(*ntnv1alpha1.SatelliteEphemeris)
+	if !ok {
+		return nil
+	}
+
+	log := logf.FromContext(ctx)
+
+	var ccList ntnv1alpha1.NTNCellConfigList
+	if err := r.List(ctx, &ccList, client.InNamespace(eph.Namespace)); err != nil {
+		log.Error(err, "Failed to list NTNCellConfigs for ephemeris mapper")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, cc := range ccList.Items {
+		if cc.Spec.EphemerisRef == eph.Name {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cc.Name,
+					Namespace: cc.Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -186,7 +186,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
 					Provider: ntnv1alpha1.ProviderRef{Type: "oai"},
 					NTN: ntnv1alpha1.NTNParams{
-						EphemerisECEF: ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
 					},
 				},
 			}
@@ -399,6 +399,133 @@ var _ = Describe("NTNCellConfig Controller", func() {
 
 			// Clean up ConfigMap.
 			_ = k8sClient.Delete(context.Background(), cm)
+		})
+	})
+
+	Context("When creating NTNCellConfig with ephemerisRef", func() {
+		const ephRefName = "test-eph-ref-cell"
+		ephRefNN := types.NamespacedName{Name: ephRefName, Namespace: namespace}
+
+		AfterEach(func() {
+			cr := &ntnv1alpha1.NTNCellConfig{}
+			err := k8sClient.Get(context.Background(), ephRefNN, cr)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if controllerutil.ContainsFinalizer(cr, "ntn.operators.dev/configmap-cleanup") {
+				controllerutil.RemoveFinalizer(cr, "ntn.operators.dev/configmap-cleanup")
+				Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			}
+			Expect(k8sClient.Delete(context.Background(), cr)).To(Succeed())
+		})
+
+		It("should accept a CR with ephemerisRef set", func() {
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: ephRefName, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+							PosX: 20922195, PosY: 1967783, PosZ: 19770302,
+						},
+						PayloadType: "transparent",
+					},
+					EphemerisRef: "my-sat-ephemeris",
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+
+			// Verify it was persisted correctly.
+			fetched := &ntnv1alpha1.NTNCellConfig{}
+			Expect(k8sClient.Get(context.Background(), ephRefNN, fetched)).To(Succeed())
+			Expect(fetched.Spec.EphemerisRef).To(Equal("my-sat-ephemeris"))
+		})
+	})
+
+	Context("ephemerisToNTNCellConfig mapper", func() {
+		const (
+			ccWithRef    = "cc-with-ref"
+			ccWithoutRef = "cc-without-ref"
+			ephName      = "test-eph-mapper"
+		)
+
+		BeforeEach(func() {
+			// Create a NTNCellConfig that references the ephemeris.
+			cr1 := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: ccWithRef, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+							PosX: 20922195, PosY: 1967783, PosZ: 19770302,
+						},
+						PayloadType: "transparent",
+					},
+					EphemerisRef: ephName,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr1)).To(Succeed())
+
+			// Create a NTNCellConfig without ephemerisRef.
+			cr2 := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: ccWithoutRef, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+							PosX: 20922195, PosY: 1967783, PosZ: 19770302,
+						},
+						PayloadType: "transparent",
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr2)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			for _, name := range []string{ccWithRef, ccWithoutRef} {
+				cr := &ntnv1alpha1.NTNCellConfig{}
+				nn := types.NamespacedName{Name: name, Namespace: namespace}
+				err := k8sClient.Get(context.Background(), nn, cr)
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				Expect(err).NotTo(HaveOccurred())
+				if controllerutil.ContainsFinalizer(cr, "ntn.operators.dev/configmap-cleanup") {
+					controllerutil.RemoveFinalizer(cr, "ntn.operators.dev/configmap-cleanup")
+					Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+				}
+				Expect(k8sClient.Delete(context.Background(), cr)).To(Succeed())
+			}
+		})
+
+		It("should return requests only for NTNCellConfigs that reference the ephemeris", func() {
+			reconciler := newReconciler(&provider.MockProvider{})
+
+			// Simulate a SatelliteEphemeris object.
+			eph := &ntnv1alpha1.SatelliteEphemeris{
+				ObjectMeta: metav1.ObjectMeta{Name: ephName, Namespace: namespace},
+			}
+
+			requests := reconciler.ephemerisToNTNCellConfig(context.Background(), eph)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName.Name).To(Equal(ccWithRef))
+			Expect(requests[0].NamespacedName.Namespace).To(Equal(namespace))
+		})
+
+		It("should return empty requests when no NTNCellConfigs reference the ephemeris", func() {
+			reconciler := newReconciler(&provider.MockProvider{})
+
+			eph := &ntnv1alpha1.SatelliteEphemeris{
+				ObjectMeta: metav1.ObjectMeta{Name: "nonexistent-eph", Namespace: namespace},
+			}
+
+			requests := reconciler.ephemerisToNTNCellConfig(context.Background(), eph)
+			Expect(requests).To(BeEmpty())
 		})
 	})
 

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -65,20 +65,22 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
 	}
 
-	deleteCR := func() {
+	// deleteCellConfig deletes an NTNCellConfig by NamespacedName, removing finalizers first.
+	deleteCellConfig := func(nn types.NamespacedName) {
 		cr := &ntnv1alpha1.NTNCellConfig{}
-		err := k8sClient.Get(context.Background(), typeNamespacedName, cr)
+		err := k8sClient.Get(context.Background(), nn, cr)
 		if apierrors.IsNotFound(err) {
 			return
 		}
 		Expect(err).NotTo(HaveOccurred())
-		// Remove finalizer if present (otherwise CR stays in Terminating).
 		if controllerutil.ContainsFinalizer(cr, "ntn.operators.dev/configmap-cleanup") {
 			controllerutil.RemoveFinalizer(cr, "ntn.operators.dev/configmap-cleanup")
 			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
 		}
 		Expect(k8sClient.Delete(context.Background(), cr)).To(Succeed())
 	}
+
+	deleteCR := func() { deleteCellConfig(typeNamespacedName) }
 
 	newReconciler := func(p provider.NTNProvider) *NTNCellConfigReconciler {
 		return &NTNCellConfigReconciler{
@@ -406,19 +408,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		const cellWithRefName = "test-eph-ref-cell"
 		cellWithRefNN := types.NamespacedName{Name: cellWithRefName, Namespace: namespace}
 
-		AfterEach(func() {
-			cr := &ntnv1alpha1.NTNCellConfig{}
-			err := k8sClient.Get(context.Background(), cellWithRefNN, cr)
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			Expect(err).NotTo(HaveOccurred())
-			if controllerutil.ContainsFinalizer(cr, "ntn.operators.dev/configmap-cleanup") {
-				controllerutil.RemoveFinalizer(cr, "ntn.operators.dev/configmap-cleanup")
-				Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
-			}
-			Expect(k8sClient.Delete(context.Background(), cr)).To(Succeed())
-		})
+		AfterEach(func() { deleteCellConfig(cellWithRefNN) })
 
 		It("should accept a CR with ephemerisRef set", func() {
 			cr := &ntnv1alpha1.NTNCellConfig{
@@ -488,18 +478,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 
 		AfterEach(func() {
 			for _, name := range []string{ccWithRef, ccWithoutRef} {
-				cr := &ntnv1alpha1.NTNCellConfig{}
-				nn := types.NamespacedName{Name: name, Namespace: namespace}
-				err := k8sClient.Get(context.Background(), nn, cr)
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-				Expect(err).NotTo(HaveOccurred())
-				if controllerutil.ContainsFinalizer(cr, "ntn.operators.dev/configmap-cleanup") {
-					controllerutil.RemoveFinalizer(cr, "ntn.operators.dev/configmap-cleanup")
-					Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
-				}
-				Expect(k8sClient.Delete(context.Background(), cr)).To(Succeed())
+				deleteCellConfig(types.NamespacedName{Name: name, Namespace: namespace})
 			}
 		})
 

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -403,12 +403,12 @@ var _ = Describe("NTNCellConfig Controller", func() {
 	})
 
 	Context("When creating NTNCellConfig with ephemerisRef", func() {
-		const ephRefName = "test-eph-ref-cell"
-		ephRefNN := types.NamespacedName{Name: ephRefName, Namespace: namespace}
+		const cellWithRefName = "test-eph-ref-cell"
+		cellWithRefNN := types.NamespacedName{Name: cellWithRefName, Namespace: namespace}
 
 		AfterEach(func() {
 			cr := &ntnv1alpha1.NTNCellConfig{}
-			err := k8sClient.Get(context.Background(), ephRefNN, cr)
+			err := k8sClient.Get(context.Background(), cellWithRefNN, cr)
 			if apierrors.IsNotFound(err) {
 				return
 			}
@@ -422,7 +422,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 
 		It("should accept a CR with ephemerisRef set", func() {
 			cr := &ntnv1alpha1.NTNCellConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: ephRefName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: cellWithRefName, Namespace: namespace},
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
 					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
 					NTN: ntnv1alpha1.NTNParams{
@@ -439,7 +439,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 
 			// Verify it was persisted correctly.
 			fetched := &ntnv1alpha1.NTNCellConfig{}
-			Expect(k8sClient.Get(context.Background(), ephRefNN, fetched)).To(Succeed())
+			Expect(k8sClient.Get(context.Background(), cellWithRefNN, fetched)).To(Succeed())
 			Expect(fetched.Spec.EphemerisRef).To(Equal("my-sat-ephemeris"))
 		})
 	})


### PR DESCRIPTION
## Summary
- Add `ephemerisRef` field to `NTNCellConfigSpec` allowing a NTNCellConfig to reference a SatelliteEphemeris CR in the same namespace for dynamic NTN parameter updates.
- Add `ephemerisToNTNCellConfig` watch mapper so the NTNCellConfig controller re-reconciles when a referenced SatelliteEphemeris changes (following the existing `groundStationToEphemeris` pattern).
- Add RBAC marker for `satelliteephemeris` get/list/watch on the NTNCellConfig controller.
- Add tests for ephemerisRef creation and mapper correctness.
- Fix pre-existing test compilation error (EphemerisECEF value vs pointer in CEL validation test).

Closes #20 (partial -- PR-A only)

## Test plan
- [x] `go test -count=1 ./...` passes (all 69 controller specs + all pkg tests)
- [ ] Verify CRD schema includes `ephemerisRef` via `kubectl apply -f config/crd/bases/`
- [ ] Create NTNCellConfig with `ephemerisRef` set and verify controller re-reconciles on SatelliteEphemeris updates