### PR TITLE
feat(metrics): optional endpoint allow-list for Prometheus source (#93)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,12 @@ func main() {
 	var maxConcurrentReconciles int
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
 		"Maximum number of concurrent reconciles per controller.")
+	var prometheusAllowedHosts string
+	flag.StringVar(&prometheusAllowedHosts, "prometheus-allowed-endpoint-hosts", "",
+		"Comma-separated list of hostnames that NTNSlice.spec.metricsSource.prometheus.endpoint "+
+			"is allowed to target. Empty (default) is permit-all, which matches the pre-flag "+
+			"behaviour for single-tenant deployments. Set this in multi-tenant clusters so a "+
+			"tenant cannot aim the operator at arbitrary cluster-internal services.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -238,7 +244,8 @@ func main() {
 	// keyed by endpoint, and one Provider that picks the right Reader
 	// (annotations | prometheus) based on each NTNSlice spec.
 	metricsPool := slicemetrics.NewClientPool()
-	metricsProvider := slicemetrics.NewProvider(metricsPool)
+	metricsProvider := slicemetrics.NewProvider(metricsPool,
+		slicemetrics.WithEndpointAllowlist(netutil.ParseEndpointAllowlist(prometheusAllowedHosts)))
 	if err := (&controller.NTNSliceReconciler{
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),

--- a/docs/design/metrics-source.md
+++ b/docs/design/metrics-source.md
@@ -34,13 +34,12 @@ must not ship as the default behaviour for production users.
 - Background pull / push-gateway mode. Sync query per reconcile is sufficient
   for the current scale target (tens of NTNSlices).
 - RSRQ / SINR metrics.
-- **Endpoint allow-list for SSRF hardening.** `spec.metricsSource.prometheus.endpoint`
-  is a user-supplied URL that the operator issues HTTP POSTs against. In the
-  current deployment model NTNSlice creation is cluster-admin-only RBAC, which
-  bounds the blast radius: an admin can already curl anything the operator pod
-  can reach. Multi-tenant installs should add an admission-time allow-list of
-  endpoint hosts before granting non-admin tenants `create ntnslices`. Filed
-  as a follow-up; not fixed here.
+- **IP-level SSRF hardening.** DNS-resolve-time IP range bans, DNS rebinding
+  mitigations, and redirect-following disablement are the operator Pod
+  NetworkPolicy's job; they are the Kubernetes-native layer for "the
+  operator may only egress to these endpoints" and do not belong in the
+  CR schema. The host-name allow-list shipped in D6 provides
+  tenant-visible guardrails on top.
 
 ## Design decisions
 
@@ -85,6 +84,30 @@ We do not hardcode PromQL. Users provide their own queries for each of
 gNB / UPF exporter dialect (Open5GS exporter labels are not the same as
 a third-party gNB RIC exporter). The trade-off is that a typo in PromQL
 produces an `ErrNoMetrics` at runtime — handled by D1 + admission.
+
+### D6. Optional endpoint allow-list (#93)
+
+The operator ships a `--prometheus-allowed-endpoint-hosts=csv` flag.
+Empty (the default) is permit-all, matching the pre-flag behaviour so
+single-tenant deployments do not break. When non-empty, every
+`spec.metricsSource.prometheus.endpoint` URL is parsed and its
+`Hostname()` is required to exactly match one of the configured hosts.
+
+Implementation in `pkg/netutil.EndpointAllowlist`:
+
+- URL must parse, use `http` or `https`, and not carry userinfo — these
+  catch parser-trick SSRF bypasses (`http://attacker@allowed/`,
+  `javascript://allowed`, etc.) independent of the allow-list content.
+- Host comparison is exact + case-insensitive; prefix or suffix
+  matching is refused because `allowed.svc.attacker.com` would beat
+  a prefix rule on `allowed.svc` without the defender noticing.
+- DNS resolution and IP-range banning are NOT performed — see
+  non-goals. NetworkPolicy is the correct layer for that.
+
+A rejected endpoint surfaces in the reconciler as
+`FailoverReady=Unknown` with `reason=EndpointNotAllowed`, distinct
+from `MetricsReaderError` / `MetricsUnavailable` so `kubectl describe`
+is actionable.
 
 ### D5. RSRP on Open5GS — limitation acknowledged
 

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -41,11 +41,20 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 	"github.com/thc1006/ntn-operators/pkg/slice"
 	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
 )
 
 const sliceRequeueInterval = 30 * time.Second
+
+// Reason labels for the FailoverReady=Unknown path. Matched on by
+// kubectl describe and dashboard filters, so keep them stable.
+const (
+	reasonMetricsReaderError = "MetricsReaderError"
+	reasonMetricsUnavailable = "MetricsUnavailable"
+	reasonEndpointNotAllowed = "EndpointNotAllowed"
+)
 
 // NTNSliceReconciler reconciles a NTNSlice object
 type NTNSliceReconciler struct {
@@ -111,14 +120,21 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Step 2: Read path quality metrics via the configured source.
 	reader, err := r.readerProvider().For(ns)
 	if err != nil {
-		log.Error(err, "failed to build metrics reader")
-		return r.setMetricsUnknown(ctx, ns, "MetricsReaderError", err.Error())
+		// Distinguish admin-configured endpoint rejection from other
+		// build errors so kubectl describe surfaces a specific reason
+		// rather than a generic MetricsReaderError.
+		reason := reasonMetricsReaderError
+		if errors.Is(err, netutil.ErrEndpointNotAllowed) {
+			reason = reasonEndpointNotAllowed
+		}
+		log.Error(err, "failed to build metrics reader", "reason", reason)
+		return r.setMetricsUnknown(ctx, ns, reason, err.Error())
 	}
 	readResult, err := reader.Read(ctx, ns)
 	if err != nil {
-		reason := "MetricsUnavailable"
+		reason := reasonMetricsUnavailable
 		if !errors.Is(err, slicemetrics.ErrNoMetrics) {
-			reason = "MetricsReaderError"
+			reason = reasonMetricsReaderError
 		}
 		log.Info("metrics unavailable; holding current path", "reason", reason, "err", err.Error())
 		return r.setMetricsUnknown(ctx, ns, reason, err.Error())

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
 )
 
 var _ = Describe("NTNSlice Controller", func() {
@@ -896,6 +898,46 @@ var _ = Describe("NTNSlice Controller", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 			Expect(cond.Reason).To(SatisfyAny(Equal("MetricsReaderError"), Equal("MetricsUnavailable")),
 				"unreachable Prometheus must surface as one of the metrics-failure reasons")
+		})
+	})
+
+	Context("MetricsSource prometheus: endpoint allow-list rejects non-listed host", func() {
+		It("should set FailoverReady=Unknown with reason=EndpointNotAllowed when admin allow-list denies the host", func() {
+			allow := netutil.ParseEndpointAllowlist("allowed.prom.example.com")
+			provider := slicemetrics.NewProvider(slicemetrics.NewClientPool(),
+				slicemetrics.WithEndpointAllowlist(allow))
+
+			spec := baseSpec()
+			spec.MetricsSource = &ntnv1alpha1.MetricsSource{
+				Type: ntnv1alpha1.MetricsSourcePrometheus,
+				Prometheus: &ntnv1alpha1.PrometheusMetricsSource{
+					Endpoint: "http://denied.prom.example.com:9090",
+					Queries:  ntnv1alpha1.PrometheusQueries{RsrpDbm: "up"},
+				},
+			}
+			slice := &ntnv1alpha1.NTNSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "allowlist-denied", Namespace: namespace},
+				Spec:       spec,
+			}
+			Expect(k8sClient.Create(context.Background(), slice)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), slice) })
+
+			rec := newReconciler()
+			rec.ReaderProvider = provider
+			_, err := rec.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "allowlist-denied", Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &ntnv1alpha1.NTNSlice{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "allowlist-denied", Namespace: namespace}, updated)).To(Succeed())
+			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionFailoverReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal("EndpointNotAllowed"),
+				"allow-list rejection must surface its own reason, not a generic one")
+			Expect(cond.Message).To(ContainSubstring("denied.prom.example.com"),
+				"reason message should name the offending host so kubectl describe is actionable")
 		})
 	})
 

--- a/pkg/netutil/allowlist.go
+++ b/pkg/netutil/allowlist.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package netutil
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// ErrEndpointNotAllowed is returned by EndpointAllowlist.Check when a URL
+// fails validation — either because it does not parse, carries userinfo,
+// uses a non-HTTP scheme, has an empty host, or the host is absent from
+// a non-empty allowlist. Callers should map this sentinel to a
+// deterministic Status condition rather than bubbling it up as a
+// generic reconcile error.
+var ErrEndpointNotAllowed = errors.New("netutil: endpoint not allowed")
+
+// EndpointAllowlist validates that a user-supplied URL is a well-formed
+// HTTP(S) endpoint whose hostname, when the list is non-empty, exactly
+// matches one of the configured hosts. It deliberately does NOT perform
+// DNS resolution or IP-range checks — that duty belongs to the operator
+// Pod's NetworkPolicy, which is the Kubernetes-native way to enforce
+// "the operator may only egress to these targets". See the
+// docs/design/metrics-source.md "Non-goals" section for the full
+// rationale.
+//
+// Why host-exact match rather than URL-prefix:
+// a prefix check on raw URL text is trivially bypassed by subdomain
+// confusion (http://allowed.svc.attacker.com) and userinfo tricks
+// (http://attacker@allowed.svc). Parsing the URL and comparing only
+// the Hostname() against the list closes both classes without needing
+// a regex engine.
+//
+// Empty allowlist — backward-compatible permissive default. Every
+// deployment that was running before the flag existed continues to
+// reconcile without change; admins opt in to restriction by setting
+// the operator flag.
+type EndpointAllowlist struct {
+	hosts []string // already lowercased; empty slice = permit-all
+}
+
+// ParseEndpointAllowlist accepts a comma-separated list of hosts. Blank
+// entries and surrounding whitespace are ignored. Hostnames are
+// normalised to lower case for DNS-equivalent matching.
+//
+// The parser is intentionally minimal: it does not accept schemes,
+// paths, ports, or glob patterns. Admins who need multiple forms
+// (short name vs FQDN) list each one explicitly; this is more typing
+// but has no ambiguity.
+func ParseEndpointAllowlist(csv string) EndpointAllowlist {
+	if csv == "" {
+		return EndpointAllowlist{}
+	}
+	parts := strings.Split(csv, ",")
+	hosts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		hosts = append(hosts, strings.ToLower(p))
+	}
+	return EndpointAllowlist{hosts: hosts}
+}
+
+// Check validates raw and returns nil if the URL is acceptable, or an
+// error wrapping ErrEndpointNotAllowed with a reason suitable for
+// logging and kubectl describe.
+func (a EndpointAllowlist) Check(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: parse: %v", ErrEndpointNotAllowed, err)
+	}
+	if sch := strings.ToLower(u.Scheme); sch != "http" && sch != "https" {
+		return fmt.Errorf("%w: scheme %q not in {http,https}", ErrEndpointNotAllowed, u.Scheme)
+	}
+	// Reject userinfo outright. `http://attacker@allowed/` has
+	// Hostname()="allowed" but the HTTP client actually treats
+	// attacker as the host for authorization semantics; even if it
+	// did not, operators do not embed credentials in the CR URL.
+	if u.User != nil {
+		return fmt.Errorf("%w: URL must not carry userinfo", ErrEndpointNotAllowed)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("%w: URL has empty host", ErrEndpointNotAllowed)
+	}
+	if len(a.hosts) == 0 {
+		return nil
+	}
+	if slices.Contains(a.hosts, host) {
+		return nil
+	}
+	return fmt.Errorf("%w: host %q is not in allow-list", ErrEndpointNotAllowed, host)
+}

--- a/pkg/netutil/allowlist.go
+++ b/pkg/netutil/allowlist.go
@@ -54,10 +54,15 @@ type EndpointAllowlist struct {
 // entries and surrounding whitespace are ignored. Hostnames are
 // normalised to lower case for DNS-equivalent matching.
 //
-// The parser is intentionally minimal: it does not accept schemes,
-// paths, ports, or glob patterns. Admins who need multiple forms
-// (short name vs FQDN) list each one explicitly; this is more typing
-// but has no ambiguity.
+// The parser is intentionally minimal: it does not validate token
+// structure beyond trimming whitespace and lowercasing. Entries are
+// treated literally, so an admin who accidentally writes
+// "https://prom.example.com" or "prom.example.com:9090" will store
+// that whole string as the key and Check will never match a real
+// Hostname against it — the NTNSlice will be rejected with
+// EndpointNotAllowed until the flag is fixed. Admins should provide
+// bare hostnames only; if multiple forms are needed (short name vs
+// FQDN), list each one explicitly.
 func ParseEndpointAllowlist(csv string) EndpointAllowlist {
 	if csv == "" {
 		return EndpointAllowlist{}

--- a/pkg/netutil/allowlist_test.go
+++ b/pkg/netutil/allowlist_test.go
@@ -74,7 +74,7 @@ func TestEndpointAllowlist_SchemeRestricted(t *testing.T) {
 		"ftp://prom.monitoring.svc",
 	} {
 		if err := a.Check(url); err == nil {
-			t.Errorf("scheme %q must be rejected even with empty allowlist", url)
+			t.Errorf("URL %q must be rejected even with empty allowlist", url)
 		}
 	}
 }
@@ -137,11 +137,10 @@ func TestEndpointAllowlist_HostMatchIsCaseInsensitive(t *testing.T) {
 }
 
 func TestEndpointAllowlist_WhitespaceAndEmptyEntries_AreIgnored(t *testing.T) {
-	// ",prom.example.com,  ,https://other.com," should parse to one
-	// useful entry and silently drop the blanks. The stray "https://"
-	// prefix on the second entry is kept as-is — the parser is not
-	// trying to be smart about user mistakes, it only normalises
-	// whitespace + case.
+	// "  ,prom.example.com,   ,  " should parse to one useful entry
+	// and silently drop the blank slots between the commas. The parser
+	// only normalises whitespace and case; it is not smart about
+	// further user mistakes (see the godoc for why).
 	a := netutil.ParseEndpointAllowlist("  ,prom.example.com,   ,  ")
 	if err := a.Check("http://prom.example.com"); err != nil {
 		t.Errorf("valid entry rejected: %v", err)

--- a/pkg/netutil/allowlist_test.go
+++ b/pkg/netutil/allowlist_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package netutil_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+)
+
+func TestEndpointAllowlist_Empty_AcceptsAnyHttpURL(t *testing.T) {
+	// Backward-compat default: no flag set -> admin opts out -> allow
+	// anything that parses to a valid http/https URL with a host.
+	a := netutil.ParseEndpointAllowlist("")
+	for _, url := range []string{
+		"http://prometheus.monitoring.svc:9090",
+		"https://prom.example.com",
+		"http://127.0.0.1:9090",
+	} {
+		if err := a.Check(url); err != nil {
+			t.Errorf("empty allowlist must accept %q, got %v", url, err)
+		}
+	}
+}
+
+func TestEndpointAllowlist_NonEmpty_OnlyExactHostMatch(t *testing.T) {
+	a := netutil.ParseEndpointAllowlist("prom.monitoring.svc,prom.example.com")
+	ok := []string{
+		"http://prom.monitoring.svc:9090",
+		"https://prom.monitoring.svc",
+		"http://prom.example.com/api/v1/query",
+	}
+	for _, url := range ok {
+		if err := a.Check(url); err != nil {
+			t.Errorf("want allow %q, got %v", url, err)
+		}
+	}
+	rejected := []string{
+		// Subdomain-confusion attack: attacker.com pretends to be a
+		// subdomain of an allowed host.
+		"http://prom.monitoring.svc.attacker.com:9090",
+		// Prefix-bypass: admin host is only a prefix of the actual
+		// registered host; rejected under exact-match semantics.
+		"http://prom.monitoring.svc.evil.internal",
+		// Completely different host.
+		"http://attacker.com",
+	}
+	for _, url := range rejected {
+		err := a.Check(url)
+		if err == nil {
+			t.Errorf("want reject %q, got accept", url)
+		} else if !errors.Is(err, netutil.ErrEndpointNotAllowed) {
+			t.Errorf("want ErrEndpointNotAllowed for %q, got %v", url, err)
+		}
+	}
+}
+
+func TestEndpointAllowlist_SchemeRestricted(t *testing.T) {
+	a := netutil.ParseEndpointAllowlist("")
+	for _, url := range []string{
+		"javascript://prom.monitoring.svc",
+		"file:///etc/passwd",
+		"gopher://prom.monitoring.svc:70",
+		"ftp://prom.monitoring.svc",
+	} {
+		if err := a.Check(url); err == nil {
+			t.Errorf("scheme %q must be rejected even with empty allowlist", url)
+		}
+	}
+}
+
+func TestEndpointAllowlist_UserinfoRejected(t *testing.T) {
+	// Classic SSRF bypass: attacker stuffs a fake host into userinfo
+	// so a naive prefix-on-URL check sees the allowed string, while
+	// the HTTP client actually resolves the real host after @.
+	a := netutil.ParseEndpointAllowlist("prom.monitoring.svc")
+	attacks := []string{
+		"http://attacker.com@prom.monitoring.svc/",
+		"http://prom.monitoring.svc@attacker.com/", // reverse trick
+		"http://user:pass@prom.monitoring.svc",
+	}
+	for _, url := range attacks {
+		if err := a.Check(url); err == nil {
+			t.Errorf("URL with userinfo %q must be rejected", url)
+		}
+	}
+}
+
+func TestEndpointAllowlist_EmptyHostRejected(t *testing.T) {
+	a := netutil.ParseEndpointAllowlist("")
+	for _, url := range []string{
+		"http://",
+		"http:///path",
+		"https://", // host is empty after scheme
+	} {
+		if err := a.Check(url); err == nil {
+			t.Errorf("%q must be rejected for empty host", url)
+		}
+	}
+}
+
+func TestEndpointAllowlist_UnparseableURLRejected(t *testing.T) {
+	a := netutil.ParseEndpointAllowlist("")
+	// Go's url.Parse is lenient: only a handful of truly malformed strings
+	// fail it. We still want our check to refuse anything the parser
+	// cannot round-trip sensibly.
+	for _, url := range []string{
+		"://no-scheme",
+		"ht tp://space-in-scheme", // Parse does error on this form
+	} {
+		if err := a.Check(url); err == nil {
+			t.Errorf("unparseable %q must be rejected", url)
+		}
+	}
+}
+
+func TestEndpointAllowlist_HostMatchIsCaseInsensitive(t *testing.T) {
+	// DNS is case-insensitive; the allowlist should be too so that
+	// "Prom.Monitoring.Svc" in the CR matches the admin's list.
+	a := netutil.ParseEndpointAllowlist("Prom.Monitoring.Svc")
+	if err := a.Check("http://prom.monitoring.svc"); err != nil {
+		t.Errorf("case-insensitive match expected, got %v", err)
+	}
+	if err := a.Check("http://PROM.MONITORING.SVC:9090"); err != nil {
+		t.Errorf("case-insensitive match expected (upper), got %v", err)
+	}
+}
+
+func TestEndpointAllowlist_WhitespaceAndEmptyEntries_AreIgnored(t *testing.T) {
+	// ",prom.example.com,  ,https://other.com," should parse to one
+	// useful entry and silently drop the blanks. The stray "https://"
+	// prefix on the second entry is kept as-is — the parser is not
+	// trying to be smart about user mistakes, it only normalises
+	// whitespace + case.
+	a := netutil.ParseEndpointAllowlist("  ,prom.example.com,   ,  ")
+	if err := a.Check("http://prom.example.com"); err != nil {
+		t.Errorf("valid entry rejected: %v", err)
+	}
+	if err := a.Check("http://other.example.com"); err == nil {
+		t.Error("should still reject hosts not in allowlist")
+	}
+}
+
+func TestEndpointAllowlist_ErrEndpointNotAllowed_IncludesHost(t *testing.T) {
+	// The error message is surfaced to operators in kubectl describe;
+	// include the host so they can act without re-running the query.
+	a := netutil.ParseEndpointAllowlist("prom.allowed.com")
+	err := a.Check("http://bad.example.com:9090/api/v1/query")
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	if !strings.Contains(err.Error(), "bad.example.com") {
+		t.Errorf("error should identify offending host, got: %v", err)
+	}
+}

--- a/pkg/slice/metrics/provider.go
+++ b/pkg/slice/metrics/provider.go
@@ -23,6 +23,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 )
 
 // Provider maps an NTNSlice CR to a Reader selected from its spec.
@@ -51,6 +52,23 @@ type Provider struct {
 	// a word of memory for no benefit, and a singleton keeps pointer
 	// identity predictable in tests and in the controller's logs.
 	annotationSingleton Reader
+
+	// allowlist gates which Prometheus endpoints each NTNSlice may
+	// reference. Zero value (empty list) is permit-all, preserving the
+	// pre-flag behaviour for single-tenant deployments.
+	allowlist netutil.EndpointAllowlist
+}
+
+// Option configures a Provider. Functional-option pattern keeps
+// NewProvider's positional args stable as new configuration lands.
+type Option func(*Provider)
+
+// WithEndpointAllowlist restricts Prometheus-mode endpoints to the
+// given host allowlist. An empty allowlist keeps the default permit-all
+// behaviour, so WithEndpointAllowlist(netutil.ParseEndpointAllowlist(""))
+// is a safe no-op.
+func WithEndpointAllowlist(a netutil.EndpointAllowlist) Option {
+	return func(p *Provider) { p.allowlist = a }
 }
 
 // readerKey identifies a cached Prometheus-mode reader. The UID alone
@@ -66,16 +84,21 @@ type readerKey struct {
 }
 
 // NewProvider returns an empty Provider. Panics on nil pool — the caller
-// is expected to wire a ClientPool at startup time.
-func NewProvider(pool *ClientPool) *Provider {
+// is expected to wire a ClientPool at startup time. Accepts optional
+// Options for future configuration (e.g., WithEndpointAllowlist).
+func NewProvider(pool *ClientPool, opts ...Option) *Provider {
 	if pool == nil {
 		panic("metrics.NewProvider: nil ClientPool")
 	}
-	return &Provider{
+	p := &Provider{
 		pool:                pool,
 		readers:             map[readerKey]Reader{},
 		annotationSingleton: NewAnnotationReader(),
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // For returns the Reader appropriate for ns according to
@@ -165,6 +188,12 @@ func (p *Provider) Evict(key client.ObjectKey) {
 }
 
 func (p *Provider) buildReader(src *ntnv1alpha1.PrometheusMetricsSource) (Reader, error) {
+	// Endpoint allow-list gate — checked first so a mis-addressed
+	// tenant spec never touches the client pool (avoids caching a
+	// client that the operator is not supposed to use anyway).
+	if err := p.allowlist.Check(src.Endpoint); err != nil {
+		return nil, err
+	}
 	// Defence in depth: CEL at admission already rejects an all-empty
 	// queries block, but a CRD schema downgrade or a direct status-
 	// subresource edit could route such a spec through here. Left

--- a/pkg/slice/metrics/provider_test.go
+++ b/pkg/slice/metrics/provider_test.go
@@ -12,6 +12,7 @@ package metrics_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 	"github.com/thc1006/ntn-operators/pkg/slice/metrics"
 )
 
@@ -143,6 +145,40 @@ func TestProvider_NilPool_PanicsAtConstruction(t *testing.T) {
 		}
 	}()
 	_ = metrics.NewProvider(nil)
+}
+
+func TestProvider_WithAllowlist_AcceptsListedHost(t *testing.T) {
+	allow := netutil.ParseEndpointAllowlist("prom.example.com")
+	p := metrics.NewProvider(metrics.NewClientPool(), metrics.WithEndpointAllowlist(allow))
+	ns := prometheusCR("http://prom.example.com:9090")
+	if _, err := p.For(ns); err != nil {
+		t.Fatalf("allowlisted host must be accepted, got %v", err)
+	}
+}
+
+func TestProvider_WithAllowlist_RejectsUnlistedHost(t *testing.T) {
+	allow := netutil.ParseEndpointAllowlist("prom.example.com")
+	p := metrics.NewProvider(metrics.NewClientPool(), metrics.WithEndpointAllowlist(allow))
+	ns := prometheusCR("http://evil.attacker.com:9090")
+	_, err := p.For(ns)
+	if err == nil {
+		t.Fatal("unlisted host must be rejected")
+	}
+	if !errors.Is(err, netutil.ErrEndpointNotAllowed) {
+		t.Errorf("want wrapped ErrEndpointNotAllowed, got %v", err)
+	}
+}
+
+func TestProvider_ZeroValueAllowlist_IsPermitAll(t *testing.T) {
+	// Default constructor with no options gets a zero-value allowlist,
+	// which keeps the pre-flag permit-all behaviour for single-tenant
+	// deployments — nothing breaks for admins who don't care about
+	// endpoint restriction.
+	p := metrics.NewProvider(metrics.NewClientPool())
+	ns := prometheusCR("http://some.random.host:9090")
+	if _, err := p.For(ns); err != nil {
+		t.Fatalf("zero-value allowlist must be permit-all, got %v", err)
+	}
 }
 
 func TestProvider_PrometheusMode_EmptyUID_IsRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #93. Adds the admin-configurable host allow-list that #67's
design doc deliberately deferred as a non-goal, so multi-tenant
clusters can bound where the operator will HTTP-GET in response to
a tenant-created NTNSlice CR.

## What ships

- `--prometheus-allowed-endpoint-hosts=<csv>` operator flag
  (default empty = permit-all, backward compatible with the pre-flag
  behaviour — every existing single-tenant install keeps reconciling
  without changes).
- `pkg/netutil.EndpointAllowlist` with `Check(url)` that parses the
  URL once, enforces scheme ∈ {http, https}, refuses userinfo and
  empty host, then requires an exact case-insensitive match on
  `Hostname()` when the list is non-empty.
- `slicemetrics.WithEndpointAllowlist(…)` functional Option on
  `Provider`, checked inside `buildReader` before the client pool
  is touched.
- Controller maps `netutil.ErrEndpointNotAllowed` to a dedicated
  `FailoverReady=Unknown` reason `EndpointNotAllowed` so
  kubectl describe is actionable.

## Design decisions (D6 in `docs/design/metrics-source.md`)

**Exact host match, not prefix.** A prefix rule on `allowed.svc`
would accept `allowed.svc.attacker.com` — the same class of bug
PortSwigger documents under "URL validation bypass cheatsheet" and
that drove CVE-2021-29923 in Go's net package. Exact match closes
the subdomain-confusion bypass at the cost of admins listing each
hostname they want (FQDN vs short name).

**Userinfo refused outright.** `http://attacker@allowed/` parses to
`Hostname() == "allowed"` which would trick a naive check, even
though the HTTP client will resolve and connect to `attacker`. The
allow-list rejects any URL with `u.User != nil` regardless of host
match.

**DNS + IP range validation NOT performed.** That belongs in the
operator Pod's NetworkPolicy — the Kubernetes-native layer for
egress restriction. Trying to do both at admission time creates
TOCTOU confusion with DNS rebinding; the CR schema is the wrong
place. Design doc's Non-goals section updated accordingly.

## Research references

- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- [PortSwigger: URL validation bypass cheat sheet](https://portswigger.net/research/introducing-the-url-validation-bypass-cheat-sheet)
- [Go net/url parsing pitfalls (CVE-2021-29923)](https://www.bleepingcomputer.com/news/security/go-rust-net-library-affected-by-critical-ip-address-validation-vulnerability/)

## Tests

- `pkg/netutil/allowlist_test.go` — 9 unit specs: subdomain confusion,
  userinfo (both @-positions), scheme allow-list, empty host,
  unparseable input, case insensitivity, whitespace, error-message
  contents.
- `pkg/slice/metrics/provider_test.go` — 3 Provider specs: allowed
  host accepted, unlisted host rejected with wrapped
  `ErrEndpointNotAllowed`, zero-value permits all.
- `internal/controller/ntnslice_controller_test.go` — 1 envtest spec
  drives the rejection through the reconciler and asserts
  `reason=EndpointNotAllowed` + offending host in the condition Message.
- `make test` and `make lint` clean on the whole repo.

## Test plan

- [x] `go test -race ./pkg/netutil/...`
- [x] `go test -race ./pkg/slice/metrics/...`
- [x] envtest spec with allow-list rejection path
- [x] `make test` whole repo
- [x] `make lint` clean

## Scope intentionally deferred

- Glob / regex allow-list patterns — exact match covers the current
  use cases; add later if operators report needing wildcards.
- Dynamic allow-list via ConfigMap — single-flag keeps RBAC surface
  tight; dynamic version can be a separate feature with its own
  RBAC/reload story.
- NetworkPolicy templates in `config/` — deployment environment
  specific, out of scope.