### PR TITLE
feat(slice): add hysteresis dead-band for failover anti-flapping (#50)

### DIFF
--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -99,6 +99,16 @@ type FailoverPolicy struct {
 	// sessionContinuity preserves active sessions during failover.
 	// +kubebuilder:default=true
 	SessionContinuity bool `json:"sessionContinuity,omitempty"`
+
+	// hysteresisDB is a dead-band margin applied to trigger thresholds
+	// during switchback evaluation, preventing flapping when metrics
+	// oscillate near the threshold. The value is in the same unit as
+	// the trigger (dB for RSRP, ms for latency, percent for packetLoss).
+	// Example: with trigger "rsrp < -120" and hysteresisDB "10",
+	// failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+	// +kubebuilder:validation:Pattern=`^[0-9]+\.?[0-9]*$`
+	// +optional
+	HysteresisDB string `json:"hysteresisDB,omitempty"`
 }
 
 // QoSMapping defines QoS parameter mapping between terrestrial and satellite paths.

--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -100,15 +100,15 @@ type FailoverPolicy struct {
 	// +kubebuilder:default=true
 	SessionContinuity bool `json:"sessionContinuity,omitempty"`
 
-	// hysteresisDB is a dead-band margin applied to trigger thresholds
+	// hysteresisMargin is a dead-band applied to trigger thresholds
 	// during switchback evaluation, preventing flapping when metrics
-	// oscillate near the threshold. The value is in the same unit as
+	// oscillate near the threshold. The value uses the same unit as
 	// the trigger (dB for RSRP, ms for latency, percent for packetLoss).
-	// Example: with trigger "rsrp < -120" and hysteresisDB "10",
+	// Example: with trigger "rsrp < -120" and hysteresisMargin "10",
 	// failover fires at RSRP < -120, but switchback requires RSRP >= -110.
 	// +kubebuilder:validation:Pattern=`^[0-9]+\.?[0-9]*$`
 	// +optional
-	HysteresisDB string `json:"hysteresisDB,omitempty"`
+	HysteresisMargin string `json:"hysteresisMargin,omitempty"`
 }
 
 // QoSMapping defines QoS parameter mapping between terrestrial and satellite paths.

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -110,7 +110,15 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		lastFailover = ns.Status.LastFailover.Time
 	}
 
-	result := slice.EvaluateFailoverWithContext(
+	// Parse hysteresis margin from spec (string → float64, default 0).
+	var hysteresisMargin float64
+	if ns.Spec.FailoverPolicy.HysteresisMargin != "" {
+		if v, err := strconv.ParseFloat(ns.Spec.FailoverPolicy.HysteresisMargin, 64); err == nil {
+			hysteresisMargin = v
+		}
+	}
+
+	result := slice.EvaluateFailoverWithHysteresis(
 		ctx,
 		currentPath,
 		ns.Spec.FailoverPolicy.Triggers,
@@ -119,6 +127,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		ns.Spec.FailoverPolicy.SwitchbackDelay.Duration,
 		lastFailover,
 		now,
+		hysteresisMargin,
 	)
 
 	// Step 5: Apply decision.

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -113,7 +113,13 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Parse hysteresis margin from spec (string → float64, default 0).
 	var hysteresisMargin float64
 	if ns.Spec.FailoverPolicy.HysteresisMargin != "" {
-		if v, err := strconv.ParseFloat(ns.Spec.FailoverPolicy.HysteresisMargin, 64); err == nil {
+		if v, err := strconv.ParseFloat(ns.Spec.FailoverPolicy.HysteresisMargin, 64); err != nil {
+			log.Error(err, "invalid failoverPolicy.hysteresisMargin; defaulting to 0",
+				"hysteresisMargin", ns.Spec.FailoverPolicy.HysteresisMargin)
+		} else if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+			log.Info("non-finite or negative failoverPolicy.hysteresisMargin; defaulting to 0",
+				"hysteresisMargin", ns.Spec.FailoverPolicy.HysteresisMargin)
+		} else {
 			hysteresisMargin = v
 		}
 	}

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -118,14 +118,10 @@ func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 	}
 
 	switch t.Operator {
-	case "<":
+	case "<", "<=":
 		return actual >= t.Value+margin
-	case "<=":
-		return actual > t.Value+margin
-	case ">":
+	case ">", ">=":
 		return actual <= t.Value-margin
-	case ">=":
-		return actual < t.Value-margin
 	default:
 		return false // unknown operator — fail-safe
 	}
@@ -190,6 +186,42 @@ func EvaluateFailover(
 	)
 }
 
+// triggerSetResult holds the result of parsing and evaluating a set of triggers.
+type triggerSetResult struct {
+	parsed       []Trigger
+	anyTriggered bool
+	parseSuffix  string
+	allInvalid   bool
+}
+
+// parseTriggerSet parses all triggers, evaluates them (OR logic), and returns
+// structured results including parse error accounting.
+func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) triggerSetResult {
+	var result triggerSetResult
+	parseErrors := 0
+	for _, triggerStr := range triggers {
+		trigger, err := ParseTrigger(triggerStr)
+		if err != nil {
+			parseErrors++
+			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
+			continue
+		}
+		result.parsed = append(result.parsed, trigger)
+		if !result.anyTriggered && trigger.Evaluate(metrics) {
+			result.anyTriggered = true
+			log.V(2).Info("trigger matched", "trigger", triggerStr)
+		}
+	}
+	if parseErrors > 0 {
+		if parseErrors == len(triggers) {
+			result.allInvalid = true
+		} else {
+			result.parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
+		}
+	}
+	return result
+}
+
 // EvaluateFailoverWithContext is the context-aware variant of EvaluateFailover.
 // It emits structured package-level logs for trigger parsing and decision outcomes.
 func EvaluateFailoverWithContext(
@@ -218,84 +250,64 @@ func EvaluateFailoverWithContext(
 		return res
 	}
 
-	// Parse and evaluate all triggers (OR logic).
-	anyTriggered := false
-	parseErrors := 0
-	for _, triggerStr := range triggers {
-		trigger, err := ParseTrigger(triggerStr)
-		if err != nil {
-			parseErrors++
-			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
-			continue
-		}
-		if trigger.Evaluate(metrics) {
-			anyTriggered = true
-			log.V(2).Info("trigger matched", "trigger", triggerStr)
-			break
-		}
-	}
+	ts := parseTriggerSet(log, triggers, metrics)
 
 	// Normalize unknown currentPath to terrestrial.
 	if currentPath != PathTerrestrial && currentPath != PathSatellite && currentPath != PathUnavailable {
 		currentPath = PathTerrestrial
 	}
 
-	// Surface trigger parse errors.
-	parseSuffix := ""
-	if parseErrors > 0 {
-		if parseErrors == len(triggers) {
-			return finish(FailoverResult{
-				Decision:   DecisionStay,
-				Reason:     fmt.Sprintf("All %d trigger expressions are invalid", parseErrors),
-				TargetPath: currentPath,
-			})
-		}
-		parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
+	if ts.allInvalid {
+		return finish(FailoverResult{
+			Decision:   DecisionStay,
+			Reason:     fmt.Sprintf("All %d trigger expressions are invalid", len(triggers)),
+			TargetPath: currentPath,
+		})
 	}
 
 	switch currentPath {
 	case PathTerrestrial:
-		if !anyTriggered {
+		if !ts.anyTriggered {
 			return finish(FailoverResult{
 				Decision:   DecisionStay,
-				Reason:     "Terrestrial path healthy" + parseSuffix,
+				Reason:     "Terrestrial path healthy" + ts.parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
 		if !satelliteAvailable {
 			return finish(FailoverResult{
 				Decision:   DecisionStay,
-				Reason:     "Terrestrial degraded but no satellite pass available" + parseSuffix,
+				Reason:     "Terrestrial degraded but no satellite pass available" + ts.parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
 		return finish(FailoverResult{
 			Decision:   DecisionFailover,
-			Reason:     "Terrestrial path degraded, satellite pass available" + parseSuffix,
+			Reason:     "Terrestrial path degraded, satellite pass available" + ts.parseSuffix,
 			TargetPath: PathSatellite,
 		})
 
 	case PathSatellite:
 		// If satellite pass ended, must switch back regardless.
 		if !satelliteAvailable {
-			if anyTriggered {
+			if ts.anyTriggered {
 				return finish(FailoverResult{
 					Decision:   DecisionSwitchback,
-					Reason:     "Satellite pass ended, falling back to degraded terrestrial" + parseSuffix,
+					Reason:     "Satellite pass ended, falling back to degraded terrestrial" + ts.parseSuffix,
 					TargetPath: PathTerrestrial,
 				})
 			}
 			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
-				Reason:     "Satellite pass ended, terrestrial recovered" + parseSuffix,
+				Reason:     "Satellite pass ended, terrestrial recovered" + ts.parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
-		if anyTriggered {
+		if ts.anyTriggered {
 			// Terrestrial still degraded, stay on satellite.
 			return finish(FailoverResult{
 				Decision:   DecisionStay,
-				Reason:     "Terrestrial still degraded, staying on satellite" + parseSuffix,
+				Reason:     "Terrestrial still degraded, staying on satellite" + ts.parseSuffix,
 				TargetPath: PathSatellite,
 			})
 		}
@@ -304,35 +316,35 @@ func EvaluateFailoverWithContext(
 			return finish(FailoverResult{
 				Decision: DecisionStay,
 				Reason: fmt.Sprintf("Terrestrial recovered but switchback delay not elapsed (%s remaining)%s",
-					switchbackDelay-now.Sub(lastFailover), parseSuffix),
+					switchbackDelay-now.Sub(lastFailover), ts.parseSuffix),
 				TargetPath: PathSatellite,
 			})
 		}
 		return finish(FailoverResult{
 			Decision:   DecisionSwitchback,
-			Reason:     "Terrestrial recovered, switchback delay elapsed" + parseSuffix,
+			Reason:     "Terrestrial recovered, switchback delay elapsed" + ts.parseSuffix,
 			TargetPath: PathTerrestrial,
 		})
 
 	default:
 		// Unknown or unavailable path — try terrestrial first.
-		if !anyTriggered {
+		if !ts.anyTriggered {
 			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
-				Reason:     "Initializing on terrestrial path" + parseSuffix,
+				Reason:     "Initializing on terrestrial path" + ts.parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
 		if satelliteAvailable {
 			return finish(FailoverResult{
 				Decision:   DecisionFailover,
-				Reason:     "Terrestrial unavailable, using satellite" + parseSuffix,
+				Reason:     "Terrestrial unavailable, using satellite" + ts.parseSuffix,
 				TargetPath: PathSatellite,
 			})
 		}
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
-			Reason:     "Both paths degraded" + parseSuffix,
+			Reason:     "Both paths degraded" + ts.parseSuffix,
 			TargetPath: PathUnavailable,
 		})
 	}
@@ -380,55 +392,36 @@ func EvaluateFailoverWithHysteresis(
 		return res
 	}
 
-	// Parse all triggers with error accounting (same as EvaluateFailoverWithContext).
-	anyTriggered := false
-	parseErrors := 0
-	var parsed []Trigger
-	for _, triggerStr := range triggers {
-		trigger, err := ParseTrigger(triggerStr)
-		if err != nil {
-			parseErrors++
-			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
-			continue
-		}
-		parsed = append(parsed, trigger)
-		if !anyTriggered && trigger.Evaluate(metrics) {
-			anyTriggered = true
-		}
-	}
+	ts := parseTriggerSet(log, triggers, metrics)
 
-	parseSuffix := ""
-	if parseErrors > 0 {
-		if parseErrors == len(triggers) {
-			return finish(FailoverResult{
-				Decision:   DecisionStay,
-				Reason:     fmt.Sprintf("All %d trigger expressions are invalid", parseErrors),
-				TargetPath: currentPath,
-			})
-		}
-		parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
+	if ts.allInvalid {
+		return finish(FailoverResult{
+			Decision:   DecisionStay,
+			Reason:     fmt.Sprintf("All %d trigger expressions are invalid", len(triggers)),
+			TargetPath: currentPath,
+		})
 	}
 
 	// Satellite pass ended — force switchback regardless of hysteresis.
 	if !satelliteAvailable {
-		if anyTriggered {
+		if ts.anyTriggered {
 			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
-				Reason:     "Satellite pass ended, falling back to degraded terrestrial" + parseSuffix,
+				Reason:     "Satellite pass ended, falling back to degraded terrestrial" + ts.parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
 		return finish(FailoverResult{
 			Decision:   DecisionSwitchback,
-			Reason:     "Satellite pass ended, terrestrial recovered" + parseSuffix,
+			Reason:     "Satellite pass ended, terrestrial recovered" + ts.parseSuffix,
 			TargetPath: PathTerrestrial,
 		})
 	}
 
-	if anyTriggered {
+	if ts.anyTriggered {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
-			Reason:     "Terrestrial still degraded, staying on satellite" + parseSuffix,
+			Reason:     "Terrestrial still degraded, staying on satellite" + ts.parseSuffix,
 			TargetPath: PathSatellite,
 		})
 	}
@@ -436,7 +429,7 @@ func EvaluateFailoverWithHysteresis(
 	// Triggers no longer firing at original thresholds.
 	// Check hysteresis: have ALL valid triggers recovered past the dead-band?
 	allRecovered := true
-	for _, t := range parsed {
+	for _, t := range ts.parsed {
 		if !t.EvaluateRecovery(metrics, hysteresisMargin) {
 			allRecovered = false
 			break
@@ -448,7 +441,7 @@ func EvaluateFailoverWithHysteresis(
 			Decision: DecisionStay,
 			Reason: fmt.Sprintf(
 				"Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s",
-				hysteresisMargin, parseSuffix),
+				hysteresisMargin, ts.parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}
@@ -458,14 +451,14 @@ func EvaluateFailoverWithHysteresis(
 		return finish(FailoverResult{
 			Decision: DecisionStay,
 			Reason: fmt.Sprintf("Terrestrial recovered past dead-band but switchback delay not elapsed (%s remaining)%s",
-				switchbackDelay-now.Sub(lastFailover), parseSuffix),
+				switchbackDelay-now.Sub(lastFailover), ts.parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}
 
 	return finish(FailoverResult{
 		Decision:   DecisionSwitchback,
-		Reason:     "Terrestrial recovered past hysteresis dead-band, switchback delay elapsed" + parseSuffix,
+		Reason:     "Terrestrial recovered past hysteresis dead-band, switchback delay elapsed" + ts.parseSuffix,
 		TargetPath: PathTerrestrial,
 	})
 }

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -445,7 +445,7 @@ func EvaluateFailoverWithHysteresis(
 
 	if !allRecovered {
 		return finish(FailoverResult{
-			Decision:   DecisionStay,
+			Decision: DecisionStay,
 			Reason: fmt.Sprintf(
 				"Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s",
 				hysteresisDB, parseSuffix),

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -114,7 +114,7 @@ func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 	case "packetLoss", "terrestrialPacketLoss":
 		actual = m.PacketLossPercent
 	default:
-		return true // unknown metric — assume recovered
+		return false // unknown metric — fail-safe, assume NOT recovered
 	}
 
 	switch t.Operator {
@@ -127,7 +127,7 @@ func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 	case ">=":
 		return actual < t.Value-margin
 	default:
-		return true
+		return false // unknown operator — fail-safe
 	}
 }
 
@@ -345,7 +345,7 @@ func EvaluateFailoverWithContext(
 // During switchback (satellite → terrestrial), triggers require the metric to clear
 // the threshold by the hysteresis margin before considering recovery.
 //
-// Example: trigger "rsrp < -120" with hysteresisDB=10 means failover fires at
+// Example: trigger "rsrp < -120" with hysteresisMargin=10 means failover fires at
 // RSRP < -120 dBm, but switchback requires RSRP >= -110 dBm (10 dB dead-band).
 func EvaluateFailoverWithHysteresis(
 	ctx context.Context,
@@ -356,10 +356,10 @@ func EvaluateFailoverWithHysteresis(
 	switchbackDelay time.Duration,
 	lastFailover time.Time,
 	now time.Time,
-	hysteresisDB float64,
+	hysteresisMargin float64,
 ) FailoverResult {
 	// If not on satellite or no hysteresis, delegate to the standard evaluator.
-	if currentPath != PathSatellite || hysteresisDB <= 0 {
+	if currentPath != PathSatellite || hysteresisMargin <= 0 {
 		return EvaluateFailoverWithContext(
 			ctx, currentPath, triggers, metrics,
 			satelliteAvailable, switchbackDelay, lastFailover, now,
@@ -368,7 +368,7 @@ func EvaluateFailoverWithHysteresis(
 
 	log := logr.FromContextOrDiscard(ctx)
 	log.V(2).Info("evaluate failover with hysteresis",
-		"hysteresisMargin", hysteresisDB,
+		"hysteresisMargin", hysteresisMargin,
 		"currentPath", currentPath,
 	)
 	finish := func(res FailoverResult) FailoverResult {
@@ -392,7 +392,7 @@ func EvaluateFailoverWithHysteresis(
 			continue
 		}
 		parsed = append(parsed, trigger)
-		if trigger.Evaluate(metrics) {
+		if !anyTriggered && trigger.Evaluate(metrics) {
 			anyTriggered = true
 		}
 	}
@@ -437,7 +437,7 @@ func EvaluateFailoverWithHysteresis(
 	// Check hysteresis: have ALL valid triggers recovered past the dead-band?
 	allRecovered := true
 	for _, t := range parsed {
-		if !t.EvaluateRecovery(metrics, hysteresisDB) {
+		if !t.EvaluateRecovery(metrics, hysteresisMargin) {
 			allRecovered = false
 			break
 		}
@@ -448,7 +448,7 @@ func EvaluateFailoverWithHysteresis(
 			Decision: DecisionStay,
 			Reason: fmt.Sprintf(
 				"Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s",
-				hysteresisDB, parseSuffix),
+				hysteresisMargin, parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -446,7 +446,9 @@ func EvaluateFailoverWithHysteresis(
 	if !allRecovered {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
-			Reason:     fmt.Sprintf("Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s", hysteresisDB, parseSuffix),
+			Reason: fmt.Sprintf(
+				"Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s",
+				hysteresisDB, parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -208,12 +208,13 @@ func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) trigge
 	for _, triggerStr := range triggers {
 		trigger, err := ParseTrigger(triggerStr)
 		if err != nil {
-			// Only count parse errors seen before (or without) a match,
-			// matching legacy short-circuit semantics for parseSuffix.
+			// Only count/log parse errors before first match,
+			// matching legacy short-circuit semantics.
 			if !result.anyTriggered {
 				parseErrors++
+				log.V(1).Info("invalid trigger expression",
+					"trigger", triggerStr, "error", err.Error())
 			}
-			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
 			continue
 		}
 		result.parsed = append(result.parsed, trigger)

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -368,7 +368,7 @@ func EvaluateFailoverWithHysteresis(
 
 	log := logr.FromContextOrDiscard(ctx)
 	log.V(2).Info("evaluate failover with hysteresis",
-		"hysteresisDB", hysteresisDB,
+		"hysteresisMargin", hysteresisDB,
 		"currentPath", currentPath,
 	)
 	finish := func(res FailoverResult) FailoverResult {
@@ -380,52 +380,63 @@ func EvaluateFailoverWithHysteresis(
 		return res
 	}
 
+	// Parse all triggers with error accounting (same as EvaluateFailoverWithContext).
+	anyTriggered := false
+	parseErrors := 0
+	var parsed []Trigger
+	for _, triggerStr := range triggers {
+		trigger, err := ParseTrigger(triggerStr)
+		if err != nil {
+			parseErrors++
+			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
+			continue
+		}
+		parsed = append(parsed, trigger)
+		if trigger.Evaluate(metrics) {
+			anyTriggered = true
+		}
+	}
+
+	parseSuffix := ""
+	if parseErrors > 0 {
+		if parseErrors == len(triggers) {
+			return finish(FailoverResult{
+				Decision:   DecisionStay,
+				Reason:     fmt.Sprintf("All %d trigger expressions are invalid", parseErrors),
+				TargetPath: currentPath,
+			})
+		}
+		parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
+	}
+
 	// Satellite pass ended — force switchback regardless of hysteresis.
 	if !satelliteAvailable {
-		anyTriggered := false
-		for _, ts := range triggers {
-			if t, err := ParseTrigger(ts); err == nil && t.Evaluate(metrics) {
-				anyTriggered = true
-				break
-			}
-		}
 		if anyTriggered {
 			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
-				Reason:     "Satellite pass ended, falling back to degraded terrestrial",
+				Reason:     "Satellite pass ended, falling back to degraded terrestrial" + parseSuffix,
 				TargetPath: PathTerrestrial,
 			})
 		}
 		return finish(FailoverResult{
 			Decision:   DecisionSwitchback,
-			Reason:     "Satellite pass ended, terrestrial recovered",
+			Reason:     "Satellite pass ended, terrestrial recovered" + parseSuffix,
 			TargetPath: PathTerrestrial,
 		})
 	}
 
-	// Check if ANY trigger is still firing (original thresholds).
-	for _, ts := range triggers {
-		t, err := ParseTrigger(ts)
-		if err != nil {
-			continue
-		}
-		if t.Evaluate(metrics) {
-			return finish(FailoverResult{
-				Decision:   DecisionStay,
-				Reason:     "Terrestrial still degraded, staying on satellite",
-				TargetPath: PathSatellite,
-			})
-		}
+	if anyTriggered {
+		return finish(FailoverResult{
+			Decision:   DecisionStay,
+			Reason:     "Terrestrial still degraded, staying on satellite" + parseSuffix,
+			TargetPath: PathSatellite,
+		})
 	}
 
 	// Triggers no longer firing at original thresholds.
-	// Check hysteresis: have ALL triggers recovered past the dead-band?
+	// Check hysteresis: have ALL valid triggers recovered past the dead-band?
 	allRecovered := true
-	for _, ts := range triggers {
-		t, err := ParseTrigger(ts)
-		if err != nil {
-			continue
-		}
+	for _, t := range parsed {
 		if !t.EvaluateRecovery(metrics, hysteresisDB) {
 			allRecovered = false
 			break
@@ -435,7 +446,7 @@ func EvaluateFailoverWithHysteresis(
 	if !allRecovered {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
-			Reason:     fmt.Sprintf("Terrestrial in hysteresis dead-band (margin=%.1f), staying on satellite", hysteresisDB),
+			Reason:     fmt.Sprintf("Terrestrial in hysteresis dead-band (margin=%g), staying on satellite%s", hysteresisDB, parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}
@@ -444,15 +455,15 @@ func EvaluateFailoverWithHysteresis(
 	if !lastFailover.IsZero() && now.Sub(lastFailover) < switchbackDelay {
 		return finish(FailoverResult{
 			Decision: DecisionStay,
-			Reason: fmt.Sprintf("Terrestrial recovered past dead-band but switchback delay not elapsed (%s remaining)",
-				switchbackDelay-now.Sub(lastFailover)),
+			Reason: fmt.Sprintf("Terrestrial recovered past dead-band but switchback delay not elapsed (%s remaining)%s",
+				switchbackDelay-now.Sub(lastFailover), parseSuffix),
 			TargetPath: PathSatellite,
 		})
 	}
 
 	return finish(FailoverResult{
 		Decision:   DecisionSwitchback,
-		Reason:     "Terrestrial recovered past hysteresis dead-band, switchback delay elapsed",
+		Reason:     "Terrestrial recovered past hysteresis dead-band, switchback delay elapsed" + parseSuffix,
 		TargetPath: PathTerrestrial,
 	})
 }

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -121,7 +121,13 @@ func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 	case "<", "<=":
 		return actual >= t.Value+margin
 	case ">", ">=":
-		return actual <= t.Value-margin
+		// Clamp recovery threshold to 0 for non-negative metrics
+		// (e.g., packetLoss > 5 with margin 10 → threshold 0, not -5).
+		recoveryThreshold := t.Value - margin
+		if recoveryThreshold < 0 {
+			recoveryThreshold = 0
+		}
+		return actual <= recoveryThreshold
 	default:
 		return false // unknown operator — fail-safe
 	}
@@ -202,7 +208,11 @@ func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) trigge
 	for _, triggerStr := range triggers {
 		trigger, err := ParseTrigger(triggerStr)
 		if err != nil {
-			parseErrors++
+			// Only count parse errors seen before (or without) a match,
+			// matching legacy short-circuit semantics for parseSuffix.
+			if !result.anyTriggered {
+				parseErrors++
+			}
 			log.V(1).Info("invalid trigger expression", "trigger", triggerStr, "error", err.Error())
 			continue
 		}
@@ -212,12 +222,12 @@ func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) trigge
 			log.V(2).Info("trigger matched", "trigger", triggerStr)
 		}
 	}
-	if parseErrors > 0 {
-		if parseErrors == len(triggers) {
-			result.allInvalid = true
-		} else {
-			result.parseSuffix = fmt.Sprintf(" (%d of %d triggers had parse errors)", parseErrors, len(triggers))
-		}
+	if len(result.parsed) == 0 && parseErrors > 0 {
+		result.allInvalid = true
+	} else if parseErrors > 0 {
+		result.parseSuffix = fmt.Sprintf(
+			" (%d of %d triggers had parse errors)",
+			parseErrors, len(triggers))
 	}
 	return result
 }

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -101,6 +101,36 @@ func ParseTrigger(s string) (Trigger, error) {
 	return Trigger{}, fmt.Errorf("invalid trigger format %q: expected 'metric operator value'", s)
 }
 
+// EvaluateRecovery checks if the trigger has recovered with hysteresis margin.
+// For "<"/"<=" triggers, recovery requires actual >= threshold + margin.
+// For ">"/">=" triggers, recovery requires actual <= threshold - margin.
+func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
+	var actual float64
+	switch t.Metric {
+	case "rsrp", "terrestrialRSRP":
+		actual = m.RSRP
+	case "latency", "terrestrialLatency":
+		actual = m.LatencyMs
+	case "packetLoss", "terrestrialPacketLoss":
+		actual = m.PacketLossPercent
+	default:
+		return true // unknown metric — assume recovered
+	}
+
+	switch t.Operator {
+	case "<":
+		return actual >= t.Value+margin
+	case "<=":
+		return actual > t.Value+margin
+	case ">":
+		return actual <= t.Value-margin
+	case ">=":
+		return actual < t.Value-margin
+	default:
+		return true
+	}
+}
+
 // Evaluate checks if a trigger condition is met given the current metrics.
 func (t Trigger) Evaluate(m Metrics) bool {
 	var actual float64
@@ -306,4 +336,123 @@ func EvaluateFailoverWithContext(
 			TargetPath: PathUnavailable,
 		})
 	}
+}
+
+// EvaluateFailoverWithHysteresis is like EvaluateFailoverWithContext but applies
+// a dead-band margin to trigger thresholds during switchback evaluation.
+//
+// During failover (terrestrial → satellite), triggers use their original thresholds.
+// During switchback (satellite → terrestrial), triggers require the metric to clear
+// the threshold by the hysteresis margin before considering recovery.
+//
+// Example: trigger "rsrp < -120" with hysteresisDB=10 means failover fires at
+// RSRP < -120 dBm, but switchback requires RSRP >= -110 dBm (10 dB dead-band).
+func EvaluateFailoverWithHysteresis(
+	ctx context.Context,
+	currentPath PathType,
+	triggers []string,
+	metrics Metrics,
+	satelliteAvailable bool,
+	switchbackDelay time.Duration,
+	lastFailover time.Time,
+	now time.Time,
+	hysteresisDB float64,
+) FailoverResult {
+	// If not on satellite or no hysteresis, delegate to the standard evaluator.
+	if currentPath != PathSatellite || hysteresisDB <= 0 {
+		return EvaluateFailoverWithContext(
+			ctx, currentPath, triggers, metrics,
+			satelliteAvailable, switchbackDelay, lastFailover, now,
+		)
+	}
+
+	log := logr.FromContextOrDiscard(ctx)
+	log.V(2).Info("evaluate failover with hysteresis",
+		"hysteresisDB", hysteresisDB,
+		"currentPath", currentPath,
+	)
+	finish := func(res FailoverResult) FailoverResult {
+		log.V(1).Info("failover decision (hysteresis)",
+			"decision", res.Decision,
+			"targetPath", res.TargetPath,
+			"reason", res.Reason,
+		)
+		return res
+	}
+
+	// Satellite pass ended — force switchback regardless of hysteresis.
+	if !satelliteAvailable {
+		anyTriggered := false
+		for _, ts := range triggers {
+			if t, err := ParseTrigger(ts); err == nil && t.Evaluate(metrics) {
+				anyTriggered = true
+				break
+			}
+		}
+		if anyTriggered {
+			return finish(FailoverResult{
+				Decision:   DecisionSwitchback,
+				Reason:     "Satellite pass ended, falling back to degraded terrestrial",
+				TargetPath: PathTerrestrial,
+			})
+		}
+		return finish(FailoverResult{
+			Decision:   DecisionSwitchback,
+			Reason:     "Satellite pass ended, terrestrial recovered",
+			TargetPath: PathTerrestrial,
+		})
+	}
+
+	// Check if ANY trigger is still firing (original thresholds).
+	for _, ts := range triggers {
+		t, err := ParseTrigger(ts)
+		if err != nil {
+			continue
+		}
+		if t.Evaluate(metrics) {
+			return finish(FailoverResult{
+				Decision:   DecisionStay,
+				Reason:     "Terrestrial still degraded, staying on satellite",
+				TargetPath: PathSatellite,
+			})
+		}
+	}
+
+	// Triggers no longer firing at original thresholds.
+	// Check hysteresis: have ALL triggers recovered past the dead-band?
+	allRecovered := true
+	for _, ts := range triggers {
+		t, err := ParseTrigger(ts)
+		if err != nil {
+			continue
+		}
+		if !t.EvaluateRecovery(metrics, hysteresisDB) {
+			allRecovered = false
+			break
+		}
+	}
+
+	if !allRecovered {
+		return finish(FailoverResult{
+			Decision:   DecisionStay,
+			Reason:     fmt.Sprintf("Terrestrial in hysteresis dead-band (margin=%.1f), staying on satellite", hysteresisDB),
+			TargetPath: PathSatellite,
+		})
+	}
+
+	// Recovered past dead-band — check switchback delay.
+	if !lastFailover.IsZero() && now.Sub(lastFailover) < switchbackDelay {
+		return finish(FailoverResult{
+			Decision: DecisionStay,
+			Reason: fmt.Sprintf("Terrestrial recovered past dead-band but switchback delay not elapsed (%s remaining)",
+				switchbackDelay-now.Sub(lastFailover)),
+			TargetPath: PathSatellite,
+		})
+	}
+
+	return finish(FailoverResult{
+		Decision:   DecisionSwitchback,
+		Reason:     "Terrestrial recovered past hysteresis dead-band, switchback delay elapsed",
+		TargetPath: PathTerrestrial,
+	})
 }

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -401,6 +401,38 @@ func TestEvaluateWithHysteresis_LatencyTrigger_DeadBand(t *testing.T) {
 	}
 }
 
+func TestEvaluateWithHysteresis_AllInvalidTriggers(t *testing.T) {
+	invalidTriggers := []string{"invalid", "also bad"}
+	got := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, invalidTriggers,
+		Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1},
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if got.Decision != DecisionStay {
+		t.Errorf("expected Stay for all invalid triggers, got %s", got.Decision)
+	}
+	if !strings.Contains(got.Reason, "invalid") {
+		t.Errorf("expected reason to mention invalid, got %q", got.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_MixedValidInvalidTriggers(t *testing.T) {
+	mixed := []string{"latency > 200", "rsrp << -120"} // second is invalid
+	got := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, mixed,
+		Metrics{RSRP: -90, LatencyMs: 250, PacketLossPercent: 0.1}, // latency still bad
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if got.Decision != DecisionStay {
+		t.Errorf("expected Stay (latency still degraded), got %s: %s", got.Decision, got.Reason)
+	}
+	if !strings.Contains(got.Reason, "parse error") {
+		t.Errorf("expected reason to mention parse errors, got %q", got.Reason)
+	}
+}
+
 func TestEvaluateWithHysteresis_PassEnds_ForceSwitchback(t *testing.T) {
 	// Even in dead-band, satellite pass ending forces switchback.
 	result := EvaluateFailoverWithHysteresis(

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -446,3 +446,77 @@ func TestEvaluateWithHysteresis_PassEnds_ForceSwitchback(t *testing.T) {
 		t.Errorf("expected Switchback (pass ended), got %s: %s", result.Decision, result.Reason)
 	}
 }
+
+func TestEvaluateWithHysteresis_MultipleTriggers_RequiresAllRecovered(t *testing.T) {
+	// rsrp recovered past dead-band (-109 >= -110), but latency still in dead-band:
+	// "latency > 200" with margin 10 → recovery at <= 190. Latency 195 > 190 → NOT recovered.
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite,
+		[]string{"rsrp < -120", "latency > 200"},
+		Metrics{RSRP: -109, LatencyMs: 195, PacketLossPercent: 0.1},
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if result.Decision != DecisionStay {
+		t.Errorf("expected Stay (not all triggers recovered), got %s: %s",
+			result.Decision, result.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_RSRPRecovery_BoundarySemantics(t *testing.T) {
+	t.Run("at recovery threshold stays", func(t *testing.T) {
+		// rsrp < -120, margin 10 → recovery at >= -110. At exactly -110: NOT recovered.
+		result := EvaluateFailoverWithHysteresis(
+			context.Background(),
+			PathSatellite, []string{"rsrp < -120"},
+			Metrics{RSRP: -110, LatencyMs: 20, PacketLossPercent: 0.1},
+			true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+		)
+		if result.Decision != DecisionSwitchback {
+			t.Errorf("expected Switchback at exact boundary, got %s: %s",
+				result.Decision, result.Reason)
+		}
+	})
+
+	t.Run("past recovery threshold switches back", func(t *testing.T) {
+		result := EvaluateFailoverWithHysteresis(
+			context.Background(),
+			PathSatellite, []string{"rsrp < -120"},
+			Metrics{RSRP: -109, LatencyMs: 20, PacketLossPercent: 0.1},
+			true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+		)
+		if result.Decision != DecisionSwitchback {
+			t.Errorf("expected Switchback past boundary, got %s: %s",
+				result.Decision, result.Reason)
+		}
+	})
+}
+
+func TestEvaluateWithHysteresis_LatencyRecovery_BoundarySemantics(t *testing.T) {
+	t.Run("at recovery threshold stays", func(t *testing.T) {
+		// latency > 200, margin 30 → recovery at <= 170. At exactly 170: recovered.
+		result := EvaluateFailoverWithHysteresis(
+			context.Background(),
+			PathSatellite, []string{"latency > 200"},
+			Metrics{RSRP: -90, LatencyMs: 170, PacketLossPercent: 0.1},
+			true, 60*time.Second, now.Add(-90*time.Second), now, 30,
+		)
+		if result.Decision != DecisionSwitchback {
+			t.Errorf("expected Switchback at exact boundary, got %s: %s",
+				result.Decision, result.Reason)
+		}
+	})
+
+	t.Run("past recovery threshold switches back", func(t *testing.T) {
+		result := EvaluateFailoverWithHysteresis(
+			context.Background(),
+			PathSatellite, []string{"latency > 200"},
+			Metrics{RSRP: -90, LatencyMs: 169, PacketLossPercent: 0.1},
+			true, 60*time.Second, now.Add(-90*time.Second), now, 30,
+		)
+		if result.Decision != DecisionSwitchback {
+			t.Errorf("expected Switchback past boundary, got %s: %s",
+				result.Decision, result.Reason)
+		}
+	})
+}

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -463,60 +463,36 @@ func TestEvaluateWithHysteresis_MultipleTriggers_RequiresAllRecovered(t *testing
 	}
 }
 
-func TestEvaluateWithHysteresis_RSRPRecovery_BoundarySemantics(t *testing.T) {
-	t.Run("at recovery threshold stays", func(t *testing.T) {
-		// rsrp < -120, margin 10 → recovery at >= -110. At exactly -110: NOT recovered.
-		result := EvaluateFailoverWithHysteresis(
-			context.Background(),
-			PathSatellite, []string{"rsrp < -120"},
-			Metrics{RSRP: -110, LatencyMs: 20, PacketLossPercent: 0.1},
-			true, 60*time.Second, now.Add(-90*time.Second), now, 10,
-		)
-		if result.Decision != DecisionSwitchback {
-			t.Errorf("expected Switchback at exact boundary, got %s: %s",
-				result.Decision, result.Reason)
-		}
-	})
-
-	t.Run("past recovery threshold switches back", func(t *testing.T) {
-		result := EvaluateFailoverWithHysteresis(
-			context.Background(),
-			PathSatellite, []string{"rsrp < -120"},
-			Metrics{RSRP: -109, LatencyMs: 20, PacketLossPercent: 0.1},
-			true, 60*time.Second, now.Add(-90*time.Second), now, 10,
-		)
-		if result.Decision != DecisionSwitchback {
-			t.Errorf("expected Switchback past boundary, got %s: %s",
-				result.Decision, result.Reason)
-		}
-	})
-}
-
-func TestEvaluateWithHysteresis_LatencyRecovery_BoundarySemantics(t *testing.T) {
-	t.Run("at recovery threshold stays", func(t *testing.T) {
-		// latency > 200, margin 30 → recovery at <= 170. At exactly 170: recovered.
-		result := EvaluateFailoverWithHysteresis(
-			context.Background(),
-			PathSatellite, []string{"latency > 200"},
-			Metrics{RSRP: -90, LatencyMs: 170, PacketLossPercent: 0.1},
-			true, 60*time.Second, now.Add(-90*time.Second), now, 30,
-		)
-		if result.Decision != DecisionSwitchback {
-			t.Errorf("expected Switchback at exact boundary, got %s: %s",
-				result.Decision, result.Reason)
-		}
-	})
-
-	t.Run("past recovery threshold switches back", func(t *testing.T) {
-		result := EvaluateFailoverWithHysteresis(
-			context.Background(),
-			PathSatellite, []string{"latency > 200"},
-			Metrics{RSRP: -90, LatencyMs: 169, PacketLossPercent: 0.1},
-			true, 60*time.Second, now.Add(-90*time.Second), now, 30,
-		)
-		if result.Decision != DecisionSwitchback {
-			t.Errorf("expected Switchback past boundary, got %s: %s",
-				result.Decision, result.Reason)
-		}
-	})
+func TestEvaluateWithHysteresis_RecoveryBoundarySemantics(t *testing.T) {
+	tests := []struct {
+		name     string
+		trigger  string
+		metrics  Metrics
+		margin   float64
+		wantDec  Decision
+	}{
+		// rsrp < -120, margin 10 → recovery at >= -110
+		{"rsrp at boundary", "rsrp < -120",
+			Metrics{RSRP: -110, LatencyMs: 20, PacketLossPercent: 0.1}, 10, DecisionSwitchback},
+		{"rsrp past boundary", "rsrp < -120",
+			Metrics{RSRP: -109, LatencyMs: 20, PacketLossPercent: 0.1}, 10, DecisionSwitchback},
+		// latency > 200, margin 30 → recovery at <= 170
+		{"latency at boundary", "latency > 200",
+			Metrics{RSRP: -90, LatencyMs: 170, PacketLossPercent: 0.1}, 30, DecisionSwitchback},
+		{"latency past boundary", "latency > 200",
+			Metrics{RSRP: -90, LatencyMs: 169, PacketLossPercent: 0.1}, 30, DecisionSwitchback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EvaluateFailoverWithHysteresis(
+				context.Background(),
+				PathSatellite, []string{tt.trigger}, tt.metrics,
+				true, 60*time.Second, now.Add(-90*time.Second), now, tt.margin,
+			)
+			if result.Decision != tt.wantDec {
+				t.Errorf("expected %s, got %s: %s",
+					tt.wantDec, result.Decision, result.Reason)
+			}
+		})
+	}
 }

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -465,11 +465,11 @@ func TestEvaluateWithHysteresis_MultipleTriggers_RequiresAllRecovered(t *testing
 
 func TestEvaluateWithHysteresis_RecoveryBoundarySemantics(t *testing.T) {
 	tests := []struct {
-		name     string
-		trigger  string
-		metrics  Metrics
-		margin   float64
-		wantDec  Decision
+		name    string
+		trigger string
+		metrics Metrics
+		margin  float64
+		wantDec Decision
 	}{
 		// rsrp < -120, margin 10 → recovery at >= -110
 		{"rsrp at boundary", "rsrp < -120",

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -471,10 +471,10 @@ func TestEvaluateWithHysteresis_RecoveryBoundarySemantics(t *testing.T) {
 		margin  float64
 		wantDec Decision
 	}{
-		// rsrp < -120, margin 10 → recovery at >= -110
-		{"rsrp at boundary", "rsrp < -120",
+		// rsrp < -120, margin 10 → recovery at >= -110, so exactly -110 triggers switchback
+		{"rsrp at inclusive recovery boundary", "rsrp < -120",
 			Metrics{RSRP: -110, LatencyMs: 20, PacketLossPercent: 0.1}, 10, DecisionSwitchback},
-		{"rsrp past boundary", "rsrp < -120",
+		{"rsrp beyond recovery boundary", "rsrp < -120",
 			Metrics{RSRP: -109, LatencyMs: 20, PacketLossPercent: 0.1}, 10, DecisionSwitchback},
 		// latency > 200, margin 30 → recovery at <= 170
 		{"latency at boundary", "latency > 200",

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -418,7 +418,8 @@ func TestEvaluateWithHysteresis_AllInvalidTriggers(t *testing.T) {
 }
 
 func TestEvaluateWithHysteresis_MixedValidInvalidTriggers(t *testing.T) {
-	mixed := []string{"latency > 200", "rsrp << -120"} // second is invalid
+	// Invalid trigger appears BEFORE the valid one → parse error counted.
+	mixed := []string{"rsrp << -120", "latency > 200"} // first is invalid
 	got := EvaluateFailoverWithHysteresis(
 		context.Background(),
 		PathSatellite, mixed,

--- a/pkg/slice/failover_test.go
+++ b/pkg/slice/failover_test.go
@@ -321,3 +321,96 @@ func TestEvaluateFailoverWithContext_MatchesLegacyBehavior(t *testing.T) {
 		t.Fatalf("EvaluateFailoverWithContext mismatch: got %+v want %+v", got, want)
 	}
 }
+
+// --- Hysteresis (dead-band) tests ---
+
+func TestEvaluateWithHysteresis_Failover_UsesOriginalThreshold(t *testing.T) {
+	// Trigger: rsrp < -120. RSRP = -125 → should failover (hysteresis doesn't affect failover direction).
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathTerrestrial, triggers,
+		Metrics{RSRP: -125, LatencyMs: 20, PacketLossPercent: 0.1},
+		true, 60*time.Second, time.Time{}, now, 10,
+	)
+	if result.Decision != DecisionFailover {
+		t.Errorf("expected Failover, got %s: %s", result.Decision, result.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_Switchback_InDeadBand_Stay(t *testing.T) {
+	// Single trigger: rsrp < -120, hysteresis = 10 dB.
+	// RSRP = -115 → above trigger (-120) but below recovery threshold (-110).
+	// Should STAY on satellite (in dead-band).
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, []string{"rsrp < -120"},
+		Metrics{RSRP: -115, LatencyMs: 20, PacketLossPercent: 0.1},
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if result.Decision != DecisionStay {
+		t.Errorf("expected Stay (in hysteresis dead-band), got %s: %s", result.Decision, result.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_Switchback_AboveDeadBand_Switchback(t *testing.T) {
+	// Single trigger: rsrp < -120, hysteresis = 10 dB.
+	// RSRP = -105 → above recovery threshold (-110).
+	// Should SWITCHBACK.
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, []string{"rsrp < -120"},
+		Metrics{RSRP: -105, LatencyMs: 20, PacketLossPercent: 0.1},
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if result.Decision != DecisionSwitchback {
+		t.Errorf("expected Switchback (above dead-band), got %s: %s", result.Decision, result.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_ZeroMargin_SameAsOriginal(t *testing.T) {
+	// With hysteresis=0, behavior should match non-hysteresis version.
+	metrics := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
+	want := EvaluateFailoverWithContext(
+		context.Background(),
+		PathSatellite, triggers, metrics,
+		true, 60*time.Second, now.Add(-90*time.Second), now,
+	)
+	got := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, triggers, metrics,
+		true, 60*time.Second, now.Add(-90*time.Second), now, 0,
+	)
+	if got.Decision != want.Decision || got.TargetPath != want.TargetPath {
+		t.Errorf("zero hysteresis should match original: got %+v want %+v", got, want)
+	}
+}
+
+func TestEvaluateWithHysteresis_LatencyTrigger_DeadBand(t *testing.T) {
+	// Trigger: latency > 200, hysteresis = 30.
+	// On satellite, latency = 185 → below trigger (200) but above recovery (170).
+	// Should STAY (in dead-band).
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite,
+		[]string{"latency > 200"},
+		Metrics{RSRP: -90, LatencyMs: 185, PacketLossPercent: 0.1},
+		true, 60*time.Second, now.Add(-90*time.Second), now, 30,
+	)
+	if result.Decision != DecisionStay {
+		t.Errorf("expected Stay (latency in dead-band), got %s: %s", result.Decision, result.Reason)
+	}
+}
+
+func TestEvaluateWithHysteresis_PassEnds_ForceSwitchback(t *testing.T) {
+	// Even in dead-band, satellite pass ending forces switchback.
+	result := EvaluateFailoverWithHysteresis(
+		context.Background(),
+		PathSatellite, []string{"rsrp < -120"},
+		Metrics{RSRP: -115, LatencyMs: 20, PacketLossPercent: 0.1},
+		false, // satellite pass ended
+		60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if result.Decision != DecisionSwitchback {
+		t.Errorf("expected Switchback (pass ended), got %s: %s", result.Decision, result.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

Add signal quality hysteresis (dead-band) to the failover engine to prevent flapping when metrics oscillate near trigger thresholds.

Closes #50

## How it works

| Phase | Threshold | Example (rsrp < -120, margin=10) |
|-------|-----------|----------------------------------|
| Failover | Original | RSRP < -120 dBm → failover |
| Dead zone | Between thresholds | -120 ≤ RSRP < -110 → stay on satellite |
| Switchback | Original + margin | RSRP ≥ -110 dBm → switchback |

- Hysteresis only applies during **switchback evaluation** (satellite → terrestrial)
- Failover direction uses original trigger thresholds (no change)
- Satellite pass ending still forces immediate switchback regardless of dead-band
- Zero margin produces identical behavior to the existing engine

## Changes

- api/v1alpha1/ntnslice_types.go — add FailoverPolicy.HysteresisMargin field (JSON: hysteresisMargin)
- pkg/slice/failover.go — add EvaluateRecovery(), EvaluateFailoverWithHysteresis()
- pkg/slice/failover_test.go — 13 new TDD tests (boundary, multi-trigger, invalid, dead-band)
- internal/controller/ntnslice_controller.go — wire hysteresisMargin into reconcile loop

## Test plan

- [x] go test ./pkg/slice/ -v — 33/33 pass (20 existing + 13 new)
- [x] Zero-margin equivalence test confirms backward compatibility
- [x] Dead-band tests for both < (RSRP) and > (latency) operators
- [x] Boundary semantics at exact recovery threshold
- [x] Multi-trigger requires ALL recovered
- [x] Invalid trigger parse error handling matches legacy behavior