### PR TITLE
helm: add NetworkPolicy template for production hardening (#58)

### DIFF
--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -50,6 +50,7 @@ This chart installs four Custom Resource Definitions:
 | `prometheus.enable` | bool | `false` | Create ServiceMonitor for Prometheus |
 | `podDisruptionBudget.enable` | bool | `false` | Create PodDisruptionBudget |
 | `podDisruptionBudget.minAvailable` | int | `1` | Minimum available pods |
+| `networkPolicy.enable` | bool | `false` | Create NetworkPolicy (requires CNI support) |
 
 ## Production Configuration
 
@@ -76,6 +77,9 @@ prometheus:
 podDisruptionBudget:
   enable: true
   minAvailable: 1
+
+networkPolicy:
+  enable: true
 ```
 
 ## Upgrading

--- a/dist/chart/templates/manager/networkpolicy.yaml
+++ b/dist/chart/templates/manager/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.networkPolicy.enable }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "ntn-operators.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow metrics scraping (Prometheus) and health probes (kubelet)
+    - ports:
+        - port: 8443
+          protocol: TCP
+        - port: 8081
+          protocol: TCP
+  egress:
+    # Allow HTTPS: Kubernetes API server + CelesTrak + Space-Track
+    - ports:
+        - port: 443
+          protocol: TCP
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -116,3 +116,11 @@ podDisruptionBudget:
   enable: false
   minAvailable: 1
 
+## NetworkPolicy for zero-trust pod networking.
+## Restricts ingress to metrics (8443) and health probes (8081),
+## egress to HTTPS (443) and DNS (53).
+## Requires a CNI plugin that implements NetworkPolicy (e.g., Calico, Cilium).
+##
+networkPolicy:
+  enable: false
+

--- a/hack/test-networkpolicy-template.sh
+++ b/hack/test-networkpolicy-template.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# TDD test for NetworkPolicy Helm template rendering.
+# Usage: hack/test-networkpolicy-template.sh
+set -euo pipefail
+
+CHART_DIR="dist/chart"
+ERRORS=0
+
+fail() { echo "FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+echo "=== NetworkPolicy Helm Template Tests ==="
+
+# Test 1: NetworkPolicy is NOT rendered when disabled (default)
+output=$(helm template test "$CHART_DIR" 2>/dev/null)
+if echo "$output" | grep -q 'kind: NetworkPolicy'; then
+  fail "NetworkPolicy should not render when networkPolicy.enable is false (default)"
+fi
+
+# Test 2: NetworkPolicy IS rendered when enabled
+output=$(helm template test "$CHART_DIR" --set networkPolicy.enable=true 2>/dev/null)
+if ! echo "$output" | grep -q 'kind: NetworkPolicy'; then
+  fail "NetworkPolicy should render when networkPolicy.enable=true"
+fi
+
+# Test 3: Pod selector targets controller-manager
+if ! echo "$output" | grep -A5 'podSelector' | grep -q 'control-plane: controller-manager'; then
+  fail "podSelector should match control-plane: controller-manager"
+fi
+
+# Test 4: Both Ingress and Egress policy types declared
+if ! echo "$output" | grep -qF -- '- Ingress'; then
+  fail "policyTypes should include Ingress"
+fi
+if ! echo "$output" | grep -qF -- '- Egress'; then
+  fail "policyTypes should include Egress"
+fi
+
+# Test 5: Ingress allows metrics port 8443
+if ! echo "$output" | grep -q '8443'; then
+  fail "ingress should allow port 8443 (metrics)"
+fi
+
+# Test 6: Ingress allows health probe port 8081
+if ! echo "$output" | grep -q '8081'; then
+  fail "ingress should allow port 8081 (health probes)"
+fi
+
+# Test 7: Egress allows HTTPS port 443
+if ! echo "$output" | grep -q '443'; then
+  fail "egress should allow port 443 (HTTPS)"
+fi
+
+# Test 8: Egress allows DNS port 53
+if ! echo "$output" | grep -q '53'; then
+  fail "egress should allow port 53 (DNS)"
+fi
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "PASS: all 8 tests passed."
+else
+  echo "FAIL: $ERRORS test(s) failed."
+  exit 1
+fi

--- a/hack/test-networkpolicy-template.sh
+++ b/hack/test-networkpolicy-template.sh
@@ -45,13 +45,13 @@ if ! echo "$output" | grep -q '8081'; then
   fail "ingress should allow port 8081 (health probes)"
 fi
 
-# Test 7: Egress allows HTTPS port 443
-if ! echo "$output" | grep -q '443'; then
+# Test 7: Egress allows HTTPS port 443 (not just 8443)
+if ! echo "$output" | grep -qF 'port: 443'; then
   fail "egress should allow port 443 (HTTPS)"
 fi
 
-# Test 8: Egress allows DNS port 53
-if ! echo "$output" | grep -q '53'; then
+# Test 8: Egress allows DNS port 53 (exact match)
+if ! echo "$output" | grep -qF 'port: 53'; then
   fail "egress should allow port 53 (DNS)"
 fi
 

--- a/hack/test-networkpolicy-template.sh
+++ b/hack/test-networkpolicy-template.sh
@@ -8,50 +8,63 @@ ERRORS=0
 
 fail() { echo "FAIL: $1"; ERRORS=$((ERRORS + 1)); }
 
+# Extract only the NetworkPolicy document from helm template output.
+extract_np() {
+  python3 -c "
+import sys, yaml
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get('kind') == 'NetworkPolicy':
+        print(yaml.dump(doc, default_flow_style=False))
+        break
+"
+}
+
 echo "=== NetworkPolicy Helm Template Tests ==="
 
 # Test 1: NetworkPolicy is NOT rendered when disabled (default)
-output=$(helm template test "$CHART_DIR" 2>/dev/null)
+output=$(helm template test "$CHART_DIR")
 if echo "$output" | grep -q 'kind: NetworkPolicy'; then
   fail "NetworkPolicy should not render when networkPolicy.enable is false (default)"
 fi
 
-# Test 2: NetworkPolicy IS rendered when enabled
-output=$(helm template test "$CHART_DIR" --set networkPolicy.enable=true 2>/dev/null)
-if ! echo "$output" | grep -q 'kind: NetworkPolicy'; then
+# Test 2: NetworkPolicy IS rendered when enabled — extract only the NP document
+np=$(helm template test "$CHART_DIR" --set networkPolicy.enable=true | extract_np)
+if [ -z "$np" ]; then
   fail "NetworkPolicy should render when networkPolicy.enable=true"
+  echo "FAIL: 1 test(s) failed (cannot continue without NetworkPolicy document)."
+  exit 1
 fi
 
 # Test 3: Pod selector targets controller-manager
-if ! echo "$output" | grep -A5 'podSelector' | grep -q 'control-plane: controller-manager'; then
+if ! echo "$np" | grep -q 'control-plane: controller-manager'; then
   fail "podSelector should match control-plane: controller-manager"
 fi
 
 # Test 4: Both Ingress and Egress policy types declared
-if ! echo "$output" | grep -qF -- '- Ingress'; then
+if ! echo "$np" | grep -qF -- '- Ingress'; then
   fail "policyTypes should include Ingress"
 fi
-if ! echo "$output" | grep -qF -- '- Egress'; then
+if ! echo "$np" | grep -qF -- '- Egress'; then
   fail "policyTypes should include Egress"
 fi
 
 # Test 5: Ingress allows metrics port 8443
-if ! echo "$output" | grep -q '8443'; then
+if ! echo "$np" | grep -qF 'port: 8443'; then
   fail "ingress should allow port 8443 (metrics)"
 fi
 
 # Test 6: Ingress allows health probe port 8081
-if ! echo "$output" | grep -q '8081'; then
+if ! echo "$np" | grep -qF 'port: 8081'; then
   fail "ingress should allow port 8081 (health probes)"
 fi
 
-# Test 7: Egress allows HTTPS port 443 (not just 8443)
-if ! echo "$output" | grep -qF 'port: 443'; then
+# Test 7: Egress allows HTTPS port 443
+if ! echo "$np" | grep -qF 'port: 443'; then
   fail "egress should allow port 443 (HTTPS)"
 fi
 
-# Test 8: Egress allows DNS port 53 (exact match)
-if ! echo "$output" | grep -qF 'port: 53'; then
+# Test 8: Egress allows DNS port 53
+if ! echo "$np" | grep -qF 'port: 53'; then
   fail "egress should allow port 53 (DNS)"
 fi
 


### PR DESCRIPTION
## Summary

Add zero-trust NetworkPolicy for the controller manager pod. Follows kubebuilder issue [#1885](https://github.com/kubernetes-sigs/kubebuilder/issues/1885) recommendation to use NetworkPolicy for production hardening.

Closes #58

## NetworkPolicy Rules

**Ingress (into manager pod):**
| Port | Protocol | Purpose |
|------|----------|---------|
| 8443 | TCP | Metrics scraping (Prometheus) |
| 8081 | TCP | Health probes (kubelet liveness/readiness) |

**Egress (from manager pod):**
| Port | Protocol | Purpose |
|------|----------|---------|
| 443 | TCP | HTTPS — K8s API server, CelesTrak, Space-Track |
| 53 | TCP+UDP | DNS resolution (CoreDNS) |

## Changes

- `dist/chart/templates/manager/networkpolicy.yaml` — NetworkPolicy template
- `dist/chart/values.yaml` — add `networkPolicy.enable: false`
- `dist/chart/README.md` — add values table row + production config example
- `hack/test-networkpolicy-template.sh` — TDD test (8 assertions)

## Test plan

- [x] `hack/test-networkpolicy-template.sh` — 8/8 pass
- [x] `helm lint dist/chart/` — clean (both enabled and disabled)
- [x] `helm template` renders correct NetworkPolicy when enabled
- [x] No NetworkPolicy rendered when disabled (default)