### PR TITLE
feat: add PushEphemerisUpdate to NTNProvider interface (#20)

### DIFF
--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -31,9 +31,9 @@ type EphemerisUpdate struct {
 	Orbital *ntnv1alpha1.EphemerisOrbital
 }
 
-// NTNProvider abstracts NTN backend interactions for cell configuration.
-// Ephemeris and ground station lifecycle are handled directly by their
-// respective controllers (not via Provider).
+// NTNProvider abstracts NTN backend interactions for cell configuration
+// and ephemeris updates. Ground station lifecycle is handled directly
+// by its respective controller.
 //
 // Implementations:
 //   - OCUDU: generates geo_ntn.yml and writes to a ConfigMap

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -22,12 +22,21 @@ import (
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
+// EphemerisUpdate carries fresh ephemeris data for a live update push.
+// The provider uses whichever representation is populated (ECEF or orbital).
+type EphemerisUpdate struct {
+	// ECEF state vector (mutually exclusive with Orbital).
+	ECEF *ntnv1alpha1.EphemerisECEF
+	// Keplerian orbital elements (mutually exclusive with ECEF).
+	Orbital *ntnv1alpha1.EphemerisOrbital
+}
+
 // NTNProvider abstracts NTN backend interactions for cell configuration.
 // Ephemeris and ground station lifecycle are handled directly by their
 // respective controllers (not via Provider).
 //
 // Implementations:
-//   - OCUDU: generates geo_ntn.yml and writes to a ConfigMap (future: Helm values overlay / O1 NETCONF)
+//   - OCUDU: generates geo_ntn.yml and writes to a ConfigMap
 type NTNProvider interface {
 	// ApplyCellConfig applies NTN radio parameters to the backend.
 	// crName is the NTNCellConfig CR name (used to scope resources like ConfigMaps).
@@ -36,4 +45,9 @@ type NTNProvider interface {
 	// GetCellStatus returns the current applied configuration status
 	// for the given CR name and namespace.
 	GetCellStatus(ctx context.Context, crName, namespace string) (*ntnv1alpha1.NTNCellConfigStatus, error)
+
+	// PushEphemerisUpdate pushes fresh ephemeris data to the backend.
+	// Phase 1 (ConfigMap): regenerates the ephemeris section of the config.
+	// Phase 2 (future): pushes via OCUDU WebSocket handle_ntn_param_update.
+	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -28,13 +28,16 @@ var _ NTNProvider = &MockProvider{}
 
 // MockProvider is a test double for NTNProvider.
 type MockProvider struct {
-	mu          sync.Mutex
-	ApplyErr    error
-	StatusErr   error
-	ApplyCalls  int
-	StatusCalls int
-	LastSpec    *ntnv1alpha1.NTNCellConfigSpec
-	StatusValue *ntnv1alpha1.NTNCellConfigStatus
+	mu             sync.Mutex
+	ApplyErr       error
+	StatusErr      error
+	EphemerisErr   error
+	ApplyCalls     int
+	StatusCalls    int
+	EphemerisCalls int
+	LastSpec       *ntnv1alpha1.NTNCellConfigSpec
+	LastEphemeris  *EphemerisUpdate
+	StatusValue    *ntnv1alpha1.NTNCellConfigStatus
 }
 
 func (m *MockProvider) ApplyCellConfig(_ context.Context, _ string, spec *ntnv1alpha1.NTNCellConfigSpec) error {
@@ -53,4 +56,12 @@ func (m *MockProvider) GetCellStatus(_ context.Context, _, _ string) (*ntnv1alph
 		return m.StatusValue, m.StatusErr
 	}
 	return &ntnv1alpha1.NTNCellConfigStatus{}, m.StatusErr
+}
+
+func (m *MockProvider) PushEphemerisUpdate(_ context.Context, _, _ string, update EphemerisUpdate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.EphemerisCalls++
+	m.LastEphemeris = &update
+	return m.EphemerisErr
 }

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -181,7 +181,8 @@ func (p *Provider) PushEphemerisUpdate(
 		Namespace: namespace,
 	}
 	if err := p.client.Get(ctx, key, cm); err != nil {
-		return fmt.Errorf("reading ConfigMap: %w", err)
+		return fmt.Errorf("reading ConfigMap %s/%s: %w",
+			namespace, ConfigMapNameFor(crName), err)
 	}
 
 	yamlContent, ok := cm.Data["geo_ntn.yml"]
@@ -260,7 +261,7 @@ func replaceEphemeris(
 		if skip {
 			// Skip all lines more indented than the key (4+ spaces),
 			// including comments and blank lines within the block.
-			if strings.HasPrefix(line, "    ") {
+			if strings.HasPrefix(line, "    ") || trimmed == "" {
 				continue
 			}
 			skip = false

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -243,22 +243,24 @@ func replaceEphemeris(
 	}
 
 	// Find and replace ephemeris_info_ecef or ephemeris_orbital block.
+	// Uses HasPrefix to tolerate inline comments on the key line.
 	lines := strings.Split(content, "\n")
 	var result []string
 	skip := false
 	found := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "ephemeris_info_ecef:" ||
-			trimmed == "ephemeris_orbital:" {
+		if strings.HasPrefix(trimmed, "ephemeris_info_ecef:") ||
+			strings.HasPrefix(trimmed, "ephemeris_orbital:") {
 			skip = true
 			found = true
 			result = append(result, strings.Split(newBlock, "\n")...)
 			continue
 		}
 		if skip {
-			// Skip indented sub-fields of the old block.
-			if strings.HasPrefix(line, "    ") && !strings.HasPrefix(trimmed, "#") {
+			// Skip all lines more indented than the key (4+ spaces),
+			// including comments and blank lines within the block.
+			if strings.HasPrefix(line, "    ") {
 				continue
 			}
 			skip = false

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -186,11 +186,18 @@ func (p *Provider) PushEphemerisUpdate(
 
 	yamlContent, ok := cm.Data["geo_ntn.yml"]
 	if !ok {
-		return fmt.Errorf("ConfigMap missing geo_ntn.yml")
+		return fmt.Errorf(
+			"ConfigMap %s/%s missing geo_ntn.yml",
+			namespace, ConfigMapNameFor(crName))
 	}
 
 	// Replace the ephemeris section in the existing YAML.
-	updated := replaceEphemeris(yamlContent, update)
+	updated, replaced := replaceEphemeris(yamlContent, update)
+	if !replaced {
+		return fmt.Errorf(
+			"ConfigMap %s/%s has no ephemeris block to replace",
+			namespace, ConfigMapNameFor(crName))
+	}
 	cm.Data["geo_ntn.yml"] = updated
 
 	if err := p.client.Update(ctx, cm); err != nil {
@@ -200,9 +207,10 @@ func (p *Provider) PushEphemerisUpdate(
 }
 
 // replaceEphemeris replaces the ephemeris block in OCUDU config YAML.
+// Returns the updated content and whether a replacement was made.
 func replaceEphemeris(
 	content string, update provider.EphemerisUpdate,
-) string {
+) (string, bool) {
 	var newBlock string
 	if update.Orbital != nil {
 		newBlock = fmt.Sprintf(`  ephemeris_orbital:
@@ -238,11 +246,13 @@ func replaceEphemeris(
 	lines := strings.Split(content, "\n")
 	var result []string
 	skip := false
+	found := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "ephemeris_info_ecef:" ||
 			trimmed == "ephemeris_orbital:" {
 			skip = true
+			found = true
 			result = append(result, strings.Split(newBlock, "\n")...)
 			continue
 		}
@@ -255,5 +265,5 @@ func replaceEphemeris(
 		}
 		result = append(result, line)
 	}
-	return strings.Join(result, "\n")
+	return strings.Join(result, "\n"), found
 }

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
 // ConfigMapPrefix is the prefix for ConfigMap names. Final name = prefix + CR name.
@@ -156,4 +157,103 @@ func (p *Provider) GetCellStatus(
 	}
 
 	return status, nil
+}
+
+// PushEphemerisUpdate updates the ephemeris section of the existing ConfigMap.
+// Phase 1 implementation: reads the current config, replaces the ephemeris
+// data, and writes it back. Future Phase 2 will use OCUDU's WebSocket API.
+func (p *Provider) PushEphemerisUpdate(
+	ctx context.Context, crName, namespace string, update provider.EphemerisUpdate,
+) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace must not be empty")
+	}
+	if update.ECEF == nil && update.Orbital == nil {
+		return fmt.Errorf("either ECEF or Orbital must be set")
+	}
+	if update.ECEF != nil && update.Orbital != nil {
+		return fmt.Errorf("ECEF and Orbital are mutually exclusive")
+	}
+
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{
+		Name:      ConfigMapNameFor(crName),
+		Namespace: namespace,
+	}
+	if err := p.client.Get(ctx, key, cm); err != nil {
+		return fmt.Errorf("reading ConfigMap: %w", err)
+	}
+
+	yamlContent, ok := cm.Data["geo_ntn.yml"]
+	if !ok {
+		return fmt.Errorf("ConfigMap missing geo_ntn.yml")
+	}
+
+	// Replace the ephemeris section in the existing YAML.
+	updated := replaceEphemeris(yamlContent, update)
+	cm.Data["geo_ntn.yml"] = updated
+
+	if err := p.client.Update(ctx, cm); err != nil {
+		return fmt.Errorf("updating ConfigMap: %w", err)
+	}
+	return nil
+}
+
+// replaceEphemeris replaces the ephemeris block in OCUDU config YAML.
+func replaceEphemeris(
+	content string, update provider.EphemerisUpdate,
+) string {
+	var newBlock string
+	if update.Orbital != nil {
+		newBlock = fmt.Sprintf(`  ephemeris_orbital:
+    semi_major_axis: %d
+    eccentricity: %d
+    inclination: %d
+    right_ascension: %d
+    arg_of_periapsis: %d
+    mean_anomaly: %d`,
+			update.Orbital.SemiMajorAxis,
+			update.Orbital.Eccentricity,
+			update.Orbital.Inclination,
+			update.Orbital.RightAscension,
+			update.Orbital.ArgOfPeriapsis,
+			update.Orbital.MeanAnomaly)
+	} else {
+		newBlock = fmt.Sprintf(`  ephemeris_info_ecef:
+    pos_x: %d
+    pos_y: %d
+    pos_z: %d
+    vel_x: %d
+    vel_y: %d
+    vel_z: %d`,
+			update.ECEF.PosX,
+			update.ECEF.PosY,
+			update.ECEF.PosZ,
+			update.ECEF.VelX,
+			update.ECEF.VelY,
+			update.ECEF.VelZ)
+	}
+
+	// Find and replace ephemeris_info_ecef or ephemeris_orbital block.
+	lines := strings.Split(content, "\n")
+	var result []string
+	skip := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "ephemeris_info_ecef:" ||
+			trimmed == "ephemeris_orbital:" {
+			skip = true
+			result = append(result, strings.Split(newBlock, "\n")...)
+			continue
+		}
+		if skip {
+			// Skip indented sub-fields of the old block.
+			if strings.HasPrefix(line, "    ") && !strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			skip = false
+		}
+		result = append(result, line)
+	}
+	return strings.Join(result, "\n")
 }

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -389,6 +389,80 @@ func TestPushEphemerisUpdate_NeitherSet(t *testing.T) {
 	}
 }
 
+func TestPushEphemerisUpdate_YAMLWithComments(t *testing.T) {
+	// YAML with inline comment on key + indented comment in block.
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ntnv1alpha1.AddToScheme(scheme)
+	yamlWithComments := `ntn:
+  cell_specific_koffset: 150
+  ta_info:
+    ta_common: 0
+  ephemeris_info_ecef: # GEO satellite
+    # position in ECEF
+    pos_x: 20922195
+    pos_y: 1967783
+    pos_z: 19770302
+    vel_x: 0
+    vel_y: 0
+    vel_z: 0
+cell_cfg:
+  sib:
+    si_window_length: 5`
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigMapNameFor("test"),
+			Namespace: "ntn-system",
+		},
+		Data: map[string]string{"geo_ntn.yml": yamlWithComments},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cm, ns).Build()
+	p := &Provider{client: c}
+
+	update := provider.EphemerisUpdate{
+		ECEF: &ntnv1alpha1.EphemerisECEF{
+			PosX: 111, PosY: 222, PosZ: 333,
+			VelX: 1, VelY: 2, VelZ: 3,
+		},
+	}
+	err := p.PushEphemerisUpdate(
+		context.Background(), "test", "ntn-system", update,
+	)
+	if err != nil {
+		t.Fatalf("PushEphemerisUpdate: %v", err)
+	}
+
+	var updated corev1.ConfigMap
+	key := types.NamespacedName{
+		Name: ConfigMapNameFor("test"), Namespace: "ntn-system",
+	}
+	if err := p.client.Get(context.Background(), key, &updated); err != nil {
+		t.Fatal(err)
+	}
+	yaml := updated.Data["geo_ntn.yml"]
+	if !contains(yaml, "pos_x: 111") {
+		t.Errorf("expected new pos_x:\n%s", yaml)
+	}
+	// Old values + comments should be gone.
+	if contains(yaml, "pos_x: 20922195") {
+		t.Error("old pos_x still present")
+	}
+	if contains(yaml, "# GEO satellite") {
+		t.Error("inline comment on key line still present")
+	}
+	if contains(yaml, "# position in ECEF") {
+		t.Error("indented comment still present")
+	}
+	// cell_cfg should still be there.
+	if !contains(yaml, "cell_cfg:") {
+		t.Errorf("cell_cfg section missing:\n%s", yaml)
+	}
+}
+
 func TestPushEphemerisUpdate_MissingGeoNtn(t *testing.T) {
 	// ConfigMap exists but without geo_ntn.yml key.
 	scheme := runtime.NewScheme()

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -388,3 +388,36 @@ func TestPushEphemerisUpdate_NeitherSet(t *testing.T) {
 		t.Fatal("expected error when neither ECEF nor Orbital is set")
 	}
 }
+
+func TestPushEphemerisUpdate_MissingGeoNtn(t *testing.T) {
+	// ConfigMap exists but without geo_ntn.yml key.
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ntnv1alpha1.AddToScheme(scheme)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigMapNameFor("test"),
+			Namespace: "ntn-system",
+		},
+		Data: map[string]string{}, // missing geo_ntn.yml
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cm, ns).Build()
+	p := &Provider{client: c}
+
+	update := provider.EphemerisUpdate{
+		ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+	}
+	err := p.PushEphemerisUpdate(
+		context.Background(), "test", "ntn-system", update,
+	)
+	if err == nil {
+		t.Fatal("expected error for missing geo_ntn.yml")
+	}
+	if !contains(err.Error(), "missing geo_ntn.yml") {
+		t.Errorf("expected 'missing geo_ntn.yml' in error, got: %v", err)
+	}
+}

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -263,3 +263,128 @@ func TestConfigMapNameFor_NoCollision(t *testing.T) {
 		t.Errorf("name exceeds K8s limit: %d", len(nameA))
 	}
 }
+
+func TestPushEphemerisUpdate_ECEF(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+
+	// First apply to create the ConfigMap.
+	spec := geoSpec()
+	if err := p.ApplyCellConfig(ctx, "test-cr", spec); err != nil {
+		t.Fatalf("ApplyCellConfig: %v", err)
+	}
+
+	// Push updated ECEF.
+	update := provider.EphemerisUpdate{
+		ECEF: &ntnv1alpha1.EphemerisECEF{
+			PosX: 99999, PosY: 88888, PosZ: 77777,
+			VelX: 10, VelY: 20, VelZ: 30,
+		},
+	}
+	if err := p.PushEphemerisUpdate(ctx, "test-cr", "ntn-system", update); err != nil {
+		t.Fatalf("PushEphemerisUpdate: %v", err)
+	}
+
+	// Verify ConfigMap was updated.
+	var cm corev1.ConfigMap
+	key := types.NamespacedName{
+		Name:      ConfigMapNameFor("test-cr"),
+		Namespace: "ntn-system",
+	}
+	if err := p.client.Get(ctx, key, &cm); err != nil {
+		t.Fatalf("Get ConfigMap: %v", err)
+	}
+	yaml := cm.Data["geo_ntn.yml"]
+	if !contains(yaml, "pos_x: 99999") {
+		t.Errorf("expected updated pos_x in YAML:\n%s", yaml)
+	}
+	if !contains(yaml, "vel_z: 30") {
+		t.Errorf("expected updated vel_z in YAML:\n%s", yaml)
+	}
+	// Old values should be gone.
+	if contains(yaml, "pos_x: 20922195") {
+		t.Error("old pos_x should have been replaced")
+	}
+}
+
+func TestPushEphemerisUpdate_Orbital(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+
+	// First apply to create the ConfigMap.
+	if err := p.ApplyCellConfig(ctx, "test-cr", geoSpec()); err != nil {
+		t.Fatalf("ApplyCellConfig: %v", err)
+	}
+
+	// Push orbital update (replaces the ECEF block).
+	update := provider.EphemerisUpdate{
+		Orbital: &ntnv1alpha1.EphemerisOrbital{
+			SemiMajorAxis:  7000000,
+			Eccentricity:   100,
+			Inclination:    970000,
+			RightAscension: 500000,
+			ArgOfPeriapsis: 300000,
+			MeanAnomaly:    100000,
+		},
+	}
+	if err := p.PushEphemerisUpdate(ctx, "test-cr", "ntn-system", update); err != nil {
+		t.Fatalf("PushEphemerisUpdate: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	key := types.NamespacedName{
+		Name:      ConfigMapNameFor("test-cr"),
+		Namespace: "ntn-system",
+	}
+	if err := p.client.Get(ctx, key, &cm); err != nil {
+		t.Fatalf("Get ConfigMap: %v", err)
+	}
+	yaml := cm.Data["geo_ntn.yml"]
+	if !contains(yaml, "ephemeris_orbital:") {
+		t.Errorf("expected ephemeris_orbital block:\n%s", yaml)
+	}
+	if !contains(yaml, "semi_major_axis: 7000000") {
+		t.Errorf("expected semi_major_axis:\n%s", yaml)
+	}
+	// Old ECEF block should be gone.
+	if contains(yaml, "ephemeris_info_ecef:") {
+		t.Error("old ECEF block should have been replaced")
+	}
+}
+
+func TestPushEphemerisUpdate_BothSet(t *testing.T) {
+	p := newTestProvider(t)
+	err := p.PushEphemerisUpdate(
+		context.Background(), "cr", "ns",
+		provider.EphemerisUpdate{
+			ECEF:    &ntnv1alpha1.EphemerisECEF{PosX: 1},
+			Orbital: &ntnv1alpha1.EphemerisOrbital{SemiMajorAxis: 1},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error when both ECEF and Orbital are set")
+	}
+}
+
+func TestPushEphemerisUpdate_NoConfigMap(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+
+	update := provider.EphemerisUpdate{
+		ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1},
+	}
+	err := p.PushEphemerisUpdate(ctx, "nonexistent", "ntn-system", update)
+	if err == nil {
+		t.Fatal("expected error when ConfigMap doesn't exist")
+	}
+}
+
+func TestPushEphemerisUpdate_NeitherSet(t *testing.T) {
+	p := newTestProvider(t)
+	err := p.PushEphemerisUpdate(
+		context.Background(), "cr", "ns", provider.EphemerisUpdate{},
+	)
+	if err == nil {
+		t.Fatal("expected error when neither ECEF nor Orbital is set")
+	}
+}


### PR DESCRIPTION
## Summary
Extend `NTNProvider` interface with `PushEphemerisUpdate` for dynamic ephemeris updates.

**Phase 1 (this PR):** ConfigMap-based — reads existing `geo_ntn.yml`, replaces the ephemeris block (ECEF or orbital), writes back.

**Phase 2 (future):** WebSocket direct push via OCUDU `handle_ntn_param_update`.

### Changes
- `EphemerisUpdate` struct — carries ECEF or orbital variant
- `NTNProvider.PushEphemerisUpdate` — new interface method
- OCUDU provider: `replaceEphemeris` string-based YAML section replacement
- `MockProvider` updated with `EphemerisCalls` + `LastEphemeris`

## Test plan
- [x] `TestPushEphemerisUpdate_ECEF` — updates ECEF in existing ConfigMap
- [x] `TestPushEphemerisUpdate_Orbital` — replaces ECEF with orbital
- [x] `TestPushEphemerisUpdate_BothSet` — rejects both set
- [x] `TestPushEphemerisUpdate_NeitherSet` — rejects neither set
- [x] `TestPushEphemerisUpdate_NoConfigMap` — errors on missing CM
- [x] All tests pass, 0 lint issues