### PR TITLE
chore: add Dependabot for automated dependency updates (#63)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps):"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci):"
+
+  # Docker (Dockerfile, if added later)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(docker):"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` for automated dependency monitoring.

- **Go modules**: weekly on Monday, max 5 open PRs
- **GitHub Actions**: weekly on Monday, max 5 open PRs  
- **Docker**: monthly, max 3 open PRs

All PRs labeled `dependencies`, Actions PRs also labeled `ci`.

Closes #63

## Test plan
- [ ] Dependabot starts creating PRs after merge