### PR TITLE
fix: resolve hashed labels + package logging + Chart.yaml (#39 #41 #42)

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - satellite
   - 5g
   - non-terrestrial-network
-  - srsran
+  - ocudu
 
 home: https://github.com/thc1006/ntn-operators
 sources:

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -182,18 +183,19 @@ func groundStationLabelValue(namespace, gsName string) string {
 	if len(labelValue) <= maxLabelValueLen {
 		return labelValue
 	}
-	// Preserve namespace + "." prefix, truncate+hash only the name part.
+	// Always preserve a dot separator so nodeToGroundStation can parse
+	// the namespace. If namespace is too long, truncate it too.
+	h := sha256.Sum256([]byte(labelValue))
+	suffix := hex.EncodeToString(h[:4]) // 8 hex chars
+
 	prefix := namespace + "."
 	remaining := maxLabelValueLen - len(prefix) - 9 // room for "-" + 8-char hash
 	if remaining < 1 {
-		// Namespace alone is too long (≥54 chars) — hash the whole thing.
-		// Note: this loses the "." separator so nodeToGroundStation won't
-		// parse it. The GS controller still works via periodic reconcile.
-		h := sha256.Sum256([]byte(labelValue))
-		return hex.EncodeToString(h[:4]) + hex.EncodeToString(h[4:8])
+		// Namespace too long — truncate namespace to fit while keeping ".".
+		nsMax := min(maxLabelValueLen-1-8, len(namespace)) // 63 - "." - suffix = 54, clamped
+		truncNs := strings.TrimRight(namespace[:nsMax], "-.")
+		return truncNs + "." + suffix
 	}
-	h := sha256.Sum256([]byte(labelValue))
-	suffix := hex.EncodeToString(h[:4])
 	truncName := strings.TrimRight(gsName[:remaining], "-.")
 	if truncName == "" {
 		// gsName was entirely "-." chars — use hash only.
@@ -487,7 +489,7 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 	if !upToDate && gs.Spec.Firmware.AutoUpdate &&
 		(gs.Status.Phase == ntnv1alpha1.PhaseRunning || gs.Status.Phase == ntnv1alpha1.PhaseDegraded) {
 		if gs.Spec.Firmware.MaintenanceWindow != "" {
-			inWindow, err := lifecycle.IsWithinMaintenanceWindow(gs.Spec.Firmware.MaintenanceWindow, r.now())
+			inWindow, err := lifecycle.IsWithinMaintenanceWindowWithContext(ctx, gs.Spec.Firmware.MaintenanceWindow, r.now())
 			if err != nil {
 				meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 					Type:               ntnv1alpha1.ConditionFirmwareUpToDate,
@@ -582,6 +584,9 @@ func (r *GroundStationLifecycleReconciler) SetupWithManager(mgr ctrl.Manager) er
 }
 
 // nodeToGroundStation maps a Node change to the GroundStationLifecycle it belongs to.
+// For short names, the label is "<namespace>.<name>" and can be parsed directly.
+// For long names (hashed labels), the mapper lists GS CRs in the parsed namespace
+// and matches by recomputing groundStationLabelValue.
 func (r *GroundStationLifecycleReconciler) nodeToGroundStation(
 	ctx context.Context, obj client.Object,
 ) []ctrl.Request {
@@ -593,14 +598,66 @@ func (r *GroundStationLifecycleReconciler) nodeToGroundStation(
 	if !found {
 		return nil
 	}
-	// Label format: "<namespace>.<name>". Parse directly.
 	parts := strings.SplitN(labelValue, ".", 2)
 	if len(parts) != 2 {
-		return nil // invalid label format
+		return nil // invalid label format (or hash-only fallback)
 	}
 	gsNamespace, gsName := parts[0], parts[1]
 
-	return []ctrl.Request{{
-		NamespacedName: client.ObjectKey{Namespace: gsNamespace, Name: gsName},
-	}}
+	// Fast path: try direct Get with the parsed name.
+	key := client.ObjectKey{Namespace: gsNamespace, Name: gsName}
+	var gs ntnv1alpha1.GroundStationLifecycle
+	if err := r.Get(ctx, key, &gs); err == nil {
+		// Verify the label matches to avoid false hits (e.g., a real GS
+		// name that coincides with a truncated+hashed value).
+		if groundStationLabelValue(gs.Namespace, gs.Name) == labelValue {
+			return []ctrl.Request{{NamespacedName: key}}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		// Transient error — still enqueue parsed key so the event isn't
+		// lost (mapper funcs aren't retried; reconcile will handle it).
+		log := logf.FromContext(ctx)
+		log.Error(err, "transient error in node mapper Get, enqueuing best-guess", "key", key)
+		return []ctrl.Request{{NamespacedName: key}}
+	}
+
+	// Slow path: NotFound — label is likely hashed.
+	// List GS CRs in parsed namespace and match by recomputing label value.
+	log := logf.FromContext(ctx)
+	var gsList ntnv1alpha1.GroundStationLifecycleList
+	if err := r.List(ctx, &gsList, client.InNamespace(gsNamespace)); err != nil {
+		log.Error(err, "failed to list GroundStations for node mapper, enqueuing best-guess")
+		return []ctrl.Request{{NamespacedName: key}}
+	}
+	var requests []ctrl.Request
+	for _, gs := range gsList.Items {
+		if groundStationLabelValue(gs.Namespace, gs.Name) == labelValue {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gs.Namespace, Name: gs.Name,
+				},
+			})
+		}
+	}
+	// If namespace was truncated (label near max length with hash suffix),
+	// the parsed namespace won't match any real namespace.
+	// Only do expensive cluster-wide search for labels that look truncated.
+	looksLikeTruncatedNs := len(requests) == 0 && len(labelValue) >= maxLabelValueLen-2
+	if looksLikeTruncatedNs {
+		var allGS ntnv1alpha1.GroundStationLifecycleList
+		if err := r.List(ctx, &allGS); err != nil {
+			log.Error(err, "cluster-wide GS list failed, enqueuing best-guess")
+			return []ctrl.Request{{NamespacedName: key}}
+		}
+		for _, gs := range allGS.Items {
+			if groundStationLabelValue(gs.Namespace, gs.Name) == labelValue {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: client.ObjectKey{
+						Namespace: gs.Namespace, Name: gs.Name,
+					},
+				})
+			}
+		}
+	}
+	return requests
 }

--- a/internal/controller/groundstationlifecycle_controller_test.go
+++ b/internal/controller/groundstationlifecycle_controller_test.go
@@ -585,18 +585,37 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 	// --- nodeToGroundStation mapper tests ---
 
 	Context("nodeToGroundStation mapper", func() {
-		It("should map labeled node to ground station request", func() {
+		It("should map labeled node to existing ground station", func() {
+			// Create a real GS so Get succeeds.
+			gs := &ntnv1alpha1.GroundStationLifecycle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gs-mapper-test", Namespace: namespace,
+				},
+				Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+					Deployment: ntnv1alpha1.DeploymentSpec{
+						Location: ntnv1alpha1.GeoLocation{Lat: "0", Lon: "0"},
+					},
+					Hardware: ntnv1alpha1.HardwareSpec{
+						Vendor: "test", Model: "test",
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), gs)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(context.Background(), gs)).To(Succeed())
+			})
+
 			reconciler := &GroundStationLifecycleReconciler{Client: k8sClient}
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "edge-node-1",
-					Labels: map[string]string{groundStationLabel: "default.gs-test"},
+					Labels: map[string]string{groundStationLabel: namespace + ".gs-mapper-test"},
 				},
 			}
 			requests := reconciler.nodeToGroundStation(context.Background(), node)
 			Expect(requests).To(HaveLen(1))
-			Expect(requests[0].Name).To(Equal("gs-test"))
-			Expect(requests[0].Namespace).To(Equal("default"))
+			Expect(requests[0].Name).To(Equal("gs-mapper-test"))
+			Expect(requests[0].Namespace).To(Equal(namespace))
 		})
 
 		It("should return nil for node without label", func() {
@@ -618,6 +637,40 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			}
 			requests := reconciler.nodeToGroundStation(context.Background(), node)
 			Expect(requests).To(BeEmpty())
+		})
+
+		It("should resolve hashed label by listing GS CRs in namespace", func() {
+			// Create a GS with a long name that triggers label hashing.
+			longName := "gs-" + strings.Repeat("x", 55)
+			gs := &ntnv1alpha1.GroundStationLifecycle{
+				ObjectMeta: metav1.ObjectMeta{Name: longName, Namespace: namespace},
+				Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+					Deployment: ntnv1alpha1.DeploymentSpec{
+						Location: ntnv1alpha1.GeoLocation{Lat: "0", Lon: "0"},
+					},
+					Hardware: ntnv1alpha1.HardwareSpec{
+						Vendor: "test", Model: "test",
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), gs)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(context.Background(), gs)).To(Succeed())
+			})
+
+			// Simulate a Node with the hashed label.
+			hashedLabel := groundStationLabelValue(namespace, longName)
+			reconciler := &GroundStationLifecycleReconciler{Client: k8sClient}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "edge-node-hashed",
+					Labels: map[string]string{groundStationLabel: hashedLabel},
+				},
+			}
+			requests := reconciler.nodeToGroundStation(context.Background(), node)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal(longName))
+			Expect(requests[0].Namespace).To(Equal(namespace))
 		})
 	})
 
@@ -655,14 +708,16 @@ var _ = Describe("GroundStationLifecycle Controller", func() {
 			Expect(hexSuffix).To(MatchRegexp("^[0-9a-f]{8}$"))
 		})
 
-		It("should fall back to pure hash for extremely long namespace", func() {
+		It("should truncate namespace for extremely long namespace but keep dot", func() {
 			// Namespace so long that prefix (ns + ".") >= 55 chars → remaining < 1
 			ns := strings.Repeat("n", 58)
 			name := strings.Repeat("g", 10) // total = 58 + 1 + 10 = 69 > 63
 			val := groundStationLabelValue(ns, name)
 			Expect(len(val)).To(BeNumerically("<=", 63))
-			// Pure hash — 16 hex chars, no dot separator.
-			Expect(val).To(HaveLen(16))
+			// Must always contain a dot for nodeToGroundStation parsing.
+			Expect(strings.Contains(val, ".")).To(BeTrue())
+			// Namespace is truncated but present.
+			Expect(strings.HasPrefix(val, "nnn")).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -73,45 +73,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Step 2: Handle finalizer for ConfigMap cleanup on deletion.
-	finalizerName := "ntn.operators.dev/configmap-cleanup"
-	if cc.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(cc, finalizerName) {
-			// Delete the ConfigMap.
-			cm := &corev1.ConfigMap{}
-			cmKey := client.ObjectKey{
-				Namespace: cc.Namespace,
-				Name:      ocudu.ConfigMapNameFor(cc.Name),
-			}
-			if err := r.Get(ctx, cmKey, cm); err != nil {
-				if client.IgnoreNotFound(err) != nil {
-					// Transient error (not NotFound) — requeue to retry.
-					log.Error(err, "Failed to get ConfigMap during finalization")
-					return ctrl.Result{}, err
-				}
-				// NotFound — ConfigMap already gone, proceed to remove finalizer.
-			} else {
-				if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
-					log.Error(err, "Failed to delete ConfigMap during finalization")
-					return ctrl.Result{}, err
-				}
-				log.Info("Deleted ConfigMap during finalization", "configmap", cmKey)
-			}
-			controllerutil.RemoveFinalizer(cc, finalizerName)
-			if err := r.Update(ctx, cc); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		return ctrl.Result{}, nil
-	}
-
-	// Add finalizer if not present, then requeue to reconcile with latest resourceVersion.
-	if !controllerutil.ContainsFinalizer(cc, finalizerName) {
-		controllerutil.AddFinalizer(cc, finalizerName)
-		if err := r.Update(ctx, cc); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.V(1).Info("finalizer added, requeueing")
-		return ctrl.Result{RequeueAfter: time.Second}, nil
+	if done, result, err := r.handleFinalizer(ctx, cc); done {
+		return result, err
 	}
 
 	// Step 3: Guard against nil provider.
@@ -239,6 +202,53 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.Info("NTN cell configuration applied successfully")
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// handleFinalizer manages ConfigMap cleanup on NTNCellConfig deletion.
+// Returns (done, result, error). If done is true, the caller should return.
+func (r *NTNCellConfigReconciler) handleFinalizer(
+	ctx context.Context, cc *ntnv1alpha1.NTNCellConfig,
+) (bool, ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	finalizerName := "ntn.operators.dev/configmap-cleanup"
+
+	if cc.DeletionTimestamp != nil {
+		if controllerutil.ContainsFinalizer(cc, finalizerName) {
+			cm := &corev1.ConfigMap{}
+			cmKey := client.ObjectKey{
+				Namespace: cc.Namespace,
+				Name:      ocudu.ConfigMapNameFor(cc.Name),
+			}
+			if err := r.Get(ctx, cmKey, cm); err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					log.Error(err, "Failed to get ConfigMap during finalization")
+					return true, ctrl.Result{}, err
+				}
+			} else {
+				if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
+					log.Error(err, "Failed to delete ConfigMap during finalization")
+					return true, ctrl.Result{}, err
+				}
+				log.Info("Deleted ConfigMap during finalization", "configmap", cmKey)
+			}
+			controllerutil.RemoveFinalizer(cc, finalizerName)
+			if err := r.Update(ctx, cc); err != nil {
+				return true, ctrl.Result{}, err
+			}
+		}
+		return true, ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(cc, finalizerName) {
+		controllerutil.AddFinalizer(cc, finalizerName)
+		if err := r.Update(ctx, cc); err != nil {
+			return true, ctrl.Result{}, err
+		}
+		log.V(1).Info("finalizer added, requeueing")
+		return true, ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
+	return false, ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -110,7 +110,8 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		lastFailover = ns.Status.LastFailover.Time
 	}
 
-	result := slice.EvaluateFailover(
+	result := slice.EvaluateFailoverWithContext(
+		ctx,
 		currentPath,
 		ns.Spec.FailoverPolicy.Triggers,
 		metrics,

--- a/pkg/lifecycle/maintenance_window.go
+++ b/pkg/lifecycle/maintenance_window.go
@@ -17,9 +17,12 @@ limitations under the License.
 package lifecycle
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 var maintenanceWindowRE = regexp.MustCompile(`^(\d{2}:\d{2})-(\d{2}:\d{2})\s+UTC$`)
@@ -31,7 +34,21 @@ var maintenanceWindowRE = regexp.MustCompile(`^(\d{2}:\d{2})-(\d{2}:\d{2})\s+UTC
 // returns (false, nil) so callers can decide to proceed unconditionally.
 // A window where start == end (e.g., "00:00-00:00 UTC") is treated as invalid.
 func IsWithinMaintenanceWindow(window string, now time.Time) (bool, error) {
+	return IsWithinMaintenanceWindowWithContext(context.Background(), window, now)
+}
+
+// IsWithinMaintenanceWindowWithContext is the context-aware variant of
+// IsWithinMaintenanceWindow. It emits structured package-level logs.
+func IsWithinMaintenanceWindowWithContext(
+	ctx context.Context,
+	window string,
+	now time.Time,
+) (bool, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	log.V(2).Info("evaluate maintenance window", "window", window, "nowUTC", now.UTC().Format(time.RFC3339))
+
 	if window == "" {
+		log.V(1).Info("maintenance window not configured")
 		return false, nil
 	}
 
@@ -58,10 +75,24 @@ func IsWithinMaintenanceWindow(window string, now time.Time) (bool, error) {
 
 	if startHM < endHM {
 		// Normal window: e.g., "02:00-04:00 UTC"
-		return nowMinutes >= startHM && nowMinutes < endHM, nil
+		inWindow := nowMinutes >= startHM && nowMinutes < endHM
+		log.V(1).Info("maintenance window evaluated",
+			"inWindow", inWindow,
+			"startMinutes", startHM,
+			"endMinutes", endHM,
+			"nowMinutes", nowMinutes,
+		)
+		return inWindow, nil
 	}
 	// Midnight wraparound: e.g., "23:00-02:00 UTC"
-	return nowMinutes >= startHM || nowMinutes < endHM, nil
+	inWindow := nowMinutes >= startHM || nowMinutes < endHM
+	log.V(1).Info("maintenance window evaluated (wraparound)",
+		"inWindow", inWindow,
+		"startMinutes", startHM,
+		"endMinutes", endHM,
+		"nowMinutes", nowMinutes,
+	)
+	return inWindow, nil
 }
 
 // parseHHMM parses "HH:MM" into minutes since midnight.

--- a/pkg/lifecycle/maintenance_window_test.go
+++ b/pkg/lifecycle/maintenance_window_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lifecycle
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -118,5 +119,20 @@ func TestIsWithinMaintenanceWindow(t *testing.T) {
 					tc.window, tc.now, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsWithinMaintenanceWindowWithContext_MatchesLegacyBehavior(t *testing.T) {
+	now := utc(3, 0)
+	want, err := IsWithinMaintenanceWindow("02:00-04:00 UTC", now)
+	if err != nil {
+		t.Fatalf("legacy function returned error: %v", err)
+	}
+	got, err := IsWithinMaintenanceWindowWithContext(context.Background(), "02:00-04:00 UTC", now)
+	if err != nil {
+		t.Fatalf("context function returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("mismatch: got %v want %v", got, want)
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -89,4 +89,7 @@ func init() {
 		GPFetchDuration,
 		GPSatelliteCount,
 	)
+	// Note: logging here is intentionally omitted because init() runs
+	// before controller-runtime's logger is configured. Registration
+	// success is verified by the metrics_test.go suite.
 }

--- a/pkg/netutil/safeclient.go
+++ b/pkg/netutil/safeclient.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // privateRanges are CIDR blocks that should never be accessed by the operator.
@@ -72,6 +74,7 @@ var ErrPrivateIP = fmt.Errorf("connection to private/reserved IP address is bloc
 // against private/reserved ranges before connecting.
 func safeDialContext(dialer *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		log := logr.FromContextOrDiscard(ctx)
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
@@ -85,10 +88,12 @@ func safeDialContext(dialer *net.Dialer) func(ctx context.Context, network, addr
 		if len(ips) == 0 {
 			return nil, fmt.Errorf("DNS resolution for %q returned no addresses", host)
 		}
+		log.V(2).Info("resolved outbound host", "host", host, "ipCount", len(ips))
 
 		// Validate ALL resolved IPs before connecting.
 		for _, ipAddr := range ips {
 			if IsPrivateIP(ipAddr.IP) {
+				log.V(1).Info("blocked outbound dial to private/reserved IP", "host", host, "ip", ipAddr.IP.String())
 				return nil, fmt.Errorf("%w: %s resolves to %s", ErrPrivateIP, host, ipAddr.IP)
 			}
 		}
@@ -98,6 +103,7 @@ func safeDialContext(dialer *net.Dialer) func(ctx context.Context, network, addr
 		for _, ipAddr := range ips {
 			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ipAddr.IP.String(), port))
 			if dialErr == nil {
+				log.V(2).Info("outbound dial succeeded", "host", host, "ip", ipAddr.IP.String())
 				return conn, nil
 			}
 			lastErr = dialErr
@@ -121,6 +127,7 @@ func NewSafeHTTPClient(timeout time.Duration) *http.Client {
 		Transport: transport,
 		// Validate redirect targets against private IP ranges (defense in depth).
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			log := logr.FromContextOrDiscard(req.Context())
 			if len(via) >= 3 {
 				return fmt.Errorf("too many redirects")
 			}
@@ -132,9 +139,11 @@ func NewSafeHTTPClient(timeout time.Duration) *http.Client {
 			}
 			for _, ipAddr := range ips {
 				if IsPrivateIP(ipAddr.IP) {
+					log.V(1).Info("blocked redirect to private/reserved IP", "host", host, "ip", ipAddr.IP.String())
 					return fmt.Errorf("%w: redirect to %s resolves to %s", ErrPrivateIP, host, ipAddr.IP)
 				}
 			}
+			log.V(2).Info("redirect target allowed", "host", host, "ipCount", len(ips))
 			return nil
 		},
 	}

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -17,11 +17,14 @@ limitations under the License.
 package slice
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // PathType represents the active network path.
@@ -145,6 +148,46 @@ func EvaluateFailover(
 	lastFailover time.Time,
 	now time.Time,
 ) FailoverResult {
+	return EvaluateFailoverWithContext(
+		context.Background(),
+		currentPath,
+		triggers,
+		metrics,
+		satelliteAvailable,
+		switchbackDelay,
+		lastFailover,
+		now,
+	)
+}
+
+// EvaluateFailoverWithContext is the context-aware variant of EvaluateFailover.
+// It emits structured package-level logs for trigger parsing and decision outcomes.
+func EvaluateFailoverWithContext(
+	ctx context.Context,
+	currentPath PathType,
+	triggers []string,
+	metrics Metrics,
+	satelliteAvailable bool,
+	switchbackDelay time.Duration,
+	lastFailover time.Time,
+	now time.Time,
+) FailoverResult {
+	log := logr.FromContextOrDiscard(ctx)
+	log.V(2).Info("evaluate failover",
+		"currentPath", currentPath,
+		"triggerCount", len(triggers),
+		"satelliteAvailable", satelliteAvailable,
+		"switchbackDelay", switchbackDelay,
+	)
+	finish := func(res FailoverResult) FailoverResult {
+		log.V(1).Info("failover decision",
+			"decision", res.Decision,
+			"targetPath", res.TargetPath,
+			"reason", res.Reason,
+		)
+		return res
+	}
+
 	// Parse and evaluate all triggers (OR logic).
 	anyTriggered := false
 	parseErrors := 0
@@ -152,10 +195,12 @@ func EvaluateFailover(
 		trigger, err := ParseTrigger(triggerStr)
 		if err != nil {
 			parseErrors++
+			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
 			continue
 		}
 		if trigger.Evaluate(metrics) {
 			anyTriggered = true
+			log.V(2).Info("trigger matched", "trigger", triggerStr)
 			break
 		}
 	}
@@ -169,11 +214,11 @@ func EvaluateFailover(
 	parseSuffix := ""
 	if parseErrors > 0 {
 		if parseErrors == len(triggers) {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionStay,
 				Reason:     fmt.Sprintf("All %d trigger expressions are invalid", parseErrors),
 				TargetPath: currentPath,
-			}
+			})
 		}
 		parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
 	}
@@ -181,84 +226,84 @@ func EvaluateFailover(
 	switch currentPath {
 	case PathTerrestrial:
 		if !anyTriggered {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionStay,
 				Reason:     "Terrestrial path healthy" + parseSuffix,
 				TargetPath: PathTerrestrial,
-			}
+			})
 		}
 		if !satelliteAvailable {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionStay,
 				Reason:     "Terrestrial degraded but no satellite pass available" + parseSuffix,
 				TargetPath: PathTerrestrial,
-			}
+			})
 		}
-		return FailoverResult{
+		return finish(FailoverResult{
 			Decision:   DecisionFailover,
 			Reason:     "Terrestrial path degraded, satellite pass available" + parseSuffix,
 			TargetPath: PathSatellite,
-		}
+		})
 
 	case PathSatellite:
 		// If satellite pass ended, must switch back regardless.
 		if !satelliteAvailable {
 			if anyTriggered {
-				return FailoverResult{
+				return finish(FailoverResult{
 					Decision:   DecisionSwitchback,
 					Reason:     "Satellite pass ended, falling back to degraded terrestrial" + parseSuffix,
 					TargetPath: PathTerrestrial,
-				}
+				})
 			}
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
 				Reason:     "Satellite pass ended, terrestrial recovered" + parseSuffix,
 				TargetPath: PathTerrestrial,
-			}
+			})
 		}
 		if anyTriggered {
 			// Terrestrial still degraded, stay on satellite.
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionStay,
 				Reason:     "Terrestrial still degraded, staying on satellite" + parseSuffix,
 				TargetPath: PathSatellite,
-			}
+			})
 		}
 		// Terrestrial recovered — check switchback delay.
 		if !lastFailover.IsZero() && now.Sub(lastFailover) < switchbackDelay {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision: DecisionStay,
 				Reason: fmt.Sprintf("Terrestrial recovered but switchback delay not elapsed (%s remaining)%s",
 					switchbackDelay-now.Sub(lastFailover), parseSuffix),
 				TargetPath: PathSatellite,
-			}
+			})
 		}
-		return FailoverResult{
+		return finish(FailoverResult{
 			Decision:   DecisionSwitchback,
 			Reason:     "Terrestrial recovered, switchback delay elapsed" + parseSuffix,
 			TargetPath: PathTerrestrial,
-		}
+		})
 
 	default:
 		// Unknown or unavailable path — try terrestrial first.
 		if !anyTriggered {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
 				Reason:     "Initializing on terrestrial path" + parseSuffix,
 				TargetPath: PathTerrestrial,
-			}
+			})
 		}
 		if satelliteAvailable {
-			return FailoverResult{
+			return finish(FailoverResult{
 				Decision:   DecisionFailover,
 				Reason:     "Terrestrial unavailable, using satellite" + parseSuffix,
 				TargetPath: PathSatellite,
-			}
+			})
 		}
-		return FailoverResult{
+		return finish(FailoverResult{
 			Decision:   DecisionStay,
 			Reason:     "Both paths degraded" + parseSuffix,
 			TargetPath: PathUnavailable,
-		}
+		})
 	}
 }

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package slice
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -302,5 +303,21 @@ func TestEvaluateFailover_EmptyPath_Degraded_Failover(t *testing.T) {
 	}
 	if result.TargetPath != PathSatellite {
 		t.Errorf("expected satellite, got %s", result.TargetPath)
+	}
+}
+
+func TestEvaluateFailoverWithContext_MatchesLegacyBehavior(t *testing.T) {
+	metrics := Metrics{RSRP: -125, LatencyMs: 250, PacketLossPercent: 0.1}
+	want := EvaluateFailover(
+		PathTerrestrial, triggers, metrics,
+		true, 60*time.Second, time.Time{}, now,
+	)
+	got := EvaluateFailoverWithContext(
+		context.Background(),
+		PathTerrestrial, triggers, metrics,
+		true, 60*time.Second, time.Time{}, now,
+	)
+	if got != want {
+		t.Fatalf("EvaluateFailoverWithContext mismatch: got %+v want %+v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

### Label resolution (#41)
- `groundStationLabelValue`: always preserve dot separator, even for extremely long namespaces
- `nodeToGroundStation`: Get-first (O(1)) + List-fallback for hashed labels
- Regression test with real GS CR for hashed label resolution

### Package-level logging (#39)
- `lifecycle.IsWithinMaintenanceWindowWithContext` — V(1) window evaluation, V(2) input details
- `slice.EvaluateFailoverWithContext` — V(1) decision outcome, V(2) trigger matching
- `netutil/safeclient.go` — V(1) blocked private IPs, V(2) DNS resolution + dial
- Old APIs preserved as backward-compatible delegates

### Chart.yaml (#42)
- `srsran` keyword → `ocudu`

Closes #39, closes #41, closes #42

## Test plan
- [x] `TestIsWithinMaintenanceWindowWithContext_MatchesLegacyBehavior`
- [x] `TestEvaluateFailoverWithContext_MatchesLegacyBehavior`
- [x] nodeToGroundStation: normal label, unlabeled, invalid, hashed label resolution
- [x] groundStationLabelValue: short, long, extremely long namespace
- [x] All tests pass, 0 lint issues (pre-existing gocyclo on main excluded)