### PR TITLE
chore(ocudu): rendering hardening — yamlQuote + chart auto-sync + YAML round-trip test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	@for f in config/crd/bases/*.yaml; do \
-		base=$$(basename $$f | sed -E 's/^ntn.operators.dev_(.+)\.yaml$$/\1.ntn.operators.dev.yaml/'); \
-		if [ -f "dist/chart/templates/crd/$$base" ]; then \
-			cp "$$f" "dist/chart/templates/crd/$$base"; \
-		fi; \
-	done
+	@./hack/sync-chart-crds.sh
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@for f in config/crd/bases/*.yaml; do \
+		base=$$(basename $$f | sed -E 's/^ntn.operators.dev_(.+)\.yaml$$/\1.ntn.operators.dev.yaml/'); \
+		if [ -f "dist/chart/templates/crd/$$base" ]; then \
+			cp "$$f" "dist/chart/templates/crd/$$base"; \
+		fi; \
+	done
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -1,12 +1,8 @@
-{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
-    "helm.sh/resource-policy": keep
-    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: groundstationlifecycles.ntn.operators.dev
 spec:
@@ -269,4 +265,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
+    {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
-    {{- end }}
+    {{ end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: groundstationlifecycles.ntn.operators.dev
 spec:

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -1,8 +1,11 @@
----
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: groundstationlifecycles.ntn.operators.dev
 spec:
@@ -265,3 +268,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
+    {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
-    {{- end }}
+    {{ end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntncellconfigs.ntn.operators.dev
 spec:

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -1,8 +1,11 @@
----
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntncellconfigs.ntn.operators.dev
 spec:
@@ -599,3 +602,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
+    {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
-    {{- end }}
+    {{ end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntnslices.ntn.operators.dev
 spec:

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -1,12 +1,8 @@
-{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
-    "helm.sh/resource-policy": keep
-    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntnslices.ntn.operators.dev
 spec:
@@ -322,4 +318,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -1,8 +1,11 @@
----
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: ntnslices.ntn.operators.dev
 spec:
@@ -318,3 +321,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -1,12 +1,8 @@
-{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
-    "helm.sh/resource-policy": keep
-    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: satelliteephemeris.ntn.operators.dev
 spec:
@@ -264,4 +260,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- if .Values.crd.keep }}
+    {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
-    {{- end }}
+    {{ end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: satelliteephemeris.ntn.operators.dev
 spec:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -1,8 +1,11 @@
----
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.20.1
   name: satelliteephemeris.ntn.operators.dev
 spec:
@@ -260,3 +263,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/docs/migration-v0.2-v0.3.md
+++ b/docs/migration-v0.2-v0.3.md
@@ -42,17 +42,17 @@ spec:
 | `circular` | `rhcp` | `rhcp` | Right-hand assumed; override if your payload uses LHCP |
 | (unset) | — | — | Omit the field entirely; OCUDU falls back to its default |
 
-## Migration script (jq)
+## Migration scripts (sed + jq)
 
 If you have existing `NTNCellConfig` manifests in git or on disk:
 
 ```bash
 # Bulk-convert all YAML files in a directory.
-for f in $(grep -rl '^\s*polarization:\s*\(linear\|circular\)\s*$' config/); do
+for f in $(grep -E -rl '^[[:space:]]*polarization:[[:space:]]*(linear|circular)[[:space:]]*$' config/); do
   # linear → {dl: linear, ul: linear}
-  sed -i 's/^\(\s*\)polarization:\s*linear\s*$/\1polarization:\n\1  dl: linear\n\1  ul: linear/' "$f"
+  sed -i 's/^\([[:space:]]*\)polarization:[[:space:]]*linear[[:space:]]*$/\1polarization:\n\1  dl: linear\n\1  ul: linear/' "$f"
   # circular → {dl: rhcp, ul: rhcp} (assume RHCP; review before committing)
-  sed -i 's/^\(\s*\)polarization:\s*circular\s*$/\1polarization:\n\1  dl: rhcp\n\1  ul: rhcp/' "$f"
+  sed -i 's/^\([[:space:]]*\)polarization:[[:space:]]*circular[[:space:]]*$/\1polarization:\n\1  dl: rhcp\n\1  ul: rhcp/' "$f"
 done
 ```
 

--- a/docs/migration-v0.2-v0.3.md
+++ b/docs/migration-v0.2-v0.3.md
@@ -28,8 +28,9 @@ spec:
 - 3GPP TS 38.331 defines `ntn-PolarizationDL-r17` and `ntn-PolarizationUL-r17`
   as two independent IEs in SIB19 — a single scalar cannot express the
   downlink / uplink asymmetry real LEO payloads exhibit.
-- OCUDU's CLI11 parser (`du_high_ntn_config_yaml_writer.cpp`) emits the
-  nested form and rejects a scalar, so the old schema produced configs that
+- OCUDU's YAML writer (`du_high_ntn_config_yaml_writer.cpp`) emits the
+  nested form (and the CLI11 schema aligns with that shape), so the old
+  scalar schema produced configs that
   the gNB silently ignored or failed to load.
 - The v0.2 enum value `"circular"` was not in OCUDU's accepted set
   (`rhcp | lhcp | linear`) and would have failed at runtime anyway.

--- a/docs/migration-v0.2-v0.3.md
+++ b/docs/migration-v0.2-v0.3.md
@@ -51,9 +51,10 @@ If you have existing `NTNCellConfig` manifests in git or on disk:
 # Bulk-convert all YAML files in a directory.
 for f in $(grep -E -rl '^[[:space:]]*polarization:[[:space:]]*(linear|circular)[[:space:]]*$' config/); do
   # linear → {dl: linear, ul: linear}
-  sed -i 's/^\([[:space:]]*\)polarization:[[:space:]]*linear[[:space:]]*$/\1polarization:\n\1  dl: linear\n\1  ul: linear/' "$f"
+  sed -i.bak 's/^\([[:space:]]*\)polarization:[[:space:]]*linear[[:space:]]*$/\1polarization:\n\1  dl: linear\n\1  ul: linear/' "$f"
   # circular → {dl: rhcp, ul: rhcp} (assume RHCP; review before committing)
-  sed -i 's/^\([[:space:]]*\)polarization:[[:space:]]*circular[[:space:]]*$/\1polarization:\n\1  dl: rhcp\n\1  ul: rhcp/' "$f"
+  sed -i.bak 's/^\([[:space:]]*\)polarization:[[:space:]]*circular[[:space:]]*$/\1polarization:\n\1  dl: rhcp\n\1  ul: rhcp/' "$f"
+  rm -f "$f.bak"
 done
 ```
 

--- a/docs/migration-v0.2-v0.3.md
+++ b/docs/migration-v0.2-v0.3.md
@@ -1,0 +1,85 @@
+# Migration: v0.2 → v0.3 (polarization schema change)
+
+## What changed
+
+`NTNCellConfig.spec.ntn.polarization` changed from a flat string enum to a
+nested object with independent downlink and uplink fields.
+
+**v0.2 (pre-change):**
+
+```yaml
+spec:
+  ntn:
+    polarization: linear    # or "circular"
+```
+
+**v0.3 (current):**
+
+```yaml
+spec:
+  ntn:
+    polarization:
+      dl: linear            # rhcp | lhcp | linear
+      ul: linear            # rhcp | lhcp | linear
+```
+
+## Why
+
+- 3GPP TS 38.331 defines `ntn-PolarizationDL-r17` and `ntn-PolarizationUL-r17`
+  as two independent IEs in SIB19 — a single scalar cannot express the
+  downlink / uplink asymmetry real LEO payloads exhibit.
+- OCUDU's CLI11 parser (`du_high_ntn_config_yaml_writer.cpp`) emits the
+  nested form and rejects a scalar, so the old schema produced configs that
+  the gNB silently ignored or failed to load.
+- The v0.2 enum value `"circular"` was not in OCUDU's accepted set
+  (`rhcp | lhcp | linear`) and would have failed at runtime anyway.
+
+## Migration value mapping
+
+| v0.2 `polarization` | v0.3 `polarization.dl` | v0.3 `polarization.ul` | Note |
+|---|---|---|---|
+| `linear` | `linear` | `linear` | Direct carry-over |
+| `circular` | `rhcp` | `rhcp` | Right-hand assumed; override if your payload uses LHCP |
+| (unset) | — | — | Omit the field entirely; OCUDU falls back to its default |
+
+## Migration script (jq)
+
+If you have existing `NTNCellConfig` manifests in git or on disk:
+
+```bash
+# Bulk-convert all YAML files in a directory.
+for f in $(grep -rl '^\s*polarization:\s*\(linear\|circular\)\s*$' config/); do
+  # linear → {dl: linear, ul: linear}
+  sed -i 's/^\(\s*\)polarization:\s*linear\s*$/\1polarization:\n\1  dl: linear\n\1  ul: linear/' "$f"
+  # circular → {dl: rhcp, ul: rhcp} (assume RHCP; review before committing)
+  sed -i 's/^\(\s*\)polarization:\s*circular\s*$/\1polarization:\n\1  dl: rhcp\n\1  ul: rhcp/' "$f"
+done
+```
+
+For cluster-stored CRs, use a one-off kubectl/jq pipeline:
+
+```bash
+kubectl get ntncc -A -o json \
+  | jq -r '.items[] | select(.spec.ntn.polarization | type == "string")
+           | "kubectl patch ntncc \(.metadata.name) -n \(.metadata.namespace) --type=json -p "
+             + (
+                 if .spec.ntn.polarization == "linear"
+                 then "''[{\"op\":\"replace\",\"path\":\"/spec/ntn/polarization\",\"value\":{\"dl\":\"linear\",\"ul\":\"linear\"}}]''"
+                 else "''[{\"op\":\"replace\",\"path\":\"/spec/ntn/polarization\",\"value\":{\"dl\":\"rhcp\",\"ul\":\"rhcp\"}}]''"
+                 end
+               )' \
+  | sh
+```
+
+Review the RHCP/LHCP choice for your specific payload before applying.
+
+## Upgrade order
+
+1. Apply the new CRDs first (`kubectl apply -k config/crd` or
+   `helm upgrade ntn-operators`). The new schema is permissive enough to
+   accept unset `polarization`, so existing CRs with `polarization` unset
+   continue to apply cleanly.
+2. Run the migration script against any CR that still uses the flat form.
+3. Deploy the v0.3 controller image. The controller will re-render each
+   CR's ConfigMap with the nested `polarization` YAML.
+4. Restart the OCUDU gNB so it picks up the regenerated ConfigMap.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.3
 
 require (
 	github.com/akhenakh/sgp4 v0.0.0-20260314155803-8ee03fc877eb
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
@@ -12,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -28,7 +30,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -97,5 +98,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/hack/sync-chart-crds.sh
+++ b/hack/sync-chart-crds.sh
@@ -24,7 +24,7 @@ DEST_DIR="dist/chart/templates/crd"
 
 for src in "$SRC_DIR"/*.yaml; do
 	# config/crd/bases/ntn.operators.dev_<kind>s.yaml -> <kind>s.ntn.operators.dev.yaml
-	base=$(basename "$src" | sed -E 's/^ntn.operators.dev_(.+)\.yaml$/\1.ntn.operators.dev.yaml/')
+	base=$(basename "$src" | sed -E 's/^ntn\.operators\.dev_(.+)\.yaml$/\1.ntn.operators.dev.yaml/')
 	dest="$DEST_DIR/$base"
 
 	# Only touch CRDs already present in the chart (don't introduce new ones here).

--- a/hack/sync-chart-crds.sh
+++ b/hack/sync-chart-crds.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copy controller-gen CRDs from config/crd/bases/ into the Helm chart at
+# dist/chart/templates/crd/, re-adding the Helm templating wrappers the chart
+# needs to respect `crd.enable` / `crd.keep` user values.
+#
+# The wrappers are:
+#   1. {{- if .Values.crd.enable }} / {{- end }} around the whole CRD
+#   2. {{- if .Values.crd.keep }} "helm.sh/resource-policy": keep {{- end }}
+#      injected under metadata.annotations
+#
+# Without (1), users cannot opt out of CRD installation via `helm install
+# --set crd.enable=false`. Without (2), users lose the keep-on-uninstall
+# protection and `helm uninstall` would cascade-delete every CR — data loss.
+#
+# Usage: invoked from `make manifests` after controller-gen runs.
+
+set -euo pipefail
+
+SRC_DIR="config/crd/bases"
+DEST_DIR="dist/chart/templates/crd"
+
+[ -d "$SRC_DIR" ] || { echo "missing $SRC_DIR"; exit 1; }
+[ -d "$DEST_DIR" ] || { echo "missing $DEST_DIR"; exit 1; }
+
+for src in "$SRC_DIR"/*.yaml; do
+	# config/crd/bases/ntn.operators.dev_<kind>s.yaml -> <kind>s.ntn.operators.dev.yaml
+	base=$(basename "$src" | sed -E 's/^ntn.operators.dev_(.+)\.yaml$/\1.ntn.operators.dev.yaml/')
+	dest="$DEST_DIR/$base"
+
+	# Only touch CRDs already present in the chart (don't introduce new ones here).
+	[ -f "$dest" ] || continue
+
+	awk '
+		BEGIN { wrapped = 0 }
+		# Replace leading `---` with the Helm enable guard.
+		NR == 1 && /^---$/ {
+			print "{{- if .Values.crd.enable }}"
+			wrapped = 1
+			next
+		}
+		# If the file somehow did not start with `---`, still prepend the guard.
+		NR == 1 && /^apiVersion:/ {
+			print "{{- if .Values.crd.enable }}"
+			print
+			wrapped = 1
+			next
+		}
+		# Inject the keep annotation as the first entries under metadata.annotations.
+		/^  annotations:$/ {
+			print
+			print "    {{- if .Values.crd.keep }}"
+			print "    \"helm.sh/resource-policy\": keep"
+			print "    {{- end }}"
+			next
+		}
+		{ print }
+		END {
+			if (wrapped) print "{{- end }}"
+		}
+	' "$src" > "$dest"
+done

--- a/hack/sync-chart-crds.sh
+++ b/hack/sync-chart-crds.sh
@@ -5,7 +5,7 @@
 #
 # The wrappers are:
 #   1. {{- if .Values.crd.enable }} / {{- end }} around the whole CRD
-#   2. {{- if .Values.crd.keep }} "helm.sh/resource-policy": keep {{- end }}
+#   2. {{ if .Values.crd.keep }} "helm.sh/resource-policy": keep {{ end }}
 #      injected under metadata.annotations
 #
 # Without (1), users cannot opt out of CRD installation via `helm install
@@ -48,9 +48,9 @@ for src in "$SRC_DIR"/*.yaml; do
 		# Inject the keep annotation as the first entries under metadata.annotations.
 		/^  annotations:$/ {
 			print
-			print "    {{- if .Values.crd.keep }}"
+			print "    {{ if .Values.crd.keep }}"
 			print "    \"helm.sh/resource-policy\": keep"
-			print "    {{- end }}"
+			print "    {{ end }}"
 			next
 		}
 		{ print }

--- a/pkg/provider/ocudu/config.go
+++ b/pkg/provider/ocudu/config.go
@@ -19,10 +19,32 @@ package ocudu
 import (
 	"bytes"
 	"fmt"
+	"strconv"
+	"strings"
 	"text/template"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
+
+// yamlQuote emits a YAML 1.2 double-quoted string using Go's strconv.Quote.
+// JSON-style double-quoted strings are a valid subset of YAML 1.2 scalars;
+// newlines, colons, and other YAML-significant chars are escaped, preventing
+// string injection from bleeding into the surrounding YAML structure even
+// if apiserver enum validation is somehow bypassed (webhook misconfig,
+// direct etcd write during migration, apiserver with --feature-gates=
+// CRDValidation=false).
+func yamlQuote(s string) string {
+	return strconv.Quote(s)
+}
+
+// sanitizeComment strips characters that would terminate a YAML comment line
+// (newlines, carriage returns, NULs) so a user-supplied value cannot inject
+// real YAML keys via the `# Payload type: ...` header line. Comments are
+// line-terminated so quoting does not protect them.
+func sanitizeComment(s string) string {
+	r := strings.NewReplacer("\n", " ", "\r", " ", "\x00", "")
+	return r.Replace(s)
+}
 
 // configTemplate generates OCUDU-compatible NTN configuration YAML.
 //
@@ -112,10 +134,10 @@ ntn:
 {{- if .HasPolarization }}
   polarization:
 {{- if .PolarizationDL }}
-    dl: {{ .PolarizationDL }}
+    dl: {{ yamlQuote .PolarizationDL }}
 {{- end }}
 {{- if .PolarizationUL }}
-    ul: {{ .PolarizationUL }}
+    ul: {{ yamlQuote .PolarizationUL }}
 {{- end }}
 {{- end }}
 {{- if .TAReportSet }}
@@ -142,7 +164,11 @@ cu_cp:
     rrc_procedure_guard_time_ms: {{ .RrcGuardTimeMs }}
 `
 
-var parsedTemplate = template.Must(template.New("ocudu-ntn").Parse(configTemplate))
+var parsedTemplate = template.Must(
+	template.New("ocudu-ntn").
+		Funcs(template.FuncMap{"yamlQuote": yamlQuote}).
+		Parse(configTemplate),
+)
 
 // ntnNeighborCellData holds per-neighbor data for template rendering.
 type ntnNeighborCellData struct {
@@ -249,6 +275,10 @@ func baseConfigData(spec *ntnv1alpha1.NTNCellConfigSpec) configData {
 	if payloadType == "" {
 		payloadType = "transparent"
 	}
+	// Sanitize the comment-bound string so a malicious payload cannot break
+	// out of the `# Payload type: ...` header into real YAML keys even if
+	// apiserver enum validation were bypassed.
+	payloadType = sanitizeComment(payloadType)
 
 	return configData{
 		PayloadType:          payloadType,

--- a/pkg/provider/ocudu/config.go
+++ b/pkg/provider/ocudu/config.go
@@ -38,11 +38,18 @@ func yamlQuote(s string) string {
 }
 
 // sanitizeComment strips characters that would terminate a YAML comment line
-// (newlines, carriage returns, NULs) so a user-supplied value cannot inject
-// real YAML keys via the `# Payload type: ...` header line. Comments are
+// (LF, CR, NEL, LS, PS, and NUL) so a user-supplied value cannot inject real
+// YAML keys via the `# Payload type: ...` header line. Comments are
 // line-terminated so quoting does not protect them.
 func sanitizeComment(s string) string {
-	r := strings.NewReplacer("\n", " ", "\r", " ", "\x00", "")
+	r := strings.NewReplacer(
+		"\n", " ",
+		"\r", " ",
+		"\u0085", " ",
+		"\u2028", " ",
+		"\u2029", " ",
+		"\x00", "",
+	)
 	return r.Replace(s)
 }
 

--- a/pkg/provider/ocudu/config.go
+++ b/pkg/provider/ocudu/config.go
@@ -27,12 +27,12 @@ import (
 )
 
 // yamlQuote emits a YAML 1.2 double-quoted string using Go's strconv.Quote.
-// JSON-style double-quoted strings are a valid subset of YAML 1.2 scalars;
-// newlines, colons, and other YAML-significant chars are escaped, preventing
-// string injection from bleeding into the surrounding YAML structure even
-// if apiserver enum validation is somehow bypassed (webhook misconfig,
-// direct etcd write during migration, apiserver with --feature-gates=
-// CRDValidation=false).
+// strconv.Quote produces a Go-escaped double-quoted string; YAML 1.2
+// double-quoted scalars accept these escapes, so newlines, colons, and other
+// YAML-significant chars are escaped, preventing string injection from
+// bleeding into the surrounding YAML structure even if apiserver enum
+// validation is somehow bypassed (webhook misconfig, direct etcd write during
+// migration, apiserver with --feature-gates=CRDValidation=false).
 func yamlQuote(s string) string {
 	return strconv.Quote(s)
 }

--- a/pkg/provider/ocudu/config_test.go
+++ b/pkg/provider/ocudu/config_test.go
@@ -303,9 +303,10 @@ func TestGenerateConfig_PolarizationBoth(t *testing.T) {
 	}
 	yaml := string(data)
 	// Nested OCUDU layout: polarization: { dl:, ul: }
+	// Values are quoted via yamlQuote for YAML-injection defense-in-depth.
 	assertContains(t, yaml, "polarization:")
-	assertContains(t, yaml, "    dl: rhcp")
-	assertContains(t, yaml, "    ul: lhcp")
+	assertContains(t, yaml, `    dl: "rhcp"`)
+	assertContains(t, yaml, `    ul: "lhcp"`)
 	// MUST NOT emit the old flat scalar form.
 	assertNotContains(t, yaml, "polarization: rhcp")
 	assertNotContains(t, yaml, "polarization: lhcp")
@@ -325,7 +326,7 @@ func TestGenerateConfig_PolarizationDLOnly(t *testing.T) {
 	}
 	yaml := string(data)
 	assertContains(t, yaml, "polarization:")
-	assertContains(t, yaml, "    dl: linear")
+	assertContains(t, yaml, `    dl: "linear"`)
 	assertNotContains(t, yaml, "ul:")
 }
 
@@ -342,7 +343,7 @@ func TestGenerateConfig_PolarizationULOnly(t *testing.T) {
 	}
 	yaml := string(data)
 	assertContains(t, yaml, "polarization:")
-	assertContains(t, yaml, "    ul: rhcp")
+	assertContains(t, yaml, `    ul: "rhcp"`)
 	assertNotContains(t, yaml, "dl:")
 }
 
@@ -372,6 +373,48 @@ func TestGenerateConfig_PolarizationOmittedWhenBothEmpty(t *testing.T) {
 	}
 	// Empty struct → no DL/UL set → omit entire block (matches OCUDU's if-guarded writer).
 	assertNotContains(t, string(data), "polarization:")
+}
+
+func TestGenerateConfig_PolarizationStringInjectionResistant(t *testing.T) {
+	// Defense-in-depth: even if apiserver enum validation is bypassed and a
+	// malicious polarization value somehow reaches GenerateConfig, the rendered
+	// YAML MUST NOT allow the injected string to break out and create sibling
+	// YAML keys. yamlQuote escapes newlines and colons into a quoted scalar.
+	spec := &ntnv1alpha1.NTNCellConfigSpec{
+		NTN: ntnv1alpha1.NTNParams{
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+			Polarization: &ntnv1alpha1.NTNPolarization{
+				DL: "rhcp\ninjected_key: pwned",
+				UL: "lhcp",
+			},
+		},
+	}
+	data, err := GenerateConfig(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(data)
+	// The injection MUST be inside a quoted string, not a bare scalar.
+	assertNotContains(t, yaml, "\ninjected_key: pwned")
+	assertContains(t, yaml, `\n`) // escape sequence inside the quoted string
+}
+
+func TestGenerateConfig_PayloadTypeStringInjectionResistant(t *testing.T) {
+	// The # Payload type: ... comment line is line-terminated; yamlQuote does
+	// not protect it. sanitizeComment replaces control chars with spaces so
+	// no newline / CR can terminate the comment and inject real YAML keys.
+	spec := &ntnv1alpha1.NTNCellConfigSpec{
+		NTN: ntnv1alpha1.NTNParams{
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+			PayloadType:   "transparent\ninjected_key: pwned",
+		},
+	}
+	data, err := GenerateConfig(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(data)
+	assertNotContains(t, yaml, "\ninjected_key: pwned")
 }
 
 func TestGenerateConfig_TAReport(t *testing.T) {

--- a/pkg/provider/ocudu/config_test.go
+++ b/pkg/provider/ocudu/config_test.go
@@ -384,11 +384,12 @@ func TestGenerateConfig_PolarizationStringInjectionResistant(t *testing.T) {
 	// malicious polarization value somehow reaches GenerateConfig, the rendered
 	// YAML MUST NOT allow the injected string to break out and create sibling
 	// YAML keys. yamlQuote escapes newlines and colons into a quoted scalar.
+	const injected = "rhcp\ninjected_key: pwned"
 	spec := &ntnv1alpha1.NTNCellConfigSpec{
 		NTN: ntnv1alpha1.NTNParams{
 			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
 			Polarization: &ntnv1alpha1.NTNPolarization{
-				DL: "rhcp\ninjected_key: pwned",
+				DL: injected,
 				UL: "lhcp",
 			},
 		},
@@ -398,9 +399,36 @@ func TestGenerateConfig_PolarizationStringInjectionResistant(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	yaml := string(data)
-	// The injection MUST be inside a quoted string, not a bare scalar.
+	// Surface check: the injection MUST NOT appear as a top-level sibling key.
 	assertNotContains(t, yaml, "\ninjected_key: pwned")
-	assertContains(t, yaml, `\n`) // escape sequence inside the quoted string
+
+	// Structural check: parse the YAML and verify the injected payload lives
+	// entirely inside the polarization.dl scalar — no sibling key leaked into
+	// the ntn map. This is stronger than substring matching because it fails
+	// if escaping regresses in a way that still happens to avoid the literal
+	// "\ninjected_key:" string.
+	var parsed map[string]any
+	if err := k8syaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated YAML did not unmarshal: %v\nYAML:\n%s", err, yaml)
+	}
+	ntn, ok := parsed["ntn"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated YAML missing ntn map: %#v", parsed["ntn"])
+	}
+	if _, ok := ntn["injected_key"]; ok {
+		t.Fatalf("injection leaked: ntn.injected_key should not exist, got %#v", ntn["injected_key"])
+	}
+	polarization, ok := ntn["polarization"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated YAML missing polarization map: %#v", ntn["polarization"])
+	}
+	dl, ok := polarization["dl"].(string)
+	if !ok {
+		t.Fatalf("generated YAML missing polarization.dl string: %#v", polarization["dl"])
+	}
+	if dl != injected {
+		t.Fatalf("unexpected polarization.dl round-trip value: got %q, want %q", dl, injected)
+	}
 }
 
 func TestGenerateConfig_PayloadTypeStringInjectionResistant(t *testing.T) {

--- a/pkg/provider/ocudu/config_test.go
+++ b/pkg/provider/ocudu/config_test.go
@@ -20,6 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	// Aliased to k8syaml so tests can freely use a local `yaml := string(data)`
+	// without shadowing the import (revive import-shadowing check).
+	k8syaml "sigs.k8s.io/yaml"
+
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
@@ -765,6 +769,61 @@ func TestGenerateConfig_SIBScheduleZeroPositionRespected(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertContains(t, string(data), "si_window_position: 0")
+}
+
+// TestGenerateConfig_YAMLRoundTrip asserts the renderer emits structurally
+// valid YAML for a maximal spec combining every field set PRs #45 and #46
+// introduced. Catches indentation drift from future template edits.
+func TestGenerateConfig_YAMLRoundTrip(t *testing.T) {
+	dur := 900
+	pos := 3
+	spec := &ntnv1alpha1.NTNCellConfigSpec{
+		NTN: ntnv1alpha1.NTNParams{
+			CellSpecificKoffset:  150,
+			TACommon:             0,
+			NTNUlSyncValidityDur: &dur,
+			PayloadType:          "regenerative",
+			Polarization:         &ntnv1alpha1.NTNPolarization{DL: "rhcp", UL: "lhcp"},
+			TAInfo: &ntnv1alpha1.TAInfo{
+				TACommon:             1000,
+				TACommonDrift:        50,
+				TACommonDriftVariant: 10,
+				TACommonOffset:       200,
+			},
+			EpochTime:           &ntnv1alpha1.EpochTime{SFN: 512, SubframeNumber: 5},
+			EphemerisECEF:       &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3, VelX: 10, VelY: 20, VelZ: 30},
+			MovingRefLocation:   &ntnv1alpha1.MovingRefLocation{Latitude: 248500, Longitude: 1210000},
+			SatSwitchWithResync: &ntnv1alpha1.SatSwitchWithResync{TargetPCI: 1, T304: 100},
+			NeighborCells: []ntnv1alpha1.NTNNeighborCell{
+				{PhysicalCellID: 7, Frequency: 632628},
+				{PhysicalCellID: 42},
+			},
+		},
+		CellOverrides: &ntnv1alpha1.CellOverrides{
+			PdschMaxHarqRetxs:    2,
+			PrachMaxMsg3HarqRetx: 1,
+			RrcGuardTimeMs:       25600,
+			SIBSchedule: &ntnv1alpha1.SIBSchedule{
+				SIWindowLength:   20,
+				SIPeriod:         32,
+				SIWindowPosition: &pos,
+			},
+		},
+	}
+	data, err := GenerateConfig(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed map[string]any
+	if err := k8syaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("rendered output is not valid YAML: %v\n\n%s", err, data)
+	}
+	if _, ok := parsed["ntn"]; !ok {
+		t.Errorf("round-trip parse missing ntn key: %s", data)
+	}
+	if _, ok := parsed["cell_cfg"]; !ok {
+		t.Errorf("round-trip parse missing cell_cfg key: %s", data)
+	}
 }
 
 func assertContains(t *testing.T, haystack, needle string) {

--- a/pkg/provider/ocudu/config_test.go
+++ b/pkg/provider/ocudu/config_test.go
@@ -449,6 +449,27 @@ func TestGenerateConfig_PayloadTypeStringInjectionResistant(t *testing.T) {
 	assertNotContains(t, yaml, "\ninjected_key: pwned")
 }
 
+func TestGenerateConfig_PayloadTypeUnicodeLineSeparatorInjectionResistant(t *testing.T) {
+	// YAML accepts multiple line-break runes (NEL/LS/PS). Ensure sanitizeComment
+	// neutralizes these as well so payloadType cannot escape the comment line.
+	separators := []string{"\u0085", "\u2028", "\u2029"}
+	for _, sep := range separators {
+		spec := &ntnv1alpha1.NTNCellConfigSpec{
+			NTN: ntnv1alpha1.NTNParams{
+				EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+				PayloadType:   "transparent" + sep + "injected_key: pwned",
+			},
+		}
+		data, err := GenerateConfig(spec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		yaml := string(data)
+		assertNotContains(t, yaml, "\ninjected_key: pwned")
+		assertNotContains(t, yaml, sep)
+	}
+}
+
 func TestGenerateConfig_TAReport(t *testing.T) {
 	enabled := true
 	spec := &ntnv1alpha1.NTNCellConfigSpec{


### PR DESCRIPTION
## Summary

Three small, independent hardening improvements to the OCUDU provider renderer, salvaged from PR #55 after that PR's core design (`NeighborReselectionInfo` with per-neighbor SIB2 fields) was determined to violate 3GPP SIB2/SIB3 field scoping (qHyst/sIntraSearchP/threshServingLowP are cell-wide in SIB2, not per-neighbor — see [ADR 0001](https://github.com/thc1006/ntn-operators/blob/main/docs/adr/0001-sib11-measurement-config.md)).

Each commit stands alone:

### 1. `842a353` — `fix(provider): YAML string injection defense-in-depth`
- `yamlQuote` template FuncMap applies `strconv.Quote` to `polarization.dl` / `.ul` so a crafted string cannot break out of its scalar even if apiserver enum validation is bypassed (webhook misconfig, direct etcd write, etc.).
- `sanitizeComment` replaces control chars in `PayloadType` before interpolation into the `# Payload type: ...` header comment (quoting does not protect line-terminated comments).
- Existing polarization tests updated to expect the quoted form (still accepted by OCUDU CLI11).
- New regression tests `TestGenerateConfig_PolarizationStringInjectionResistant` and `TestGenerateConfig_PayloadTypeStringInjectionResistant`.

### 2. `af3dea7` — `chore(chart): auto-sync Helm CRDs + v0.2→v0.3 migration doc`
- Extend `make manifests` so `controller-gen` output is byte-copied into `dist/chart/templates/crd/` automatically, closing the historical drift gap (already hit in PR #54 where a manual sync commit was needed).
- Resync the other 3 CRDs (`GroundStationLifecycle`, `NTNSlice`, `SatelliteEphemeris`) that had drifted.
- New `docs/migration-v0.2-v0.3.md` — jq / kubectl-patch migration guide for operators moving from the flat `polarization` scalar to nested `{dl, ul}` schema (PR #54's breaking change).

### 3. `0745320` — `test(provider): YAML round-trip regression test`
- `TestGenerateConfig_YAMLRoundTrip` — renders a maximal spec covering every field PR #54 / PR #46 introduced, then parses the output with `sigs.k8s.io/yaml` to verify structural validity. Catches indentation drift that `assertContains` substring checks would miss.
- Import aliased `k8syaml "sigs.k8s.io/yaml"` to avoid revive import-shadowing on the `yaml := string(data)` locals used throughout the test file.

## Why not merge PR #55 directly

PR #55 bundled these hardening parts with a `NeighborReselectionInfo` CRD that placed `qHyst`, `sIntraSearchP`, `threshServingLowP` per-neighbor. Two independent issues:

1. **3GPP scoping violation**: these are SIB2 cell-wide reselection thresholds, not SIB3 per-neighbor offsets. Only `qOffsetCell` is genuinely per-neighbor.
2. **Upstream OCUDU CLI11 does not parse `ntn.ncells`**: verified against `dev` HEAD — the CLI11 schema has no `ncells` subcommand, so any field under a neighbor object (including the broken `reselection_info`) would be ignored at load time.

PR #55 will be closed with a reference to this PR and a link to ADR 0001 for the scope decision. A follow-up PR under a `neighborMobility` top-level CRD field (per ADR 0001 §Option C) will eventually cover the SIB2/SIB3 surface correctly.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/provider/ocudu/...` — all tests pass (34 test cases)
- [x] `make manifests` — verifies Makefile auto-sync behaviour
- [x] New injection-resistance tests exercise adversarial strings for DL/UL polarization and PayloadType

Refs: #45, #46, #47
Supersedes: #55