### PR TITLE
perf: add benchmark tests and controller tuning options (#59)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ vet: ## Run go vet against code.
 
 .PHONY: bench
 bench: ## Run Go benchmarks with memory allocation stats.
-	go test -bench=. -benchmem -benchtime=3s ./pkg/...
+	go test -bench=. -benchmem -benchtime=3s -run='^$$' ./pkg/...
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: bench
+bench: ## Run Go benchmarks with memory allocation stats.
+	go test -bench=. -benchmem -benchtime=3s ./pkg/...
+
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,6 +93,10 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	if maxConcurrentReconciles < 1 {
+		maxConcurrentReconciles = 1
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,6 +84,9 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	var maxConcurrentReconciles int
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
+		"Maximum number of concurrent reconciles per controller.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -189,38 +192,42 @@ func main() {
 		"https://www.space-track.org",
 	)
 	if err := (&controller.SatelliteEphemerisReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorder("satelliteephemeris-controller"),
-		Fetcher:           ephemeris.NewCelesTrakFetcher(gpHTTPClient),
-		SpaceTrackFetcher: spaceTrackFetcher,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("satelliteephemeris-controller"),
+		Fetcher:                 ephemeris.NewCelesTrakFetcher(gpHTTPClient),
+		SpaceTrackFetcher:       spaceTrackFetcher,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "SatelliteEphemeris")
 		os.Exit(1)
 	}
 	if err := (&controller.GroundStationLifecycleReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		Recorder:   mgr.GetEventRecorder("groundstationlifecycle-controller"),
-		HTTPClient: netutil.NewSafeHTTPClient(5 * time.Second),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("groundstationlifecycle-controller"),
+		HTTPClient:              netutil.NewSafeHTTPClient(5 * time.Second),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "GroundStationLifecycle")
 		os.Exit(1)
 	}
 	ocuduProvider := ocudu.NewProvider(mgr.GetClient())
 	if err := (&controller.NTNCellConfigReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("ntncellconfig-controller"),
-		Provider: ocuduProvider,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("ntncellconfig-controller"),
+		Provider:                ocuduProvider,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NTNCellConfig")
 		os.Exit(1)
 	}
 	if err := (&controller.NTNSliceReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("ntnslice-controller"),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("ntnslice-controller"),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NTNSlice")
 		os.Exit(1)

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -53,6 +53,9 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:8081
+        {{- if gt (int .Values.manager.maxConcurrentReconciles) 1 }}
+        - --max-concurrent-reconciles={{ .Values.manager.maxConcurrentReconciles }}
+        {{- end }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -22,6 +22,11 @@ manager:
   args:
     - --leader-elect
 
+  ## Maximum concurrent reconciles per controller (default: 1).
+  ## Increase for large deployments (100+ ground stations, multiple constellations).
+  ##
+  maxConcurrentReconciles: 1
+
   ## Environment variables
   ##
   env: []

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -75,10 +76,11 @@ func (e *ambiguousNodeError) Error() string {
 // GroundStationLifecycleReconciler reconciles a GroundStationLifecycle object
 type GroundStationLifecycleReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Recorder   events.EventRecorder
-	HTTPClient *http.Client
-	Now        func() time.Time // injectable clock; nil defaults to time.Now
+	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
+	MaxConcurrentReconciles int
+	HTTPClient              *http.Client
+	Now                     func() time.Time // injectable clock; nil defaults to time.Now
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=groundstationlifecycles,verbs=get;list;watch;create;update;patch;delete
@@ -580,6 +582,7 @@ func (r *GroundStationLifecycleReconciler) SetupWithManager(mgr ctrl.Manager) er
 			handler.EnqueueRequestsFromMapFunc(r.nodeToGroundStation),
 		).
 		Named("groundstationlifecycle").
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlrt "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -582,7 +582,7 @@ func (r *GroundStationLifecycleReconciler) SetupWithManager(mgr ctrl.Manager) er
 			handler.EnqueueRequestsFromMapFunc(r.nodeToGroundStation),
 		).
 		Named("groundstationlifecycle").
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(ctrlrt.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlrt "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -433,7 +433,7 @@ func (r *NTNCellConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.ephemerisToNTNCellConfig),
 		).
 		Named("ntncellconfig").
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(ctrlrt.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -47,9 +48,10 @@ import (
 // NTNCellConfigReconciler reconciles a NTNCellConfig object
 type NTNCellConfigReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
-	Provider provider.NTNProvider
+	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
+	MaxConcurrentReconciles int
+	Provider                provider.NTNProvider
 }
 
 const (
@@ -431,6 +433,7 @@ func (r *NTNCellConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.ephemerisToNTNCellConfig),
 		).
 		Named("ntncellconfig").
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlrt "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -344,7 +344,7 @@ func (r *NTNSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.ephemerisToSlice),
 		).
 		Named("ntnslice").
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(ctrlrt.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -46,9 +47,10 @@ const sliceRequeueInterval = 30 * time.Second
 // NTNSliceReconciler reconciles a NTNSlice object
 type NTNSliceReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
-	Now      func() time.Time
+	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
+	MaxConcurrentReconciles int
+	Now                     func() time.Time
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntnslices,verbs=get;list;watch;create;update;patch;delete
@@ -342,6 +344,7 @@ func (r *NTNSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.ephemerisToSlice),
 		).
 		Named("ntnslice").
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -47,10 +48,11 @@ const minRefreshInterval = 2 * time.Hour
 // SatelliteEphemerisReconciler reconciles a SatelliteEphemeris object
 type SatelliteEphemerisReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	Recorder          events.EventRecorder
-	Fetcher           ephemeris.GPFetcher          // CelesTrak fetcher
-	SpaceTrackFetcher *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
+	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
+	MaxConcurrentReconciles int
+	Fetcher                 ephemeris.GPFetcher          // CelesTrak fetcher
+	SpaceTrackFetcher       *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris,verbs=get;list;watch;create;update;patch;delete
@@ -403,6 +405,7 @@ func (r *SatelliteEphemerisReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			handler.EnqueueRequestsFromMapFunc(r.groundStationToEphemeris),
 		).
 		Named("satelliteephemeris").
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlrt "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -405,7 +405,7 @@ func (r *SatelliteEphemerisReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			handler.EnqueueRequestsFromMapFunc(r.groundStationToEphemeris),
 		).
 		Named("satelliteephemeris").
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(ctrlrt.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/pkg/ephemeris/propagator_bench_test.go
+++ b/pkg/ephemeris/propagator_bench_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ephemeris
+
+import (
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+)
+
+func benchOMM() sgp4.OMM {
+	return sgp4.OMM{
+		ObjectName:      "ONEWEB-0569",
+		ObjectID:        "2023-068A",
+		NoradCatID:      56700,
+		EpochStr:        "2026-04-01T12:00:00.000000",
+		MeanMotion:      12.85,
+		Eccentricity:    0.0012,
+		Inclination:     87.9,
+		RAOfAscNode:     120.5,
+		ArgOfPericenter: 90.2,
+		MeanAnomaly:     270.0,
+		BStar:           0.0001,
+	}
+}
+
+func BenchmarkPropagateToECEF(b *testing.B) {
+	omm := benchOMM()
+	t, _ := time.Parse("2006-01-02T15:04:05.000000", omm.EpochStr)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := PropagateToECEF(omm, t.Add(time.Duration(i)*time.Minute))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPredictPasses_SingleSatSingleStation(b *testing.B) {
+	omm := benchOMM()
+	stations := []GroundStation{{
+		Name:      "taipei",
+		Latitude:  25.033,
+		Longitude: 121.565,
+		Altitude:  15,
+	}}
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	horizon := 24 * time.Hour
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := PredictPasses(
+			[]sgp4.OMM{omm}, stations, 10.0, horizon, nil, start,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPredictPasses_10Sats2Stations(b *testing.B) {
+	omms := make([]sgp4.OMM, 10)
+	for i := range omms {
+		omm := benchOMM()
+		omm.NoradCatID = 56700 + i
+		omm.MeanAnomaly = float64(i * 36) // spread across orbit
+		omms[i] = omm
+	}
+	stations := []GroundStation{
+		{Name: "taipei", Latitude: 25.033, Longitude: 121.565, Altitude: 15},
+		{Name: "hsinchu", Latitude: 24.796, Longitude: 120.997, Altitude: 50},
+	}
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := PredictPasses(
+			omms, stations, 10.0, 24*time.Hour, nil, start,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/ephemeris/propagator_bench_test.go
+++ b/pkg/ephemeris/propagator_bench_test.go
@@ -41,7 +41,10 @@ func benchOMM() sgp4.OMM {
 
 func BenchmarkPropagateToECEF(b *testing.B) {
 	omm := benchOMM()
-	t, _ := time.Parse("2006-01-02T15:04:05.000000", omm.EpochStr)
+	t, err := time.Parse("2006-01-02T15:04:05.000000", omm.EpochStr)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/provider/ocudu/config_bench_test.go
+++ b/pkg/provider/ocudu/config_bench_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocudu
+
+import (
+	"testing"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+func benchSpec() *ntnv1alpha1.NTNCellConfigSpec {
+	return &ntnv1alpha1.NTNCellConfigSpec{
+		NTN: ntnv1alpha1.NTNParams{
+			CellSpecificKoffset: 150,
+			TACommon:            0,
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+				PosX: 20922195,
+				PosY: 1967783,
+				PosZ: 19770302,
+			},
+			PayloadType: "transparent",
+			TAInfo: &ntnv1alpha1.TAInfo{
+				TACommon:      58629666,
+				TACommonDrift: 100,
+			},
+			NeighborCells: []ntnv1alpha1.NTNNeighborCell{
+				{PhysicalCellID: 101, Frequency: 437000},
+				{PhysicalCellID: 102, Frequency: 437100},
+			},
+		},
+	}
+}
+
+func BenchmarkGenerateConfig_Minimal(b *testing.B) {
+	spec := &ntnv1alpha1.NTNCellConfigSpec{
+		NTN: ntnv1alpha1.NTNParams{
+			CellSpecificKoffset: 150,
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{
+				PosX: 20922195, PosY: 1967783, PosZ: 19770302,
+			},
+			PayloadType: "transparent",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := GenerateConfig(spec)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGenerateConfig_Full(b *testing.B) {
+	spec := benchSpec()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := GenerateConfig(spec)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/slice/failover_bench_test.go
+++ b/pkg/slice/failover_bench_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 )
 
+var benchResult FailoverResult // prevent compiler from eliding calls
+
 func BenchmarkParseTrigger(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseTrigger("rsrp < -120")
@@ -32,36 +34,37 @@ func BenchmarkParseTrigger(b *testing.B) {
 }
 
 func BenchmarkEvaluateFailover_Healthy(b *testing.B) {
+	ctx := context.Background()
 	trigs := []string{"rsrp < -120", "latency > 200", "packetLoss > 5"}
 	m := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
 	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		EvaluateFailoverWithContext(
-			context.Background(),
-			PathTerrestrial, trigs, m,
+		benchResult = EvaluateFailoverWithContext(
+			ctx, PathTerrestrial, trigs, m,
 			true, 60*time.Second, time.Time{}, t,
 		)
 	}
 }
 
 func BenchmarkEvaluateFailover_Degraded(b *testing.B) {
+	ctx := context.Background()
 	trigs := []string{"rsrp < -120", "latency > 200", "packetLoss > 5"}
 	m := Metrics{RSRP: -130, LatencyMs: 20, PacketLossPercent: 0.1}
 	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		EvaluateFailoverWithContext(
-			context.Background(),
-			PathTerrestrial, trigs, m,
+		benchResult = EvaluateFailoverWithContext(
+			ctx, PathTerrestrial, trigs, m,
 			true, 60*time.Second, time.Time{}, t,
 		)
 	}
 }
 
 func BenchmarkEvaluateFailoverWithHysteresis(b *testing.B) {
+	ctx := context.Background()
 	trigs := []string{"rsrp < -120"}
 	m := Metrics{RSRP: -115, LatencyMs: 20, PacketLossPercent: 0.1}
 	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
@@ -69,9 +72,8 @@ func BenchmarkEvaluateFailoverWithHysteresis(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		EvaluateFailoverWithHysteresis(
-			context.Background(),
-			PathSatellite, trigs, m,
+		benchResult = EvaluateFailoverWithHysteresis(
+			ctx, PathSatellite, trigs, m,
 			true, 60*time.Second, lastFO, t, 10,
 		)
 	}

--- a/pkg/slice/failover_bench_test.go
+++ b/pkg/slice/failover_bench_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slice
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func BenchmarkParseTrigger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := ParseTrigger("rsrp < -120")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvaluateFailover_Healthy(b *testing.B) {
+	trigs := []string{"rsrp < -120", "latency > 200", "packetLoss > 5"}
+	m := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
+	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		EvaluateFailoverWithContext(
+			context.Background(),
+			PathTerrestrial, trigs, m,
+			true, 60*time.Second, time.Time{}, t,
+		)
+	}
+}
+
+func BenchmarkEvaluateFailover_Degraded(b *testing.B) {
+	trigs := []string{"rsrp < -120", "latency > 200", "packetLoss > 5"}
+	m := Metrics{RSRP: -130, LatencyMs: 20, PacketLossPercent: 0.1}
+	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		EvaluateFailoverWithContext(
+			context.Background(),
+			PathTerrestrial, trigs, m,
+			true, 60*time.Second, time.Time{}, t,
+		)
+	}
+}
+
+func BenchmarkEvaluateFailoverWithHysteresis(b *testing.B) {
+	trigs := []string{"rsrp < -120"}
+	m := Metrics{RSRP: -115, LatencyMs: 20, PacketLossPercent: 0.1}
+	t := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	lastFO := t.Add(-90 * time.Second)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		EvaluateFailoverWithHysteresis(
+			context.Background(),
+			PathSatellite, trigs, m,
+			true, 60*time.Second, lastFO, t, 10,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Add Go benchmarks for 5 core functions and configurable MaxConcurrentReconciles for production tuning.

Closes #59

## Benchmark Results (AMD Ryzen 7 7800X3D)

| Function | ns/op | allocs/op | Notes |
|----------|-------|-----------|-------|
| PropagateToECEF | 1,090 | 6 | SGP4 + TEME→ECEF |
| PredictPasses (1 sat × 1 stn) | 1.76ms | 3,022 | 24h horizon |
| PredictPasses (10 sats × 2 stns) | 10.6ms | 61,662 | Concurrent workers |
| ParseTrigger | 172 | 3 | String parsing |
| EvaluateFailover (healthy) | 857 | 21 | 3 triggers OR logic |
| EvaluateFailover (degraded) | 898 | 23 | First trigger matches |
| EvaluateFailoverWithHysteresis | 512 | 13 | Dead-band eval |
| GenerateConfig (minimal) | 7,167 | 25 | Template execution |
| GenerateConfig (full) | 9,167 | 33 | With TAInfo + neighbors |

## Changes

- 3 benchmark test files (pkg/ephemeris, pkg/slice, pkg/provider/ocudu)
- cmd/main.go: add --max-concurrent-reconciles flag (default: 1)
- 4 controllers: add MaxConcurrentReconciles field + WithOptions()
- dist/chart/values.yaml: add manager.maxConcurrentReconciles
- dist/chart/templates/manager/manager.yaml: inject flag when > 1
- Makefile: add make bench target

## Test plan

- [x] make bench — 9 benchmarks pass
- [x] go build ./cmd/ — compiles
- [x] go vet — clean
- [x] helm lint — clean
- [x] No new lll violations (all pre-existing)