### PR TITLE
fix: push runtime ephemeris update on ephemerisRef reconcile (#37)

### DIFF
--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -415,8 +415,9 @@ type NTNCellConfigStatus struct {
 
 // Condition types for NTNCellConfig.
 const (
-	ConditionConfigApplied = "ConfigApplied"
-	ConditionConfigValid   = "ConfigValid"
+	ConditionConfigApplied   = "ConfigApplied"
+	ConditionConfigValid     = "ConfigValid"
+	ConditionEphemerisPushed = "EphemerisPushed"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -36,10 +36,9 @@ type NTNCellConfigSpec struct {
 
 	// ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
 	// When set, the controller re-reconciles this NTNCellConfig whenever the
-	// referenced SatelliteEphemeris is updated. Future work will consume the
-	// ephemeris data for dynamic NTN parameter updates; currently this field
-	// only triggers reconciliation. The static ephemeris in spec.ntn
-	// (ephemerisECEF or ephemerisOrbital) remains required.
+	// referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
+	// on the provider reconcile path. The static ephemeris in spec.ntn
+	// (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -300,7 +300,7 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	if err := r.Get(ctx, ephKey, eph); err != nil {
 		return false, "", fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", cc.Spec.EphemerisRef, err)
 	}
-	marker := ephemerisPushMarker(cc.Spec.EphemerisRef, eph.ResourceVersion)
+	marker := ephemerisPushMarker(eph)
 	if isEphemerisPushUpToDate(cc, marker) {
 		return false, marker, nil
 	}
@@ -332,8 +332,12 @@ func isEphemerisPushUpToDate(cc *ntnv1alpha1.NTNCellConfig, marker string) bool 
 		cond.Message == marker
 }
 
-func ephemerisPushMarker(ephemerisRef, resourceVersion string) string {
-	return fmt.Sprintf("ephemerisRef=%s resourceVersion=%s", ephemerisRef, resourceVersion)
+func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
+	lastUpdated := "none"
+	if eph.Status.LastUpdated != nil {
+		lastUpdated = eph.Status.LastUpdated.UTC().Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("ephemerisRef=%s generation=%d lastUpdated=%s", eph.Name, eph.Generation, lastUpdated)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -147,26 +147,6 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// Step 5a: Push ephemeris update when this config references SatelliteEphemeris.
-	// This ensures ephemeris-triggered requeues invoke the runtime update path.
-	if err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec); err != nil {
-		log.Error(err, "failed to push ephemeris update")
-		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
-			Type:               ntnv1alpha1.ConditionConfigApplied,
-			Status:             metav1.ConditionUnknown,
-			Reason:             "EphemerisPushFailed",
-			Message:            fmt.Sprintf("config applied but ephemeris push failed: %v", err),
-			ObservedGeneration: cc.Generation,
-		})
-		if err := r.Status().Update(ctx, cc); err != nil {
-			return ctrl.Result{}, err
-		}
-		if r.Recorder != nil {
-			r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", err.Error())
-		}
-		return ctrl.Result{RequeueAfter: time.Minute}, nil
-	}
-
 	// Step 5b: Ensure OwnerReference on ConfigMap for garbage collection.
 	cm := &corev1.ConfigMap{}
 	cmKey := client.ObjectKey{
@@ -210,6 +190,40 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		Message:            fmt.Sprintf("NTN config applied via %s provider", spec.Provider.Type),
 		ObservedGeneration: cc.Generation,
 	})
+
+	// Step 8: Push runtime ephemeris update if ephemerisRef is configured.
+	// Keep ConfigApplied semantics independent from ephemeris push status.
+	if cc.Spec.EphemerisRef == "" {
+		meta.RemoveStatusCondition(&cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+	} else {
+		pushed, marker, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec)
+		if err != nil {
+			log.Error(err, "failed to push ephemeris update")
+			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+				Type:               ntnv1alpha1.ConditionEphemerisPushed,
+				Status:             metav1.ConditionFalse,
+				Reason:             "PushFailed",
+				Message:            err.Error(),
+				ObservedGeneration: cc.Generation,
+			})
+			if r.Recorder != nil {
+				r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", err.Error())
+			}
+			if err := r.Status().Update(ctx, cc); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+		if pushed {
+			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+				Type:               ntnv1alpha1.ConditionEphemerisPushed,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Pushed",
+				Message:            marker,
+				ObservedGeneration: cc.Generation,
+			})
+		}
+	}
 
 	if err := r.Status().Update(ctx, cc); err != nil {
 		return ctrl.Result{}, err
@@ -275,15 +289,19 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	ctx context.Context,
 	cc *ntnv1alpha1.NTNCellConfig,
 	spec *ntnv1alpha1.NTNCellConfigSpec,
-) error {
+) (bool, string, error) {
 	if cc.Spec.EphemerisRef == "" {
-		return nil
+		return false, "", nil
 	}
 
 	eph := &ntnv1alpha1.SatelliteEphemeris{}
 	ephKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Spec.EphemerisRef}
 	if err := r.Get(ctx, ephKey, eph); err != nil {
-		return fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", cc.Spec.EphemerisRef, err)
+		return false, "", fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", cc.Spec.EphemerisRef, err)
+	}
+	marker := ephemerisPushMarker(cc.Spec.EphemerisRef, eph.ResourceVersion)
+	if isEphemerisPushUpToDate(cc, marker) {
+		return false, marker, nil
 	}
 
 	update := provider.EphemerisUpdate{}
@@ -293,14 +311,28 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	case spec.NTN.EphemerisECEF != nil:
 		update.ECEF = spec.NTN.EphemerisECEF.DeepCopy()
 	default:
-		return fmt.Errorf("ephemeris payload missing in NTNCellConfig spec")
+		return false, marker, fmt.Errorf("ephemeris payload missing in NTNCellConfig spec")
 	}
 
 	if err := r.Provider.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
-		return fmt.Errorf("provider PushEphemerisUpdate: %w", err)
+		return false, marker, fmt.Errorf("provider PushEphemerisUpdate: %w", err)
 	}
 
-	return nil
+	return true, marker, nil
+}
+
+func isEphemerisPushUpToDate(cc *ntnv1alpha1.NTNCellConfig, marker string) bool {
+	cond := meta.FindStatusCondition(cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+	if cond == nil {
+		return false
+	}
+	return cond.Status == metav1.ConditionTrue &&
+		cond.ObservedGeneration == cc.Generation &&
+		cond.Message == marker
+}
+
+func ephemerisPushMarker(ephemerisRef, resourceVersion string) string {
+	return fmt.Sprintf("ephemerisRef=%s resourceVersion=%s", ephemerisRef, resourceVersion)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,6 +50,48 @@ type NTNCellConfigReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
 	Provider provider.NTNProvider
+}
+
+const (
+	ephemerisReasonPushFailed         = "PushFailed"
+	ephemerisReasonRefNotFound        = "EphemerisRefNotFound"
+	ephemerisReasonGetFailed          = "EphemerisGetFailed"
+	ephemerisReasonPayloadMissing     = "EphemerisPayloadMissing"
+	ephemerisReasonProviderPushFailed = "ProviderPushFailed"
+)
+
+type ephemerisPushError struct {
+	reason string
+	err    error
+}
+
+func (e *ephemerisPushError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *ephemerisPushError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newEphemerisPushError(reason string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ephemerisPushError{reason: reason, err: err}
+}
+
+func ephemerisPushConditionReason(err error) string {
+	var pushErr *ephemerisPushError
+	if errors.As(err, &pushErr) && pushErr.reason != "" {
+		return pushErr.reason
+	}
+	return ephemerisReasonPushFailed
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -203,7 +247,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 				Type:               ntnv1alpha1.ConditionEphemerisPushed,
 				Status:             metav1.ConditionFalse,
-				Reason:             "PushFailed",
+				Reason:             ephemerisPushConditionReason(pushErr),
 				Message:            pushErr.Error(),
 				ObservedGeneration: cc.Generation,
 			})
@@ -298,7 +342,14 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	eph := &ntnv1alpha1.SatelliteEphemeris{}
 	ephKey := client.ObjectKey{Namespace: cc.Namespace, Name: spec.EphemerisRef}
 	if err := r.Get(ctx, ephKey, eph); err != nil {
-		return false, "", fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", spec.EphemerisRef, err)
+		reason := ephemerisReasonGetFailed
+		if apierrors.IsNotFound(err) {
+			reason = ephemerisReasonRefNotFound
+		}
+		return false, "", newEphemerisPushError(
+			reason,
+			fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", spec.EphemerisRef, err),
+		)
 	}
 	marker := ephemerisPushMarker(eph)
 	if isEphemerisPushUpToDate(cc, marker) {
@@ -312,11 +363,17 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	case spec.NTN.EphemerisECEF != nil:
 		update.ECEF = spec.NTN.EphemerisECEF.DeepCopy()
 	default:
-		return false, marker, fmt.Errorf("ephemeris payload missing in NTNCellConfig spec")
+		return false, marker, newEphemerisPushError(
+			ephemerisReasonPayloadMissing,
+			fmt.Errorf("ephemeris payload missing in NTNCellConfig spec"),
+		)
 	}
 
 	if err := r.Provider.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
-		return false, marker, fmt.Errorf("provider PushEphemerisUpdate: %w", err)
+		return false, marker, newEphemerisPushError(
+			ephemerisReasonProviderPushFailed,
+			fmt.Errorf("provider PushEphemerisUpdate: %w", err),
+		)
 	}
 
 	return true, marker, nil

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -198,19 +198,20 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	} else {
 		pushed, marker, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec)
 		if err != nil {
-			log.Error(err, "failed to push ephemeris update")
+			pushErr := err
+			log.Error(pushErr, "failed to push ephemeris update")
 			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 				Type:               ntnv1alpha1.ConditionEphemerisPushed,
 				Status:             metav1.ConditionFalse,
 				Reason:             "PushFailed",
-				Message:            err.Error(),
+				Message:            pushErr.Error(),
 				ObservedGeneration: cc.Generation,
 			})
-			if r.Recorder != nil {
-				r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", err.Error())
-			}
 			if err := r.Status().Update(ctx, cc); err != nil {
 				return ctrl.Result{}, err
+			}
+			if r.Recorder != nil {
+				r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", pushErr.Error())
 			}
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -94,6 +94,22 @@ func ephemerisPushConditionReason(err error) string {
 	return ephemerisReasonPushFailed
 }
 
+func ephemerisPushConditionChanged(
+	prev *metav1.Condition,
+	reason, message string,
+	generation int64,
+) bool {
+	return prev == nil ||
+		prev.Status != metav1.ConditionFalse ||
+		prev.Reason != reason ||
+		prev.Message != message ||
+		prev.ObservedGeneration != generation
+}
+
+func ephemerisPushShouldRequeue(reason string) bool {
+	return reason != ephemerisReasonRefNotFound
+}
+
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs/finalizers,verbs=update
@@ -244,18 +260,26 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			pushErr := err
 			log.Error(pushErr, "failed to push ephemeris update")
+			reason := ephemerisPushConditionReason(pushErr)
+			message := pushErr.Error()
+			prevEphemerisCondition := meta.FindStatusCondition(cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			conditionChanged := ephemerisPushConditionChanged(prevEphemerisCondition, reason, message, cc.Generation)
+
 			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 				Type:               ntnv1alpha1.ConditionEphemerisPushed,
 				Status:             metav1.ConditionFalse,
-				Reason:             ephemerisPushConditionReason(pushErr),
-				Message:            pushErr.Error(),
+				Reason:             reason,
+				Message:            message,
 				ObservedGeneration: cc.Generation,
 			})
 			if err := r.Status().Update(ctx, cc); err != nil {
 				return ctrl.Result{}, err
 			}
-			if r.Recorder != nil {
-				r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", pushErr.Error())
+			if conditionChanged && r.Recorder != nil {
+				r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", message)
+			}
+			if !ephemerisPushShouldRequeue(reason) {
+				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -147,6 +147,26 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
+	// Step 5a: Push ephemeris update when this config references SatelliteEphemeris.
+	// This ensures ephemeris-triggered requeues invoke the runtime update path.
+	if err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec); err != nil {
+		log.Error(err, "failed to push ephemeris update")
+		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionConfigApplied,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "EphemerisPushFailed",
+			Message:            fmt.Sprintf("config applied but ephemeris push failed: %v", err),
+			ObservedGeneration: cc.Generation,
+		})
+		if err := r.Status().Update(ctx, cc); err != nil {
+			return ctrl.Result{}, err
+		}
+		if r.Recorder != nil {
+			r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", err.Error())
+		}
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
 	// Step 5b: Ensure OwnerReference on ConfigMap for garbage collection.
 	cm := &corev1.ConfigMap{}
 	cmKey := client.ObjectKey{
@@ -249,6 +269,38 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 	}
 
 	return false, ctrl.Result{}, nil
+}
+
+func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
+	ctx context.Context,
+	cc *ntnv1alpha1.NTNCellConfig,
+	spec *ntnv1alpha1.NTNCellConfigSpec,
+) error {
+	if cc.Spec.EphemerisRef == "" {
+		return nil
+	}
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	ephKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Spec.EphemerisRef}
+	if err := r.Get(ctx, ephKey, eph); err != nil {
+		return fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", cc.Spec.EphemerisRef, err)
+	}
+
+	update := provider.EphemerisUpdate{}
+	switch {
+	case spec.NTN.EphemerisOrbital != nil:
+		update.Orbital = spec.NTN.EphemerisOrbital.DeepCopy()
+	case spec.NTN.EphemerisECEF != nil:
+		update.ECEF = spec.NTN.EphemerisECEF.DeepCopy()
+	default:
+		return fmt.Errorf("ephemeris payload missing in NTNCellConfig spec")
+	}
+
+	if err := r.Provider.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
+		return fmt.Errorf("provider PushEphemerisUpdate: %w", err)
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -291,14 +291,14 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	cc *ntnv1alpha1.NTNCellConfig,
 	spec *ntnv1alpha1.NTNCellConfigSpec,
 ) (bool, string, error) {
-	if cc.Spec.EphemerisRef == "" {
+	if spec.EphemerisRef == "" {
 		return false, "", nil
 	}
 
 	eph := &ntnv1alpha1.SatelliteEphemeris{}
-	ephKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Spec.EphemerisRef}
+	ephKey := client.ObjectKey{Namespace: cc.Namespace, Name: spec.EphemerisRef}
 	if err := r.Get(ctx, ephKey, eph); err != nil {
-		return false, "", fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", cc.Spec.EphemerisRef, err)
+		return false, "", fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", spec.EphemerisRef, err)
 	}
 	marker := ephemerisPushMarker(eph)
 	if isEphemerisPushUpToDate(cc, marker) {

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -565,7 +565,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			ephCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
 			Expect(ephCond).NotTo(BeNil())
 			Expect(ephCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(ephCond.Reason).To(Equal("PushFailed"))
+			Expect(ephCond.Reason).To(Equal("ProviderPushFailed"))
 			Expect(ephCond.Message).To(ContainSubstring("runtime push failed"))
 		})
 	})

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -511,11 +511,21 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(ephCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(ephCond.Reason).To(Equal("Pushed"))
 
-			// Third reconcile should not re-push if referenced ephemeris resourceVersion is unchanged.
-			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
-			Expect(mock.EphemerisCalls).To(Equal(1))
+				// Metadata-only updates can bump resourceVersion without changing ephemeris data.
+				// Ensure dedupe does not treat this as a new ephemeris revision.
+				eph := &ntnv1alpha1.SatelliteEphemeris{}
+				Expect(k8sClient.Get(context.Background(), ephNN, eph)).To(Succeed())
+				if eph.Annotations == nil {
+					eph.Annotations = map[string]string{}
+				}
+				eph.Annotations["review/test-rv-bump"] = "true"
+				Expect(k8sClient.Update(context.Background(), eph)).To(Succeed())
+
+				// Third reconcile should not re-push when generation + lastUpdated marker is unchanged.
+				result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+				Expect(mock.EphemerisCalls).To(Equal(1))
 		})
 
 		It("should keep ConfigApplied true and set EphemerisPushed=false when push fails", func() {

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -434,6 +434,72 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		})
 	})
 
+	Context("When reconciling with ephemerisRef configured", func() {
+		const (
+			cellName = "test-eph-push-cell"
+			ephName  = "test-eph-push-source"
+		)
+		cellNN := types.NamespacedName{Name: cellName, Namespace: namespace}
+		ephNN := types.NamespacedName{Name: ephName, Namespace: namespace}
+
+		AfterEach(func() {
+			deleteCellConfig(cellNN)
+			eph := &ntnv1alpha1.SatelliteEphemeris{}
+			err := k8sClient.Get(context.Background(), ephNN, eph)
+			if err == nil {
+				_ = k8sClient.Delete(context.Background(), eph)
+			}
+		})
+
+		It("should invoke PushEphemerisUpdate on provider", func() {
+			// Referenced SatelliteEphemeris exists in the same namespace.
+			eph := &ntnv1alpha1.SatelliteEphemeris{
+				ObjectMeta: metav1.ObjectMeta{Name: ephName, Namespace: namespace},
+				Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+					Source: ntnv1alpha1.EphemerisSource{
+						Type:            "CelesTrak",
+						URL:             "https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON",
+						RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), eph)).To(Succeed())
+
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: cellName, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+							PosX: 20922195, PosY: 1967783, PosZ: 19770302,
+						},
+						PayloadType: "transparent",
+					},
+					EphemerisRef: ephName,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+
+			mock := &provider.MockProvider{}
+			reconciler := newReconciler(mock)
+
+			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+
+			Expect(mock.ApplyCalls).To(Equal(1))
+			Expect(mock.EphemerisCalls).To(Equal(1))
+			Expect(mock.LastEphemeris).NotTo(BeNil())
+			Expect(mock.LastEphemeris.ECEF).NotTo(BeNil())
+			Expect(mock.LastEphemeris.ECEF.PosX).To(Equal(20922195))
+		})
+	})
+
 	Context("ephemerisToNTNCellConfig mapper", func() {
 		const (
 			ccWithRef    = "cc-with-ref"

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -478,9 +478,16 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			deleteCellConfig(cellNN)
 			eph := &ntnv1alpha1.SatelliteEphemeris{}
 			err := k8sClient.Get(context.Background(), ephNN, eph)
-			if err == nil {
-				_ = k8sClient.Delete(context.Background(), eph)
+			if apierrors.IsNotFound(err) {
+				return
 			}
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Delete(context.Background(), eph)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should invoke PushEphemerisUpdate on provider", func() {

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -442,17 +442,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		cellNN := types.NamespacedName{Name: cellName, Namespace: namespace}
 		ephNN := types.NamespacedName{Name: ephName, Namespace: namespace}
 
-		AfterEach(func() {
-			deleteCellConfig(cellNN)
-			eph := &ntnv1alpha1.SatelliteEphemeris{}
-			err := k8sClient.Get(context.Background(), ephNN, eph)
-			if err == nil {
-				_ = k8sClient.Delete(context.Background(), eph)
-			}
-		})
-
-		It("should invoke PushEphemerisUpdate on provider", func() {
-			// Referenced SatelliteEphemeris exists in the same namespace.
+		createReferencedEphemeris := func() {
 			eph := &ntnv1alpha1.SatelliteEphemeris{
 				ObjectMeta: metav1.ObjectMeta{Name: ephName, Namespace: namespace},
 				Spec: ntnv1alpha1.SatelliteEphemerisSpec{
@@ -464,7 +454,9 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), eph)).To(Succeed())
+		}
 
+		createCellConfig := func() {
 			cr := &ntnv1alpha1.NTNCellConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: cellName, Namespace: namespace},
 				Spec: ntnv1alpha1.NTNCellConfigSpec{
@@ -480,6 +472,20 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+		}
+
+		AfterEach(func() {
+			deleteCellConfig(cellNN)
+			eph := &ntnv1alpha1.SatelliteEphemeris{}
+			err := k8sClient.Get(context.Background(), ephNN, eph)
+			if err == nil {
+				_ = k8sClient.Delete(context.Background(), eph)
+			}
+		})
+
+		It("should invoke PushEphemerisUpdate on provider", func() {
+			createReferencedEphemeris()
+			createCellConfig()
 
 			mock := &provider.MockProvider{}
 			reconciler := newReconciler(mock)
@@ -497,6 +503,53 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(mock.LastEphemeris).NotTo(BeNil())
 			Expect(mock.LastEphemeris.ECEF).NotTo(BeNil())
 			Expect(mock.LastEphemeris.ECEF.PosX).To(Equal(20922195))
+
+			updated := &ntnv1alpha1.NTNCellConfig{}
+			Expect(k8sClient.Get(context.Background(), cellNN, updated)).To(Succeed())
+			ephCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			Expect(ephCond).NotTo(BeNil())
+			Expect(ephCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ephCond.Reason).To(Equal("Pushed"))
+
+			// Third reconcile should not re-push if referenced ephemeris resourceVersion is unchanged.
+			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+			Expect(mock.EphemerisCalls).To(Equal(1))
+		})
+
+		It("should keep ConfigApplied true and set EphemerisPushed=false when push fails", func() {
+			createReferencedEphemeris()
+			createCellConfig()
+
+			mock := &provider.MockProvider{EphemerisErr: errors.New("runtime push failed")}
+			reconciler := newReconciler(mock)
+
+			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			Expect(mock.ApplyCalls).To(Equal(1))
+			Expect(mock.StatusCalls).To(Equal(1))
+			Expect(mock.EphemerisCalls).To(Equal(1))
+
+			updated := &ntnv1alpha1.NTNCellConfig{}
+			Expect(k8sClient.Get(context.Background(), cellNN, updated)).To(Succeed())
+
+			appliedCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionConfigApplied)
+			Expect(appliedCond).NotTo(BeNil())
+			Expect(appliedCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(appliedCond.Reason).To(Equal("Applied"))
+
+			ephCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			Expect(ephCond).NotTo(BeNil())
+			Expect(ephCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ephCond.Reason).To(Equal("PushFailed"))
+			Expect(ephCond.Message).To(ContainSubstring("runtime push failed"))
 		})
 	})
 

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -568,6 +568,33 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(ephCond.Reason).To(Equal("ProviderPushFailed"))
 			Expect(ephCond.Message).To(ContainSubstring("runtime push failed"))
 		})
+
+		It("should avoid tight requeue when ephemerisRef does not exist", func() {
+			createCellConfig()
+
+			mock := &provider.MockProvider{}
+			reconciler := newReconciler(mock)
+
+			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Expect(mock.ApplyCalls).To(Equal(1))
+			Expect(mock.StatusCalls).To(Equal(1))
+			Expect(mock.EphemerisCalls).To(Equal(0))
+
+			updated := &ntnv1alpha1.NTNCellConfig{}
+			Expect(k8sClient.Get(context.Background(), cellNN, updated)).To(Succeed())
+			ephCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			Expect(ephCond).NotTo(BeNil())
+			Expect(ephCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ephCond.Reason).To(Equal("EphemerisRefNotFound"))
+			Expect(ephCond.Message).To(ContainSubstring(`referenced SatelliteEphemeris "test-eph-push-source"`))
+		})
 	})
 
 	Context("ephemerisToNTNCellConfig mapper", func() {

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -511,21 +511,21 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(ephCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(ephCond.Reason).To(Equal("Pushed"))
 
-				// Metadata-only updates can bump resourceVersion without changing ephemeris data.
-				// Ensure dedupe does not treat this as a new ephemeris revision.
-				eph := &ntnv1alpha1.SatelliteEphemeris{}
-				Expect(k8sClient.Get(context.Background(), ephNN, eph)).To(Succeed())
-				if eph.Annotations == nil {
-					eph.Annotations = map[string]string{}
-				}
-				eph.Annotations["review/test-rv-bump"] = "true"
-				Expect(k8sClient.Update(context.Background(), eph)).To(Succeed())
+			// Metadata-only updates can bump resourceVersion without changing ephemeris data.
+			// Ensure dedupe does not treat this as a new ephemeris revision.
+			eph := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), ephNN, eph)).To(Succeed())
+			if eph.Annotations == nil {
+				eph.Annotations = map[string]string{}
+			}
+			eph.Annotations["review/test-rv-bump"] = "true"
+			Expect(k8sClient.Update(context.Background(), eph)).To(Succeed())
 
-				// Third reconcile should not re-push when generation + lastUpdated marker is unchanged.
-				result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
-				Expect(mock.EphemerisCalls).To(Equal(1))
+			// Third reconcile should not re-push when generation + lastUpdated marker is unchanged.
+			result, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+			Expect(mock.EphemerisCalls).To(Equal(1))
 		})
 
 		It("should keep ConfigApplied true and set EphemerisPushed=false when push fails", func() {

--- a/internal/controller/ntncellconfig_marker_test.go
+++ b/internal/controller/ntncellconfig_marker_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEphemerisPushMarkerUsesGenerationAndLastUpdated(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC))
+	ephA := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "eph-a",
+			Generation:      7,
+			ResourceVersion: "101",
+		},
+		Status: ntnv1alpha1.SatelliteEphemerisStatus{
+			LastUpdated: &ts,
+		},
+	}
+	ephB := ephA.DeepCopy()
+	ephB.ResourceVersion = "202"
+
+	if gotA, gotB := ephemerisPushMarker(ephA), ephemerisPushMarker(ephB); gotA != gotB {
+		t.Fatalf("marker should ignore resourceVersion-only changes: %q != %q", gotA, gotB)
+	}
+
+	ephC := ephA.DeepCopy()
+	ephC.Generation = ephA.Generation + 1
+	if gotA, gotC := ephemerisPushMarker(ephA), ephemerisPushMarker(ephC); gotA == gotC {
+		t.Fatalf("marker should change when generation changes: %q == %q", gotA, gotC)
+	}
+
+	ephD := ephA.DeepCopy()
+	later := metav1.NewTime(ts.Add(5 * time.Minute))
+	ephD.Status.LastUpdated = &later
+	if gotA, gotD := ephemerisPushMarker(ephA), ephemerisPushMarker(ephD); gotA == gotD {
+		t.Fatalf("marker should change when lastUpdated changes: %q == %q", gotA, gotD)
+	}
+}

--- a/internal/controller/ntncellconfig_marker_test.go
+++ b/internal/controller/ntncellconfig_marker_test.go
@@ -74,3 +74,44 @@ func TestEphemerisPushConditionReason(t *testing.T) {
 		}
 	})
 }
+
+func TestEphemerisPushConditionChanged(t *testing.T) {
+	t.Run("nil previous condition is treated as changed", func(t *testing.T) {
+		if !ephemerisPushConditionChanged(nil, ephemerisReasonRefNotFound, "missing", 3) {
+			t.Fatalf("expected condition to be marked changed when previous condition is nil")
+		}
+	})
+
+	t.Run("identical previous condition is not changed", func(t *testing.T) {
+		prev := &metav1.Condition{
+			Status:             metav1.ConditionFalse,
+			Reason:             ephemerisReasonRefNotFound,
+			Message:            "missing",
+			ObservedGeneration: 3,
+		}
+		if ephemerisPushConditionChanged(prev, ephemerisReasonRefNotFound, "missing", 3) {
+			t.Fatalf("expected unchanged condition to be recognized as unchanged")
+		}
+	})
+
+	t.Run("generation bump is treated as changed", func(t *testing.T) {
+		prev := &metav1.Condition{
+			Status:             metav1.ConditionFalse,
+			Reason:             ephemerisReasonRefNotFound,
+			Message:            "missing",
+			ObservedGeneration: 3,
+		}
+		if !ephemerisPushConditionChanged(prev, ephemerisReasonRefNotFound, "missing", 4) {
+			t.Fatalf("expected generation change to be treated as condition change")
+		}
+	})
+}
+
+func TestEphemerisPushShouldRequeue(t *testing.T) {
+	if ephemerisPushShouldRequeue(ephemerisReasonRefNotFound) {
+		t.Fatalf("expected EphemerisRefNotFound to avoid explicit requeue")
+	}
+	if !ephemerisPushShouldRequeue(ephemerisReasonProviderPushFailed) {
+		t.Fatalf("expected provider push failures to keep explicit retry requeue")
+	}
+}

--- a/internal/controller/ntncellconfig_marker_test.go
+++ b/internal/controller/ntncellconfig_marker_test.go
@@ -1,6 +1,24 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -39,4 +57,20 @@ func TestEphemerisPushMarkerUsesGenerationAndLastUpdated(t *testing.T) {
 	if gotA, gotD := ephemerisPushMarker(ephA), ephemerisPushMarker(ephD); gotA == gotD {
 		t.Fatalf("marker should change when lastUpdated changes: %q == %q", gotA, gotD)
 	}
+}
+
+func TestEphemerisPushConditionReason(t *testing.T) {
+	t.Run("typed reason is preserved through wrapping", func(t *testing.T) {
+		typedErr := newEphemerisPushError(ephemerisReasonProviderPushFailed, errors.New("push failed"))
+		wrapped := fmt.Errorf("reconcile step failed: %w", typedErr)
+		if got := ephemerisPushConditionReason(wrapped); got != ephemerisReasonProviderPushFailed {
+			t.Fatalf("unexpected reason: got %q want %q", got, ephemerisReasonProviderPushFailed)
+		}
+	})
+
+	t.Run("fallback reason for untyped errors", func(t *testing.T) {
+		if got := ephemerisPushConditionReason(errors.New("plain error")); got != ephemerisReasonPushFailed {
+			t.Fatalf("unexpected fallback reason: got %q want %q", got, ephemerisReasonPushFailed)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- invoke provider PushEphemerisUpdate during NTNCellConfig reconcile when spec.ephemerisRef is set
- keep ApplyCellConfig path intact and add explicit EphemerisPushFailed status/event handling
- add controller envtest that proves ephemeris push is executed
- update API field comment to reflect current behavior

## Test plan
- [x] go test ./internal/controller -run TestControllers -ginkgo.focus "ephemerisRef configured"
- [x] go test ./internal/controller

Closes #37