### PR TITLE
fix: resolve follow-up issues #36 #38 + increase test coverage (#36, #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **4 CRDs**: SatelliteEphemeris, GroundStationLifecycle, NTNCellConfig, NTNSlice
 - **CelesTrak GP fetcher**: OMM JSON with ETag caching, SGP4 pass prediction
 - **SpaceTrack GP fetcher**: Cookie-based auth, session reuse, Secret credential reading
-- **OCUDU/srsRAN provider**: ConfigMap generation for NTN gNB configuration
+- **OCUDU provider**: ConfigMap generation for NTN gNB configuration
 - **Failover engine**: Terrestrial-satellite path switching with switchback delay
 - **QoS/Security/Billing**: Status reporting per active path in NTNSlice
 - **CEL validation rules**: URL scheme, lat/lon range, path priority, ECEF non-zero, SpaceTrack credentials

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ graph TB
     CL[CelesTrak API] -.-> SE
     ST[SpaceTrack API] -.-> SE
     ND[K8s Node] -.-> GS
-    CM -.-> GNB[srsRAN gNB]
+    CM -.-> GNB[OCUDU gNB]
 ```
 
 **Data sources**: SatelliteEphemeris supports CelesTrak (public, no auth) and SpaceTrack (requires credentials via K8s Secret). Both use the same OMM JSON format parsed by SGP4.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kubernetes-native management framework for Non-Terrestrial Networks (NTN). Decla
 |-----|-----------|-------------|
 | **SatelliteEphemeris** | `sateph` | Auto-fetches GP data (OMM JSON) from CelesTrak or SpaceTrack, runs SGP4 pass prediction |
 | **GroundStationLifecycle** | `gs` | Manages edge ground station nodes — health checks, firmware OTA with timeout, K8s integration |
-| **NTNCellConfig** | `ntncc` | Configures NTN gNB cells via OCUDU/srsRAN provider (generates ConfigMap with OwnerReference) |
+| **NTNCellConfig** | `ntncc` | Configures NTN gNB cells via OCUDU provider (generates ConfigMap with OwnerReference) |
 | **NTNSlice** | `nts` | Manages terrestrial-satellite slice failover, QoS mapping, security policy, billing |
 
 ## Architecture
@@ -53,7 +53,7 @@ graph TB
 
 **Data sources**: SatelliteEphemeris supports CelesTrak (public, no auth) and SpaceTrack (requires credentials via K8s Secret). Both use the same OMM JSON format parsed by SGP4.
 
-**Provider pattern**: NTNCellConfig uses a pluggable provider interface (currently OCUDU/srsRAN). OAI and Aalyria providers are planned for v0.2.
+**Provider pattern**: NTNCellConfig uses a pluggable provider interface (currently OCUDU). Additional providers may be added in future releases.
 
 **Failover engine**: NTNSlice evaluates trigger conditions (RSRP, latency, packet loss) and manages terrestrial-satellite path switching with configurable switchback delay. QoS, security, and billing parameters are tracked per active path.
 
@@ -106,7 +106,7 @@ kubectl apply -f config/samples/ntn_v1alpha1_satelliteephemeris.yaml
 kubectl apply -f config/samples/ntn_v1alpha1_groundstationlifecycle.yaml
 kubectl apply -f config/samples/ntn_v1alpha1_groundstationlifecycle_hsinchu.yaml
 
-# NTN cell configuration (OCUDU/srsRAN)
+# NTN cell configuration (OCUDU)
 kubectl apply -f config/samples/ntn_v1alpha1_ntncellconfig.yaml
 
 # Terrestrial-satellite slice failover
@@ -280,7 +280,7 @@ make test-e2e   # Run E2E tests on Kind cluster
 api/v1alpha1/           # CRD type definitions (with CEL validation rules)
 internal/controller/    # Reconciler implementations
 pkg/ephemeris/          # CelesTrak + SpaceTrack GP fetchers, SGP4 pass prediction
-pkg/provider/ocudu/     # OCUDU/srsRAN provider (config generation)
+pkg/provider/ocudu/     # OCUDU provider (config generation)
 pkg/slice/              # Failover state machine + trigger parser
 pkg/netutil/            # SSRF-safe HTTP client
 pkg/metrics/            # Custom Prometheus metrics
@@ -296,7 +296,7 @@ docs/                   # API reference (auto-generated)
 - **Metrics source**: Failover trigger metrics are read from CR annotations (`ntn.operators.dev/simulated-*`). Production UPF/Prometheus integration is planned for v0.2.
 - **Antenna health**: `AntennaReady` condition is simulated as True when the node exists. Real hardware integration requires vendor-specific agents.
 - **Session continuity**: The `sessionContinuity` field is tracked but not enforced at the data plane level.
-- **Providers**: Only OCUDU/srsRAN is implemented. OAI and Aalyria are planned for v0.2.
+- **Providers**: Only OCUDU is implemented. Additional providers may be added in future releases.
 - **Firmware updates**: The controller monitors node annotations for firmware versions but does not directly trigger OTA. An external agent on the node manages the actual update.
 
 ## Grafana Dashboard

--- a/dist/chart/templates/NOTES.txt
+++ b/dist/chart/templates/NOTES.txt
@@ -6,7 +6,7 @@ Namespace: {{ .Release.Namespace }}
 Custom Resource Definitions:
   - SatelliteEphemeris (sateph)  — satellite orbit tracking via CelesTrak/SpaceTrack
   - GroundStationLifecycle (gs)  — ground station node management
-  - NTNCellConfig (ntncc)        — OCUDU/srsRAN gNB NTN cell configuration
+  - NTNCellConfig (ntncc)        — OCUDU gNB NTN cell configuration
   - NTNSlice (nts)               — terrestrial-satellite slice failover
 
 Verify the installation:

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -171,14 +173,24 @@ func (r *GroundStationLifecycleReconciler) healthCheckInterval(gs *ntnv1alpha1.G
 // maxLabelValueLen is the Kubernetes label value length limit.
 const maxLabelValueLen = 63
 
+// groundStationLabelValue returns the label value for a ground station.
+// If namespace.name exceeds the 63-char K8s label limit, it is truncated
+// with a 8-char hash suffix to prevent collisions.
+func groundStationLabelValue(namespace, gsName string) string {
+	labelValue := namespace + "." + gsName
+	if len(labelValue) <= maxLabelValueLen {
+		return labelValue
+	}
+	h := sha256.Sum256([]byte(labelValue))
+	suffix := hex.EncodeToString(h[:4]) // 8 hex chars
+	truncLen := maxLabelValueLen - 9    // 63 - 9 = 54
+	return strings.TrimRight(labelValue[:truncLen], "-.") + "-" + suffix
+}
+
 // findMatchingNode finds a Node labeled ntn.operators.dev/groundstation=<namespace>.<name>.
 func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context, namespace, gsName string) (*corev1.Node, error) {
 	log := logf.FromContext(ctx)
-	labelValue := namespace + "." + gsName
-	if len(labelValue) > maxLabelValueLen {
-		log.V(1).Info("label value exceeds limit", "value", labelValue, "length", len(labelValue))
-		return nil, fmt.Errorf("label value %q exceeds %d-character Kubernetes limit (namespace.name = %d chars)", labelValue, maxLabelValueLen, len(labelValue))
-	}
+	labelValue := groundStationLabelValue(namespace, gsName)
 	var nodeList corev1.NodeList
 	if err := r.List(ctx, &nodeList, client.MatchingLabels{groundStationLabel: labelValue}); err != nil {
 		return nil, fmt.Errorf("listing nodes: %w", err)

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -186,7 +186,9 @@ func groundStationLabelValue(namespace, gsName string) string {
 	prefix := namespace + "."
 	remaining := maxLabelValueLen - len(prefix) - 9 // room for "-" + 8-char hash
 	if remaining < 1 {
-		// Namespace alone is too long — hash the whole thing.
+		// Namespace alone is too long (≥54 chars) — hash the whole thing.
+		// Note: this loses the "." separator so nodeToGroundStation won't
+		// parse it. The GS controller still works via periodic reconcile.
 		h := sha256.Sum256([]byte(labelValue))
 		return hex.EncodeToString(h[:4]) + hex.EncodeToString(h[4:8])
 	}

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -195,6 +195,10 @@ func groundStationLabelValue(namespace, gsName string) string {
 	h := sha256.Sum256([]byte(labelValue))
 	suffix := hex.EncodeToString(h[:4])
 	truncName := strings.TrimRight(gsName[:remaining], "-.")
+	if truncName == "" {
+		// gsName was entirely "-." chars — use hash only.
+		return prefix + suffix
+	}
 	return prefix + truncName + "-" + suffix
 }
 

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -174,20 +174,30 @@ func (r *GroundStationLifecycleReconciler) healthCheckInterval(gs *ntnv1alpha1.G
 const maxLabelValueLen = 63
 
 // groundStationLabelValue returns the label value for a ground station.
-// If namespace.name exceeds the 63-char K8s label limit, it is truncated
-// with a 8-char hash suffix to prevent collisions.
+// If namespace.name exceeds the 63-char K8s label limit, the gsName part
+// is truncated with a hash suffix while preserving "namespace." prefix.
+// This ensures nodeToGroundStation can always parse the namespace back.
 func groundStationLabelValue(namespace, gsName string) string {
 	labelValue := namespace + "." + gsName
 	if len(labelValue) <= maxLabelValueLen {
 		return labelValue
 	}
+	// Preserve namespace + "." prefix, truncate+hash only the name part.
+	prefix := namespace + "."
+	remaining := maxLabelValueLen - len(prefix) - 9 // room for "-" + 8-char hash
+	if remaining < 1 {
+		// Namespace alone is too long — hash the whole thing.
+		h := sha256.Sum256([]byte(labelValue))
+		return hex.EncodeToString(h[:4]) + hex.EncodeToString(h[4:8])
+	}
 	h := sha256.Sum256([]byte(labelValue))
-	suffix := hex.EncodeToString(h[:4]) // 8 hex chars
-	truncLen := maxLabelValueLen - 9    // 63 - 9 = 54
-	return strings.TrimRight(labelValue[:truncLen], "-.") + "-" + suffix
+	suffix := hex.EncodeToString(h[:4])
+	truncName := strings.TrimRight(gsName[:remaining], "-.")
+	return prefix + truncName + "-" + suffix
 }
 
 // findMatchingNode finds a Node labeled ntn.operators.dev/groundstation=<namespace>.<name>.
+// For long names, the label value is truncated+hashed via groundStationLabelValue.
 func (r *GroundStationLifecycleReconciler) findMatchingNode(ctx context.Context, namespace, gsName string) (*corev1.Node, error) {
 	log := logf.FromContext(ctx)
 	labelValue := groundStationLabelValue(namespace, gsName)

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -266,7 +266,7 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 			Type:               ntnv1alpha1.ConditionK8sNodeReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             "NodeNotFound",
-			Message:            fmt.Sprintf("No node with label %s=%s found", groundStationLabel, gs.Namespace+"."+gs.Name),
+			Message:            fmt.Sprintf("No node with label %s=%s found", groundStationLabel, groundStationLabelValue(gs.Namespace, gs.Name)),
 			ObservedGeneration: gs.Generation,
 		})
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -651,5 +651,15 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			// Should contain a hash separator
 			Expect(strings.Count(val, "-")).To(BeNumerically(">=", 1))
 		})
+
+		It("should fall back to pure hash for extremely long namespace", func() {
+			// Namespace so long that prefix (ns + ".") >= 55 chars → remaining < 1
+			ns := strings.Repeat("n", 58)
+			name := strings.Repeat("g", 10) // total = 58 + 1 + 10 = 69 > 63
+			val := groundStationLabelValue(ns, name)
+			Expect(len(val)).To(BeNumerically("<=", 63))
+			// Pure hash — 16 hex chars, no dot separator.
+			Expect(len(val)).To(Equal(16))
+		})
 	})
 })

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -641,15 +641,18 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			Expect(val).NotTo(Equal(val2))
 		})
 
-		It("should produce <=63 chars and end with hash suffix", func() {
-			// 70 chars total — definitely exceeds 63
+		It("should produce <=63 chars and end with 8-char hex hash suffix", func() {
 			ns := "long-ns"
-			name := strings.Repeat("x", 60)
+			name := strings.Repeat("x", 60) // total 68 > 63
 			val := groundStationLabelValue(ns, name)
 			Expect(len(val)).To(BeNumerically("<=", 63))
-			Expect(len(val)).To(BeNumerically(">", len(ns)+1))
-			// Should contain a hash separator
-			Expect(strings.Count(val, "-")).To(BeNumerically(">=", 1))
+			Expect(val).To(HavePrefix(ns + "."))
+			// Suffix after the last "-" must be 8 hex chars.
+			lastDash := strings.LastIndex(val, "-")
+			Expect(lastDash).To(BeNumerically(">", len(ns)+1))
+			hexSuffix := val[lastDash+1:]
+			Expect(hexSuffix).To(HaveLen(8))
+			Expect(hexSuffix).To(MatchRegexp("^[0-9a-f]{8}$"))
 		})
 
 		It("should fall back to pure hash for extremely long namespace", func() {

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -659,7 +659,7 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			val := groundStationLabelValue(ns, name)
 			Expect(len(val)).To(BeNumerically("<=", 63))
 			// Pure hash — 16 hex chars, no dot separator.
-			Expect(len(val)).To(Equal(16))
+			Expect(val).To(HaveLen(16))
 		})
 	})
 })

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -628,23 +629,27 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			Expect(val).To(Equal("default.gs-hsinchu-01"))
 		})
 
-		It("should truncate+hash when exceeding 63 chars", func() {
-			longName := "a-very-long-ground-station-name-that-exceeds"
-			longNs := "a-long-namespace-name"
-			val := groundStationLabelValue(longNs, longName)
+		It("should truncate+hash when exceeding 63 chars and preserve namespace prefix", func() {
+			longName := "a-very-long-ground-station-name-that-definitely-exceeds-limit"
+			ns := "my-namespace"
+			val := groundStationLabelValue(ns, longName)
 			Expect(len(val)).To(BeNumerically("<=", 63))
+			// Must preserve namespace prefix for nodeToGroundStation parsing.
+			Expect(val).To(HavePrefix(ns + "."))
 			// Different long names produce different hashes.
-			val2 := groundStationLabelValue(longNs, longName+"-2")
+			val2 := groundStationLabelValue(ns, longName+"-2")
 			Expect(val).NotTo(Equal(val2))
 		})
 
-		It("should produce exactly 63 chars for long values", func() {
-			longName := "station-" + "x"
-			for len(longName)+len("namespace.")+1 <= 63 {
-				longName += "x"
-			}
-			val := groundStationLabelValue("namespace", longName)
+		It("should produce <=63 chars and end with hash suffix", func() {
+			// 70 chars total — definitely exceeds 63
+			ns := "long-ns"
+			name := strings.Repeat("x", 60)
+			val := groundStationLabelValue(ns, name)
 			Expect(len(val)).To(BeNumerically("<=", 63))
+			Expect(len(val)).To(BeNumerically(">", len(ns)+1))
+			// Should contain a hash separator
+			Expect(strings.Count(val, "-")).To(BeNumerically(">=", 1))
 		})
 	})
 })

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -580,4 +580,71 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			Expect(err.Error()).To(ContainSubstring("lon"))
 		})
 	})
+
+	// --- nodeToGroundStation mapper tests ---
+
+	Context("nodeToGroundStation mapper", func() {
+		It("should map labeled node to ground station request", func() {
+			reconciler := &GroundStationLifecycleReconciler{Client: k8sClient}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "edge-node-1",
+					Labels: map[string]string{groundStationLabel: "default.gs-test"},
+				},
+			}
+			requests := reconciler.nodeToGroundStation(context.Background(), node)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("gs-test"))
+			Expect(requests[0].Namespace).To(Equal("default"))
+		})
+
+		It("should return nil for node without label", func() {
+			reconciler := &GroundStationLifecycleReconciler{Client: k8sClient}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "unlabeled"},
+			}
+			requests := reconciler.nodeToGroundStation(context.Background(), node)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should return nil for invalid label format", func() {
+			reconciler := &GroundStationLifecycleReconciler{Client: k8sClient}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "bad-label",
+					Labels: map[string]string{groundStationLabel: "no-dot-separator"},
+				},
+			}
+			requests := reconciler.nodeToGroundStation(context.Background(), node)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	// --- groundStationLabelValue tests ---
+
+	Context("groundStationLabelValue", func() {
+		It("should return namespace.name when within limit", func() {
+			val := groundStationLabelValue("default", "gs-hsinchu-01")
+			Expect(val).To(Equal("default.gs-hsinchu-01"))
+		})
+
+		It("should truncate+hash when exceeding 63 chars", func() {
+			longName := "a-very-long-ground-station-name-that-exceeds"
+			longNs := "a-long-namespace-name"
+			val := groundStationLabelValue(longNs, longName)
+			Expect(len(val)).To(BeNumerically("<=", 63))
+			// Different long names produce different hashes.
+			val2 := groundStationLabelValue(longNs, longName+"-2")
+			Expect(val).NotTo(Equal(val2))
+		})
+
+		It("should produce exactly 63 chars for long values", func() {
+			longName := "station-" + "x"
+			for len(longName)+len("namespace.")+1 <= 63 {
+				longName += "x"
+			}
+			val := groundStationLabelValue("namespace", longName)
+			Expect(len(val)).To(BeNumerically("<=", 63))
+		})
+	})
 })

--- a/pkg/provider/ocudu/config.go
+++ b/pkg/provider/ocudu/config.go
@@ -24,9 +24,9 @@ import (
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
-// configTemplate generates srsRAN/OCUDU-compatible NTN configuration YAML.
+// configTemplate generates OCUDU-compatible NTN configuration YAML.
 //
-// This format was validated against srsRAN gNB commit 4bf1543 (OCUDU v1.0).
+// This format was validated against OCUDU gNB (migrated from srsRAN_Project).
 // Key format differences from the old docs-era geo_ntn.yml:
 //   - ta_common is under ntn.ta_info (not ntn.ta_common)
 //   - ephemeris uses ephemeris_info_ecef or ephemeris_orbital (variant)
@@ -201,9 +201,9 @@ type configData struct {
 	RrcGuardTimeMs            int
 }
 
-// GenerateConfig produces srsRAN/OCUDU-compatible NTN configuration YAML
+// GenerateConfig produces OCUDU-compatible NTN configuration YAML
 // from an NTNCellConfigSpec. The output matches the CLI11 config format
-// accepted by srsRAN gNB (verified against commit 4bf1543).
+// accepted by OCUDU gNB (CLI11 config format).
 func GenerateConfig(spec *ntnv1alpha1.NTNCellConfigSpec) ([]byte, error) {
 	if spec == nil {
 		return nil, fmt.Errorf("spec must not be nil")

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -55,7 +55,7 @@ func ConfigMapNameFor(crName string) string {
 	return name
 }
 
-// Provider implements provider.NTNProvider for OCUDU/srsRAN gNB.
+// Provider implements provider.NTNProvider for OCUDU gNB.
 // It is stateless — status is derived from the ConfigMap.
 type Provider struct {
 	client client.Client


### PR DESCRIPTION
## Summary
- **#36**: `groundStationLabelValue` now truncates+hashes labels exceeding 63-char K8s limit instead of hard-failing
- **#38**: Update stale srsRAN references to OCUDU in provider/config/README
- **Coverage**: controller 84.4% → 86.5% (above 85% baseline)
  - Added `groundStationLabelValue` truncation tests
  - Added `nodeToGroundStation` mapper tests (labeled/unlabeled/invalid)

Closes #36, closes #38

## Test plan
- [x] All tests pass with -race
- [x] `make lint` — 0 issues
- [x] Controller coverage ≥ 85%