### PR TITLE
refactor: decouple controller from OCUDU provider — enable multi-provider support (#72)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/thc1006/ntn-operators/internal/controller"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
 	"github.com/thc1006/ntn-operators/pkg/netutil"
+	"github.com/thc1006/ntn-operators/pkg/provider"
 	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
 	// +kubebuilder:scaffold:imports
 )
@@ -207,12 +208,14 @@ func main() {
 		setupLog.Error(err, "Failed to create controller", "controller", "GroundStationLifecycle")
 		os.Exit(1)
 	}
-	ocuduProvider := ocudu.NewProvider(mgr.GetClient())
+	providers := map[string]provider.NTNProvider{
+		"ocudu": ocudu.NewProvider(mgr.GetClient()),
+	}
 	if err := (&controller.NTNCellConfigReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("ntncellconfig-controller"),
-		Provider: ocuduProvider,
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorder("ntncellconfig-controller"),
+		Providers: providers,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NTNCellConfig")
 		os.Exit(1)

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -194,8 +194,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			"config": cc.Name, "provider": spec.Provider.Type,
 		}).Inc()
 		cc.Status.AppliedKoffset = 0
-		// Preserve ConfigMapRef for best-effort finalizer cleanup (artifact may exist).
-		cc.Status.ConfigMapRef = prov.ConfigMapName(cc.Name)
+		// Preserve existing ConfigMapRef for best-effort finalizer cleanup.
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -212,22 +211,9 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// Step 5b: Ensure OwnerReference on ConfigMap for garbage collection.
-	cm := &corev1.ConfigMap{}
-	cmKey := client.ObjectKey{
-		Namespace: cc.Namespace,
-		Name:      prov.ConfigMapName(cc.Name),
-	}
-	if err := r.Get(ctx, cmKey, cm); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			log.Error(err, "failed to get ConfigMap for OwnerReference", "configmap", cmKey)
-		}
-	} else if !metav1.IsControlledBy(cm, cc) {
-		if err := controllerutil.SetControllerReference(cc, cm, r.Scheme); err != nil {
-			log.Error(err, "failed to set OwnerReference on ConfigMap", "namespace", cm.Namespace, "name", cm.Name)
-		} else if err := r.Update(ctx, cm); err != nil {
-			log.Error(err, "failed to update ConfigMap with OwnerReference", "namespace", cm.Namespace, "name", cm.Name)
-		}
+	// Step 5b: Ensure ownership on provider artifact for garbage collection.
+	if err := prov.EnsureOwnership(ctx, cc.Name, cc, r.Scheme); err != nil {
+		log.Error(err, "failed to ensure ownership on provider artifact")
 	}
 
 	// Step 6: Get applied status from provider.
@@ -353,22 +339,9 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 				controllerutil.RemoveFinalizer(cc, finalizerName)
 				return true, ctrl.Result{}, r.Update(ctx, cc)
 			}
-			cm := &corev1.ConfigMap{}
-			cmKey := client.ObjectKey{
-				Namespace: cc.Namespace,
-				Name:      prov.ConfigMapName(cc.Name),
-			}
-			if err := r.Get(ctx, cmKey, cm); err != nil {
-				if client.IgnoreNotFound(err) != nil {
-					log.Error(err, "Failed to get ConfigMap during finalization")
-					return true, ctrl.Result{}, err
-				}
-			} else {
-				if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
-					log.Error(err, "Failed to delete ConfigMap during finalization")
-					return true, ctrl.Result{}, err
-				}
-				log.Info("Deleted ConfigMap during finalization", "configmap", cmKey)
+			if err := prov.Cleanup(ctx, cc.Name, cc.Namespace); err != nil {
+				log.Error(err, "Failed to cleanup provider artifact during finalization")
+				return true, ctrl.Result{}, err
 			}
 			controllerutil.RemoveFinalizer(cc, finalizerName)
 			if err := r.Update(ctx, cc); err != nil {

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -143,8 +143,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Step 4: Validate provider.
 	if r.Providers == nil {
-		cc.Status.AppliedKoffset = 0
-		cc.Status.ConfigMapRef = ""
+		// Preserve ConfigMapRef for best-effort finalizer cleanup.
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -158,8 +157,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 	if prov == nil {
-		cc.Status.AppliedKoffset = 0
-		cc.Status.ConfigMapRef = ""
+		// Preserve ConfigMapRef for best-effort finalizer cleanup.
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -326,7 +324,12 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 						"configMapRef", cc.Status.ConfigMapRef)
 					cm := &corev1.ConfigMap{}
 					cmKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Status.ConfigMapRef}
-					if err := r.Get(ctx, cmKey, cm); err == nil {
+					if err := r.Get(ctx, cmKey, cm); err != nil {
+						if client.IgnoreNotFound(err) != nil {
+							log.Error(err, "Failed to get ConfigMap via configMapRef during best-effort finalization",
+								"configmap", cmKey)
+						}
+					} else {
 						if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
 							log.Error(err, "Failed to delete ConfigMap via configMapRef")
 						}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -41,15 +41,15 @@ import (
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
 	"github.com/thc1006/ntn-operators/pkg/provider"
-	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
 )
 
 // NTNCellConfigReconciler reconciles a NTNCellConfig object
 type NTNCellConfigReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
-	Provider provider.NTNProvider
+	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
+	Providers               map[string]provider.NTNProvider
+	MaxConcurrentReconciles int
 }
 
 const (
@@ -132,20 +132,17 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Step 2: Handle finalizer for ConfigMap cleanup on deletion.
-	if done, result, err := r.handleFinalizer(ctx, cc); done {
-		return result, err
-	}
-
-	// Step 3: Guard against nil provider.
-	if r.Provider == nil {
+	// Step 2: Look up provider from registry.
+	prov, provOK := r.Providers[cc.Spec.Provider.Type]
+	if !provOK && r.Providers == nil {
+		// Guard against nil registry (misconfigured controller).
 		cc.Status.AppliedKoffset = 0
 		cc.Status.ConfigMapRef = ""
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
 			Reason:             "InternalError",
-			Message:            "NTN provider is not configured",
+			Message:            "NTN provider registry is not configured",
 			ObservedGeneration: cc.Generation,
 		})
 		if err := r.Status().Update(ctx, cc); err != nil {
@@ -154,15 +151,18 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// Step 3: Validate provider type.
-	if cc.Spec.Provider.Type != "ocudu" {
+	// Step 3: Handle finalizer for ConfigMap cleanup on deletion.
+	if done, result, err := r.handleFinalizer(ctx, cc, prov); done {
+		return result, err
+	}
+	if !provOK {
 		cc.Status.AppliedKoffset = 0
 		cc.Status.ConfigMapRef = ""
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
 			Reason:             "UnsupportedProvider",
-			Message:            fmt.Sprintf("Provider type %q is not yet supported; only 'ocudu' is available", cc.Spec.Provider.Type),
+			Message:            fmt.Sprintf("Provider type %q is not registered", cc.Spec.Provider.Type),
 			ObservedGeneration: cc.Generation,
 		})
 		if err := r.Status().Update(ctx, cc); err != nil {
@@ -184,7 +184,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		"provider", spec.Provider.Type,
 		"koffset", spec.NTN.CellSpecificKoffset)
 
-	if err := r.Provider.ApplyCellConfig(ctx, cc.Name, spec); err != nil {
+	if err := prov.ApplyCellConfig(ctx, cc.Name, spec); err != nil {
 		log.Error(err, "Failed to apply cell config")
 		ntnmetrics.ConfigApplyErrorsTotal.With(prometheus.Labels{
 			"config": cc.Name, "provider": spec.Provider.Type,
@@ -211,7 +211,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	cm := &corev1.ConfigMap{}
 	cmKey := client.ObjectKey{
 		Namespace: cc.Namespace,
-		Name:      ocudu.ConfigMapNameFor(cc.Name),
+		Name:      prov.ArtifactName(cc.Name),
 	}
 	if err := r.Get(ctx, cmKey, cm); err == nil {
 		if !metav1.IsControlledBy(cm, cc) {
@@ -224,7 +224,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Step 6: Get applied status from provider.
-	status, err := r.Provider.GetCellStatus(ctx, cc.Name, spec.Provider.Namespace)
+	status, err := prov.GetCellStatus(ctx, cc.Name, spec.Provider.Namespace)
 	if err != nil {
 		log.Error(err, "failed to get cell status after apply")
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
@@ -256,7 +256,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if cc.Spec.EphemerisRef == "" {
 		meta.RemoveStatusCondition(&cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
 	} else {
-		pushed, marker, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec)
+		pushed, marker, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec, prov)
 		if err != nil {
 			pushErr := err
 			log.Error(pushErr, "failed to push ephemeris update")
@@ -310,17 +310,23 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // handleFinalizer manages ConfigMap cleanup on NTNCellConfig deletion.
 // Returns (done, result, error). If done is true, the caller should return.
 func (r *NTNCellConfigReconciler) handleFinalizer(
-	ctx context.Context, cc *ntnv1alpha1.NTNCellConfig,
+	ctx context.Context, cc *ntnv1alpha1.NTNCellConfig, prov provider.NTNProvider,
 ) (bool, ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	finalizerName := "ntn.operators.dev/configmap-cleanup"
 
 	if cc.DeletionTimestamp != nil {
 		if controllerutil.ContainsFinalizer(cc, finalizerName) {
+			if prov == nil {
+				log.Info("Provider not in registry during deletion; removing finalizer without cleanup",
+					"providerType", cc.Spec.Provider.Type)
+				controllerutil.RemoveFinalizer(cc, finalizerName)
+				return true, ctrl.Result{}, r.Update(ctx, cc)
+			}
 			cm := &corev1.ConfigMap{}
 			cmKey := client.ObjectKey{
 				Namespace: cc.Namespace,
-				Name:      ocudu.ConfigMapNameFor(cc.Name),
+				Name:      prov.ArtifactName(cc.Name),
 			}
 			if err := r.Get(ctx, cmKey, cm); err != nil {
 				if client.IgnoreNotFound(err) != nil {
@@ -358,6 +364,7 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	ctx context.Context,
 	cc *ntnv1alpha1.NTNCellConfig,
 	spec *ntnv1alpha1.NTNCellConfigSpec,
+	prov provider.NTNProvider,
 ) (bool, string, error) {
 	if spec.EphemerisRef == "" {
 		return false, "", nil
@@ -393,7 +400,7 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 		)
 	}
 
-	if err := r.Provider.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
+	if err := prov.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
 		return false, marker, newEphemerisPushError(
 			ephemerisReasonProviderPushFailed,
 			fmt.Errorf("provider PushEphemerisUpdate: %w", err),

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -217,13 +217,15 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		Namespace: cc.Namespace,
 		Name:      prov.ConfigMapName(cc.Name),
 	}
-	if err := r.Get(ctx, cmKey, cm); err == nil {
-		if !metav1.IsControlledBy(cm, cc) {
-			if err := controllerutil.SetControllerReference(cc, cm, r.Scheme); err != nil {
-				log.Error(err, "failed to set OwnerReference on ConfigMap", "namespace", cm.Namespace, "name", cm.Name)
-			} else if err := r.Update(ctx, cm); err != nil {
-				log.Error(err, "failed to update ConfigMap with OwnerReference", "namespace", cm.Namespace, "name", cm.Name)
-			}
+	if err := r.Get(ctx, cmKey, cm); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			log.Error(err, "failed to get ConfigMap for OwnerReference", "configmap", cmKey)
+		}
+	} else if !metav1.IsControlledBy(cm, cc) {
+		if err := controllerutil.SetControllerReference(cc, cm, r.Scheme); err != nil {
+			log.Error(err, "failed to set OwnerReference on ConfigMap", "namespace", cm.Namespace, "name", cm.Name)
+		} else if err := r.Update(ctx, cm); err != nil {
+			log.Error(err, "failed to update ConfigMap with OwnerReference", "namespace", cm.Namespace, "name", cm.Name)
 		}
 	}
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -320,8 +320,21 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 	if cc.DeletionTimestamp != nil {
 		if controllerutil.ContainsFinalizer(cc, finalizerName) {
 			if prov == nil {
-				log.Info("Provider not in registry during deletion; removing finalizer without cleanup",
-					"providerType", cc.Spec.Provider.Type)
+				// Best-effort cleanup using Status.ConfigMapRef when provider is missing.
+				if cc.Status.ConfigMapRef != "" {
+					log.Info("Provider not in registry; attempting cleanup via status.configMapRef",
+						"configMapRef", cc.Status.ConfigMapRef)
+					cm := &corev1.ConfigMap{}
+					cmKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Status.ConfigMapRef}
+					if err := r.Get(ctx, cmKey, cm); err == nil {
+						if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
+							log.Error(err, "Failed to delete ConfigMap via configMapRef")
+						}
+					}
+				} else {
+					log.Info("Provider not in registry and no configMapRef; removing finalizer without cleanup",
+						"providerType", cc.Spec.Provider.Type)
+				}
 				controllerutil.RemoveFinalizer(cc, finalizerName)
 				return true, ctrl.Result{}, r.Update(ctx, cc)
 			}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -133,8 +133,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Step 2: Look up provider from registry.
-	prov, provOK := r.Providers[cc.Spec.Provider.Type]
-	if !provOK && r.Providers == nil {
+	prov := r.Providers[cc.Spec.Provider.Type]
+	if r.Providers == nil {
 		// Guard against nil registry (misconfigured controller).
 		cc.Status.AppliedKoffset = 0
 		cc.Status.ConfigMapRef = ""
@@ -155,7 +155,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if done, result, err := r.handleFinalizer(ctx, cc, prov); done {
 		return result, err
 	}
-	if !provOK {
+	if prov == nil {
 		cc.Status.AppliedKoffset = 0
 		cc.Status.ConfigMapRef = ""
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -194,7 +194,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			"config": cc.Name, "provider": spec.Provider.Type,
 		}).Inc()
 		cc.Status.AppliedKoffset = 0
-		cc.Status.ConfigMapRef = ""
+		// Preserve ConfigMapRef for best-effort finalizer cleanup (artifact may exist).
+		cc.Status.ConfigMapRef = prov.ConfigMapName(cc.Name)
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -215,7 +215,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	cm := &corev1.ConfigMap{}
 	cmKey := client.ObjectKey{
 		Namespace: cc.Namespace,
-		Name:      prov.ArtifactName(cc.Name),
+		Name:      prov.ConfigMapName(cc.Name),
 	}
 	if err := r.Get(ctx, cmKey, cm); err == nil {
 		if !metav1.IsControlledBy(cm, cc) {
@@ -330,13 +330,18 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 					cmKey := client.ObjectKey{Namespace: cc.Namespace, Name: cc.Status.ConfigMapRef}
 					if err := r.Get(ctx, cmKey, cm); err != nil {
 						if client.IgnoreNotFound(err) != nil {
-							log.Error(err, "Failed to get ConfigMap via configMapRef during best-effort finalization",
-								"configmap", cmKey)
+							log.Error(err, "Failed to get ConfigMap during best-effort finalization", "configmap", cmKey)
+							return true, ctrl.Result{}, err // retry on transient errors
 						}
-					} else {
+					} else if metav1.IsControlledBy(cm, cc) {
 						if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
-							log.Error(err, "Failed to delete ConfigMap via configMapRef")
+							log.Error(err, "Failed to delete ConfigMap during best-effort finalization")
+							return true, ctrl.Result{}, err // retry on transient errors
 						}
+						log.Info("Deleted orphaned ConfigMap via configMapRef", "configmap", cmKey)
+					} else {
+						log.Info("ConfigMap from configMapRef not owned by this CR; skipping deletion",
+							"configmap", cmKey)
 					}
 				} else {
 					log.Info("Provider not in registry and no configMapRef; removing finalizer without cleanup",
@@ -348,7 +353,7 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 			cm := &corev1.ConfigMap{}
 			cmKey := client.ObjectKey{
 				Namespace: cc.Namespace,
-				Name:      prov.ArtifactName(cc.Name),
+				Name:      prov.ConfigMapName(cc.Name),
 			}
 			if err := r.Get(ctx, cmKey, cm); err != nil {
 				if client.IgnoreNotFound(err) != nil {

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -145,7 +145,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Step 4: Validate provider.
 	if r.Providers == nil {
-		// Preserve ConfigMapRef for best-effort finalizer cleanup.
+		// Clear stale koffset but preserve ConfigMapRef for best-effort finalizer cleanup.
+		cc.Status.AppliedKoffset = 0
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -159,7 +160,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 	if prov == nil {
-		// Preserve ConfigMapRef for best-effort finalizer cleanup.
+		// Clear stale koffset but preserve ConfigMapRef for best-effort finalizer cleanup.
+		cc.Status.AppliedKoffset = 0
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -46,10 +46,9 @@ import (
 // NTNCellConfigReconciler reconciles a NTNCellConfig object
 type NTNCellConfigReconciler struct {
 	client.Client
-	Scheme                  *runtime.Scheme
-	Recorder                events.EventRecorder
-	Providers               map[string]provider.NTNProvider
-	MaxConcurrentReconciles int
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
+	Providers map[string]provider.NTNProvider
 }
 
 const (
@@ -132,10 +131,18 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Step 2: Look up provider from registry.
+	// Step 2: Look up provider from registry (may be nil).
 	prov := r.Providers[cc.Spec.Provider.Type]
+
+	// Step 3: Handle finalizer for ConfigMap cleanup on deletion.
+	// Runs before provider validation so deletions succeed even when
+	// the provider registry is nil or the type is unregistered.
+	if done, result, err := r.handleFinalizer(ctx, cc, prov); done {
+		return result, err
+	}
+
+	// Step 4: Validate provider.
 	if r.Providers == nil {
-		// Guard against nil registry (misconfigured controller).
 		cc.Status.AppliedKoffset = 0
 		cc.Status.ConfigMapRef = ""
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
@@ -149,11 +156,6 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
-	}
-
-	// Step 3: Handle finalizer for ConfigMap cleanup on deletion.
-	if done, result, err := r.handleFinalizer(ctx, cc, prov); done {
-		return result, err
 	}
 	if prov == nil {
 		cc.Status.AppliedKoffset = 0

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -399,7 +399,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			// Verify the ConfigMap has OwnerReference pointing to the CR.
 			cm := &corev1.ConfigMap{}
 			cmKey := types.NamespacedName{
-				Name:      "ocudu-ntn-" + resourceName,
+				Name:      realProvider.ArtifactName(resourceName),
 				Namespace: namespace,
 			}
 			Expect(k8sClient.Get(context.Background(), cmKey, cm)).To(Succeed())

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -200,7 +200,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		})
 	})
 
-	Context("When provider is nil", func() {
+	Context("When provider registry is nil", func() {
 		BeforeEach(func() { createCR() })
 		AfterEach(func() { deleteCR() })
 

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -399,7 +399,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			// Verify the ConfigMap has OwnerReference pointing to the CR.
 			cm := &corev1.ConfigMap{}
 			cmKey := types.NamespacedName{
-				Name:      realProvider.ConfigMapName(resourceName),
+				Name:      ocudu.ConfigMapNameFor(resourceName),
 				Namespace: namespace,
 			}
 			Expect(k8sClient.Get(context.Background(), cmKey, cm)).To(Succeed())

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -399,7 +399,7 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			// Verify the ConfigMap has OwnerReference pointing to the CR.
 			cm := &corev1.ConfigMap{}
 			cmKey := types.NamespacedName{
-				Name:      realProvider.ArtifactName(resourceName),
+				Name:      realProvider.ConfigMapName(resourceName),
 				Namespace: namespace,
 			}
 			Expect(k8sClient.Get(context.Background(), cmKey, cm)).To(Succeed())

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -205,7 +205,12 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		AfterEach(func() { deleteCR() })
 
 		It("should set ConfigApplied=False with InternalError", func() {
-			reconciler := newReconciler(nil)
+			reconciler := &NTNCellConfigReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(10),
+				Providers: nil, // nil registry
+			}
 
 			_, err := reconcileWithFinalizer(reconciler)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -87,7 +87,9 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Client:   k8sClient,
 			Scheme:   k8sClient.Scheme(),
 			Recorder: events.NewFakeRecorder(10),
-			Provider: p,
+			Providers: map[string]provider.NTNProvider{
+				"ocudu": p,
+			},
 		}
 	}
 
@@ -382,7 +384,9 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				Client:   k8sClient,
 				Scheme:   k8sClient.Scheme(),
 				Recorder: events.NewFakeRecorder(10),
-				Provider: realProvider,
+				Providers: map[string]provider.NTNProvider{
+					"ocudu": realProvider,
+				},
 			}
 			_, err := reconcileWithFinalizer(reconciler)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -50,4 +50,9 @@ type NTNProvider interface {
 	// Phase 1 (ConfigMap): regenerates the ephemeris section of the config.
 	// Phase 2 (future): pushes via OCUDU WebSocket handle_ntn_param_update.
 	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
+
+	// ArtifactName returns the name of the backend artifact (e.g., ConfigMap)
+	// managed by this provider for the given CR name. Used by the controller
+	// for OwnerReference and finalizer cleanup without importing the provider package.
+	ArtifactName(crName string) string
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -51,8 +51,8 @@ type NTNProvider interface {
 	// Phase 2 (future): pushes via OCUDU WebSocket handle_ntn_param_update.
 	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
 
-	// ArtifactName returns the name of the ConfigMap managed by this provider
+	// ConfigMapName returns the name of the ConfigMap managed by this provider
 	// for the given CR name. The controller uses this for OwnerReference
 	// stamping and finalizer cleanup without importing the concrete provider package.
-	ArtifactName(crName string) string
+	ConfigMapName(crName string) string
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -51,8 +51,8 @@ type NTNProvider interface {
 	// Phase 2 (future): pushes via OCUDU WebSocket handle_ntn_param_update.
 	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
 
-	// ArtifactName returns the name of the backend artifact (e.g., ConfigMap)
-	// managed by this provider for the given CR name. Used by the controller
-	// for OwnerReference and finalizer cleanup without importing the provider package.
+	// ArtifactName returns the name of the ConfigMap managed by this provider
+	// for the given CR name. The controller uses this for OwnerReference
+	// stamping and finalizer cleanup without importing the concrete provider package.
 	ArtifactName(crName string) string
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -19,6 +19,9 @@ package provider
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
@@ -49,12 +52,13 @@ type NTNProvider interface {
 	// PushEphemerisUpdate pushes fresh ephemeris data to the backend.
 	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
 
-	// ConfigMapName returns the name of the ConfigMap managed by this
-	// provider for the given CR name. Used by the controller for
-	// OwnerReference and finalizer cleanup.
-	//
-	// Note: All current and planned providers use ConfigMap as the
-	// artifact type. If a non-ConfigMap provider is added, this method
-	// should be generalized to return a typed artifact reference.
-	ConfigMapName(crName string) string
+	// EnsureOwnership sets ownership metadata (e.g., OwnerReference) on
+	// the provider's managed artifact so it is garbage-collected when
+	// the parent NTNCellConfig CR is deleted.
+	EnsureOwnership(ctx context.Context, crName string, owner metav1.Object, scheme *runtime.Scheme) error
+
+	// Cleanup removes provider-managed artifacts for the given CR name
+	// and namespace. Called by the finalizer during CR deletion.
+	// Returns nil if there is nothing to clean up (artifact not found).
+	Cleanup(ctx context.Context, crName, namespace string) error
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -35,24 +35,26 @@ type EphemerisUpdate struct {
 // and ephemeris updates. Ground station lifecycle is handled directly
 // by its respective controller.
 //
-// Implementations:
-//   - OCUDU: generates geo_ntn.yml and writes to a ConfigMap
+// All current providers (OCUDU, future OAI) store configuration in a
+// ConfigMap. If a future provider uses a different artifact type,
+// the interface and controller should be generalized at that time.
 type NTNProvider interface {
 	// ApplyCellConfig applies NTN radio parameters to the backend.
-	// crName is the NTNCellConfig CR name (used to scope resources like ConfigMaps).
+	// crName is the NTNCellConfig CR name (used to scope the provider artifact).
 	ApplyCellConfig(ctx context.Context, crName string, spec *ntnv1alpha1.NTNCellConfigSpec) error
 
-	// GetCellStatus returns the current applied configuration status
-	// for the given CR name and namespace.
+	// GetCellStatus returns the current applied configuration status.
 	GetCellStatus(ctx context.Context, crName, namespace string) (*ntnv1alpha1.NTNCellConfigStatus, error)
 
 	// PushEphemerisUpdate pushes fresh ephemeris data to the backend.
-	// Phase 1 (ConfigMap): regenerates the ephemeris section of the config.
-	// Phase 2 (future): pushes via OCUDU WebSocket handle_ntn_param_update.
 	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
 
-	// ConfigMapName returns the name of the ConfigMap managed by this provider
-	// for the given CR name. The controller uses this for OwnerReference
-	// stamping and finalizer cleanup without importing the concrete provider package.
+	// ConfigMapName returns the name of the ConfigMap managed by this
+	// provider for the given CR name. Used by the controller for
+	// OwnerReference and finalizer cleanup.
+	//
+	// Note: All current and planned providers use ConfigMap as the
+	// artifact type. If a non-ConfigMap provider is added, this method
+	// should be generalized to return a typed artifact reference.
 	ConfigMapName(crName string) string
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -65,3 +65,7 @@ func (m *MockProvider) PushEphemerisUpdate(_ context.Context, _, _ string, updat
 	m.LastEphemeris = &update
 	return m.EphemerisErr
 }
+
+func (m *MockProvider) ArtifactName(crName string) string {
+	return "mock-" + crName
+}

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -66,6 +66,6 @@ func (m *MockProvider) PushEphemerisUpdate(_ context.Context, _, _ string, updat
 	return m.EphemerisErr
 }
 
-func (m *MockProvider) ArtifactName(crName string) string {
+func (m *MockProvider) ConfigMapName(crName string) string {
 	return "mock-" + crName
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
 
@@ -66,6 +69,12 @@ func (m *MockProvider) PushEphemerisUpdate(_ context.Context, _, _ string, updat
 	return m.EphemerisErr
 }
 
-func (m *MockProvider) ConfigMapName(crName string) string {
-	return "mock-" + crName
+func (m *MockProvider) EnsureOwnership(
+	_ context.Context, _ string, _ metav1.Object, _ *runtime.Scheme,
+) error {
+	return nil
+}
+
+func (m *MockProvider) Cleanup(_ context.Context, _, _ string) error {
+	return nil
 }

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -61,8 +61,8 @@ type Provider struct {
 	client client.Client
 }
 
-// ArtifactName returns the ConfigMap name managed by this provider for the given CR.
-func (p *Provider) ArtifactName(crName string) string {
+// ConfigMapName returns the ConfigMap name managed by this provider for the given CR.
+func (p *Provider) ConfigMapName(crName string) string {
 	return ConfigMapNameFor(crName)
 }
 

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -61,6 +61,11 @@ type Provider struct {
 	client client.Client
 }
 
+// ArtifactName returns the ConfigMap name managed by this provider for the given CR.
+func (p *Provider) ArtifactName(crName string) string {
+	return ConfigMapNameFor(crName)
+}
+
 // NewProvider creates an OCUDU Provider with the given K8s client.
 func NewProvider(c client.Client) *Provider {
 	return &Provider{client: c}

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -27,8 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/provider"
@@ -61,9 +63,35 @@ type Provider struct {
 	client client.Client
 }
 
-// ConfigMapName returns the ConfigMap name managed by this provider for the given CR.
-func (p *Provider) ConfigMapName(crName string) string {
-	return ConfigMapNameFor(crName)
+// EnsureOwnership sets OwnerReference on the provider's ConfigMap.
+func (p *Provider) EnsureOwnership(
+	ctx context.Context, crName string, owner metav1.Object, scheme *runtime.Scheme,
+) error {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{
+		Name:      ConfigMapNameFor(crName),
+		Namespace: owner.GetNamespace(),
+	}
+	if err := p.client.Get(ctx, key, cm); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(cm, owner) {
+		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
+			return err
+		}
+		return p.client.Update(ctx, cm)
+	}
+	return nil
+}
+
+// Cleanup deletes the provider's ConfigMap for the given CR.
+func (p *Provider) Cleanup(ctx context.Context, crName, namespace string) error {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
+	if err := p.client.Get(ctx, key, cm); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return client.IgnoreNotFound(p.client.Delete(ctx, cm))
 }
 
 // NewProvider creates an OCUDU Provider with the given K8s client.


### PR DESCRIPTION
## Summary

Remove all OCUDU-specific coupling points from the NTNCellConfig controller, enabling clean integration of future providers (e.g., OAI gNB).

Closes #72. Prerequisite for #65 (OAI provider).

## Scope

This refactor targets **ConfigMap-based providers** (OCUDU, future OAI). All current and planned providers use ConfigMap as their artifact type. The interface uses `ConfigMapName()` deliberately — if a non-ConfigMap provider is added in the future, this method will be generalized at that time (YAGNI).

## What changed

| Coupling | Before | After |
|----------|--------|-------|
| Import | Controller imports pkg/provider/ocudu | Controller only imports pkg/provider (interface) |
| Artifact naming | ocudu.ConfigMapNameFor(name) | prov.ConfigMapName(name) (interface method) |
| Provider type guard | if type != "ocudu" hardcoded | Registry lookup r.Providers[type] |
| Instantiation | ocudu.NewProvider() in reconciler | providers map in cmd/main.go |

## Adding a new provider after this PR

1. Implement NTNProvider in pkg/provider/oai/
2. Register in cmd/main.go: providers["oai"] = oai.NewProvider(...)
3. Add oai to CRD enum in ntncellconfig_types.go

## Test plan

- [x] go build ./cmd/ — compiles
- [x] go vet ./... — clean
- [x] No ocudu import in controller
- [x] Best-effort finalizer cleanup with OwnerReference check
- [x] Transient errors retry instead of silently dropping finalizer