### PR TITLE
feat: add NTNSlice validating webhook for trigger syntax (#70)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -42,6 +43,8 @@ import (
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
 	"github.com/thc1006/ntn-operators/pkg/netutil"
 	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
+
+	ntnwebhook "github.com/thc1006/ntn-operators/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -226,6 +229,14 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	// Validating webhooks.
+	if err := builder.WebhookManagedBy(mgr, &ntnv1alpha1.NTNSlice{}).
+		WithValidator(&ntnwebhook.NTNSliceCustomValidator{}).
+		Complete(); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NTNSlice")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -230,12 +230,15 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	// Validating webhooks.
-	if err := builder.WebhookManagedBy(mgr, &ntnv1alpha1.NTNSlice{}).
-		WithValidator(&ntnwebhook.NTNSliceCustomValidator{}).
-		Complete(); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "NTNSlice")
-		os.Exit(1)
+	// Validating webhooks — only register when webhook certificates are configured.
+	if len(webhookCertPath) > 0 {
+		if err := builder.WebhookManagedBy(mgr, &ntnv1alpha1.NTNSlice{}).
+			WithValidator(&ntnwebhook.NTNSliceCustomValidator{}).
+			Complete(); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "NTNSlice")
+			os.Exit(1)
+		}
+		setupLog.Info("Validating webhooks enabled")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/dist/chart/templates/webhook/service.yaml
+++ b/dist/chart/templates/webhook/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webhooks.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "ntn-operators.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    control-plane: controller-manager
+{{- end }}

--- a/dist/chart/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/dist/chart/templates/webhook/validatingwebhookconfiguration.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.webhooks.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "ntn-operators.resourceName" (dict "suffix" "validating" "context" $) }}
+  {{- if .Values.certManager.enable }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ntn-operators.resourceName" (dict "suffix" "webhook-cert" "context" $) }}
+  {{- end }}
+spec:
+  webhooks:
+    - name: vntnslice.ntn.operators.dev
+      admissionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: {{ include "ntn-operators.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+          namespace: {{ .Release.Namespace }}
+          path: /validate-ntn-operators-dev-v1alpha1-ntnslice
+      failurePolicy: Fail
+      rules:
+        - apiGroups:
+            - ntn.operators.dev
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - ntnslices
+      sideEffects: None
+{{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -124,3 +124,10 @@ podDisruptionBudget:
 networkPolicy:
   enable: false
 
+## Validating admission webhooks.
+## Validates NTNSlice trigger syntax at admission time.
+## Requires cert-manager or manual TLS certificate provisioning.
+##
+webhooks:
+  enable: false
+

--- a/internal/webhook/v1alpha1/ntnslice_webhook.go
+++ b/internal/webhook/v1alpha1/ntnslice_webhook.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+)
+
+// NTNSliceCustomValidator validates NTNSlice admission requests.
+// It checks failoverPolicy.triggers[] syntax at admission time,
+// catching errors that CEL/OpenAPI schema validation cannot express.
+type NTNSliceCustomValidator struct{}
+
+// ValidateCreate validates trigger syntax on creation.
+func (v *NTNSliceCustomValidator) ValidateCreate(
+	_ context.Context, ns *ntnv1alpha1.NTNSlice,
+) (admission.Warnings, error) {
+	return nil, validateTriggers(ns)
+}
+
+// ValidateUpdate validates trigger syntax on update.
+func (v *NTNSliceCustomValidator) ValidateUpdate(
+	_ context.Context, _, ns *ntnv1alpha1.NTNSlice,
+) (admission.Warnings, error) {
+	return nil, validateTriggers(ns)
+}
+
+// ValidateDelete allows all deletions.
+func (v *NTNSliceCustomValidator) ValidateDelete(
+	_ context.Context, _ *ntnv1alpha1.NTNSlice,
+) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateTriggers parses each failoverPolicy.triggers entry and
+// returns an error listing all invalid trigger expressions.
+func validateTriggers(ns *ntnv1alpha1.NTNSlice) error {
+	var errs []string
+	for i, t := range ns.Spec.FailoverPolicy.Triggers {
+		if _, err := slice.ParseTrigger(t); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"triggers[%d] %q: %v", i, t, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid failoverPolicy.triggers: %v", errs)
+	}
+	return nil
+}

--- a/internal/webhook/v1alpha1/ntnslice_webhook_test.go
+++ b/internal/webhook/v1alpha1/ntnslice_webhook_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+func validNTNSlice() *ntnv1alpha1.NTNSlice {
+	return &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant: "test-tenant",
+			TerrestrialPath: ntnv1alpha1.PathSpec{
+				Provider: "chunghwa-telecom",
+				Priority: "primary",
+			},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "sat-oneweb",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers: []string{"rsrp < -120", "latency > 200"},
+			},
+		},
+	}
+}
+
+func TestValidateCreate_ValidTriggers(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	warnings, err := v.ValidateCreate(context.Background(), validNTNSlice())
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestValidateCreate_InvalidTrigger(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	ns := validNTNSlice()
+	ns.Spec.FailoverPolicy.Triggers = []string{"rsrp << -120"}
+
+	_, err := v.ValidateCreate(context.Background(), ns)
+	if err == nil {
+		t.Error("expected error for invalid trigger syntax")
+	}
+}
+
+func TestValidateCreate_MixedTriggers(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	ns := validNTNSlice()
+	ns.Spec.FailoverPolicy.Triggers = []string{
+		"rsrp < -120",
+		"badmetric > 100",
+	}
+
+	_, err := v.ValidateCreate(context.Background(), ns)
+	if err == nil {
+		t.Error("expected error when any trigger is invalid")
+	}
+}
+
+func TestValidateUpdate_ValidTriggers(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	old := validNTNSlice()
+	updated := validNTNSlice()
+	updated.Spec.FailoverPolicy.Triggers = []string{"packetLoss > 5"}
+
+	warnings, err := v.ValidateUpdate(context.Background(), old, updated)
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestValidateUpdate_InvalidTrigger(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	old := validNTNSlice()
+	updated := validNTNSlice()
+	updated.Spec.FailoverPolicy.Triggers = []string{"rsrp -120"}
+
+	_, err := v.ValidateUpdate(context.Background(), old, updated)
+	if err == nil {
+		t.Error("expected error for invalid trigger in update")
+	}
+}
+
+func TestValidateDelete_AlwaysPasses(t *testing.T) {
+	v := &NTNSliceCustomValidator{}
+	warnings, err := v.ValidateDelete(context.Background(), validNTNSlice())
+	if err != nil {
+		t.Errorf("expected no error on delete, got: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", warnings)
+	}
+}


### PR DESCRIPTION
## Summary

Add admission webhook that validates `failoverPolicy.triggers[]` syntax at `kubectl apply` time. Invalid triggers (e.g., `"rsrp << -120"`, `"badmetric > 100"`) are now rejected with descriptive errors instead of silently failing at runtime.

Closes #70

## How it works

```bash
# This now fails at admission:
kubectl apply -f - <<YAML
apiVersion: ntn.operators.dev/v1alpha1
kind: NTNSlice
spec:
  failoverPolicy:
    triggers:
      - "rsrp << -120"  # ← rejected: invalid trigger format
YAML
```

Error: `invalid failoverPolicy.triggers: [triggers[0] "rsrp << -120": invalid trigger format ...]`

## Changes

- `internal/webhook/v1alpha1/ntnslice_webhook.go` — CustomValidator (typed generic, controller-runtime v0.23+)
- `internal/webhook/v1alpha1/ntnslice_webhook_test.go` — 6 tests
- `cmd/main.go` — register webhook via `builder.WebhookManagedBy`
- `dist/chart/templates/webhook/` — ValidatingWebhookConfiguration + Service
- `dist/chart/values.yaml` — add `webhooks.enable: false`

## Test plan

- [x] 6/6 webhook tests pass
- [x] `go build ./cmd/` compiles
- [x] `helm lint --set webhooks.enable=true` clean
- [ ] E2E: deploy with cert-manager, apply invalid NTNSlice → rejected