### PR TITLE
test(cmd): cover test-metrics-exporter main() wiring (#94)

### DIFF
--- a/cmd/test-metrics-exporter/main.go
+++ b/cmd/test-metrics-exporter/main.go
@@ -30,6 +30,7 @@ import (
 	"log"
 	"net/http"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -40,12 +41,18 @@ import (
 // anchored at now. Extracted so main() and unit tests see the same
 // guard logic — a zero or negative interval would otherwise silently
 // short-circuit the simulator to degradedMetrics on every scrape.
+// If both flags are bad, both are reported in one error so an admin
+// does not have to re-run the binary to find the second mistake.
 func buildSimulator(pass, gap time.Duration) (Simulator, error) {
+	var problems []string
 	if pass <= 0 {
-		return Simulator{}, fmt.Errorf("pass-duration must be positive, got %s", pass)
+		problems = append(problems, fmt.Sprintf("pass-duration must be positive, got %s", pass))
 	}
 	if gap <= 0 {
-		return Simulator{}, fmt.Errorf("gap-duration must be positive, got %s", gap)
+		problems = append(problems, fmt.Sprintf("gap-duration must be positive, got %s", gap))
+	}
+	if len(problems) > 0 {
+		return Simulator{}, errors.New(strings.Join(problems, "; "))
 	}
 	return Simulator{Start: time.Now(), PassDuration: pass, GapDuration: gap}, nil
 }

--- a/cmd/test-metrics-exporter/main.go
+++ b/cmd/test-metrics-exporter/main.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os/signal"
@@ -34,6 +35,33 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// buildSimulator validates positive durations and returns a Simulator
+// anchored at now. Extracted so main() and unit tests see the same
+// guard logic — a zero or negative interval would otherwise silently
+// short-circuit the simulator to degradedMetrics on every scrape.
+func buildSimulator(pass, gap time.Duration) (Simulator, error) {
+	if pass <= 0 {
+		return Simulator{}, fmt.Errorf("pass-duration must be positive, got %s", pass)
+	}
+	if gap <= 0 {
+		return Simulator{}, fmt.Errorf("gap-duration must be positive, got %s", gap)
+	}
+	return Simulator{Start: time.Now(), PassDuration: pass, GapDuration: gap}, nil
+}
+
+// newMux assembles the public HTTP surface of the exporter: /metrics
+// serves the Prometheus handler, /healthz is a minimal liveness probe.
+// Lifted out of main() so tests can exercise the routing table without
+// spawning a real listener.
+func newMux(handler *Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", handler)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
+}
 
 func main() {
 	var (
@@ -45,26 +73,15 @@ func main() {
 	)
 	flag.Parse()
 
-	if *passDuration <= 0 || *gapDuration <= 0 {
-		log.Fatalf("pass-duration and gap-duration must both be positive; got pass=%s gap=%s", *passDuration, *gapDuration)
-	}
-
-	sim := Simulator{
-		Start:        time.Now(),
-		PassDuration: *passDuration,
-		GapDuration:  *gapDuration,
+	sim, err := buildSimulator(*passDuration, *gapDuration)
+	if err != nil {
+		log.Fatalf("invalid flag: %v", err)
 	}
 	handler := NewHandler(prometheus.NewRegistry(), sim, *namespace, *slice, time.Now)
 
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", handler)
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
 	srv := &http.Server{
 		Addr:              *listen,
-		Handler:           mux,
+		Handler:           newMux(handler),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/cmd/test-metrics-exporter/main_test.go
+++ b/cmd/test-metrics-exporter/main_test.go
@@ -20,10 +20,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// newTestMux builds the same http.ServeMux main() assembles, so we can
-// exercise its routing and health behaviour without spawning a real
-// process. Any future addition of a new route should extend both this
-// helper and the main() equivalent in lockstep.
+// newTestHandler builds the same *Handler configuration main() wires
+// up, so tests can feed it to newMux(...) and exercise the routing +
+// health surface without spawning a real process. Any future change
+// to how main() constructs the Handler should update this helper in
+// lockstep.
 func newTestHandler(t *testing.T) *Handler {
 	t.Helper()
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -76,16 +77,20 @@ func TestBuildSimulator_RejectsNonPositiveDurations(t *testing.T) {
 	// builder exposes the same validation surface so main() can fail
 	// fast with a clear message.
 	cases := []struct {
-		name     string
-		pass     time.Duration
-		gap      time.Duration
-		wantErr  bool
-		errMatch string
+		name        string
+		pass        time.Duration
+		gap         time.Duration
+		wantErr     bool
+		mustMention []string // substrings that must all appear in the error
 	}{
-		{"both positive", time.Second, time.Second, false, ""},
-		{"zero pass", 0, time.Second, true, "pass-duration"},
-		{"zero gap", time.Second, 0, true, "gap-duration"},
-		{"negative pass", -1, time.Second, true, "pass-duration"},
+		{"both positive", time.Second, time.Second, false, nil},
+		{"zero pass", 0, time.Second, true, []string{"pass-duration"}},
+		{"zero gap", time.Second, 0, true, []string{"gap-duration"}},
+		{"negative pass", -1, time.Second, true, []string{"pass-duration"}},
+		{"negative gap", time.Second, -1, true, []string{"gap-duration"}},
+		// When both flags are wrong the admin needs to see both mistakes
+		// in one run, not fix one and re-run to discover the next.
+		{"both non-positive", 0, -1, true, []string{"pass-duration", "gap-duration"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -96,8 +101,10 @@ func TestBuildSimulator_RejectsNonPositiveDurations(t *testing.T) {
 			if !tc.wantErr && err != nil {
 				t.Fatalf("want no error for pass=%v gap=%v, got %v", tc.pass, tc.gap, err)
 			}
-			if tc.wantErr && !strings.Contains(err.Error(), tc.errMatch) {
-				t.Errorf("error %q should mention %q", err, tc.errMatch)
+			for _, want := range tc.mustMention {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q should mention %q", err, want)
+				}
 			}
 		})
 	}

--- a/cmd/test-metrics-exporter/main_test.go
+++ b/cmd/test-metrics-exporter/main_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// newTestMux builds the same http.ServeMux main() assembles, so we can
+// exercise its routing and health behaviour without spawning a real
+// process. Any future addition of a new route should extend both this
+// helper and the main() equivalent in lockstep.
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return NewHandler(
+		prometheus.NewRegistry(),
+		Simulator{Start: start, PassDuration: 10 * time.Second, GapDuration: 10 * time.Second},
+		"default", "e2e-slice",
+		func() time.Time { return start.Add(3 * time.Second) }, // inside the pass window
+	)
+}
+
+func TestNewMux_MetricsRouteServesExporterOutput(t *testing.T) {
+	mux := newMux(newTestHandler(t))
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/metrics status = %d, want 200", w.Code)
+	}
+	body, _ := io.ReadAll(w.Result().Body)
+	if !strings.Contains(string(body), "ntn_e2e_rsrp_dbm") {
+		t.Errorf("/metrics body missing ntn_e2e_rsrp_dbm line; got:\n%s", body)
+	}
+}
+
+func TestNewMux_HealthzReturns200(t *testing.T) {
+	mux := newMux(newTestHandler(t))
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/healthz status = %d, want 200", w.Code)
+	}
+}
+
+func TestNewMux_UnknownRouteReturns404(t *testing.T) {
+	mux := newMux(newTestHandler(t))
+	req := httptest.NewRequest("GET", "/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("unknown route status = %d, want 404", w.Code)
+	}
+}
+
+func TestBuildSimulator_RejectsNonPositiveDurations(t *testing.T) {
+	// Guards the flag-validation path main() does at startup: a zero or
+	// negative pass/gap duration would produce a pathological simulator
+	// that always returns degradedMetrics, silently breaking E2E. The
+	// builder exposes the same validation surface so main() can fail
+	// fast with a clear message.
+	cases := []struct {
+		name     string
+		pass     time.Duration
+		gap      time.Duration
+		wantErr  bool
+		errMatch string
+	}{
+		{"both positive", time.Second, time.Second, false, ""},
+		{"zero pass", 0, time.Second, true, "pass-duration"},
+		{"zero gap", time.Second, 0, true, "gap-duration"},
+		{"negative pass", -1, time.Second, true, "pass-duration"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSimulator(tc.pass, tc.gap)
+			if tc.wantErr && err == nil {
+				t.Fatalf("want error for pass=%v gap=%v, got nil", tc.pass, tc.gap)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want no error for pass=%v gap=%v, got %v", tc.pass, tc.gap, err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.errMatch) {
+				t.Errorf("error %q should mention %q", err, tc.errMatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #94. Adds test coverage for the `cmd/test-metrics-exporter`
binary's previously-untested glue code — HTTP routing table and
flag-validation path — by pulling them into two small named helpers
that unit tests can exercise directly.

## What changed

- `main.go` grows two package-level helpers:
  - `buildSimulator(pass, gap)` — validates positive durations and
    anchors a `Simulator` at `time.Now()`. main() used to do this
    inline, so a mistake in the guard would only surface when the
    first scrape came in and returned all-degraded metrics. When
    both flags are bad the returned error joins per-flag messages
    with `"; "` so an admin sees every mistake in one run rather
    than fixing one and re-running to discover the next.
  - `newMux(handler)` — assembles the `/metrics` + `/healthz`
    routing table. Lets tests verify the routes without spawning a
    listener and chasing an ephemeral port.
- `main()` shrinks to a thin wrapper around those helpers.

## User-visible startup-failure message change

This PR does change the fatal-error text emitted when the binary
starts with a non-positive pass/gap duration:

- Before: `pass-duration and gap-duration must both be positive; got pass=... gap=...`
- After:  `invalid flag: pass-duration must be positive, got 0s`
  (plus `; gap-duration must be positive, got 0s` when both are wrong)

The new text names only the offending flag(s) instead of
unconditionally listing both, which is more precise. The binary is a
dev fixture — nothing scripted depends on the old wording — but
calling the change out explicitly so runbook authors can update
their examples if any reference the failure text.

## Tests

- `/metrics` returns 200 with the synthetic `ntn_e2e_rsrp_dbm` line.
- `/healthz` returns 200.
- Unknown routes return 404.
- `buildSimulator`: 6 table-driven cases — both-positive accepted,
  zero/negative pass rejected, zero/negative gap rejected,
  both-non-positive rejected with both problems named.

## Scope intentionally unchanged

- No integration test with real SIGTERM / listener lifecycle. The
  graceful-shutdown path remains untested; for a fixture binary
  the cost of a flaky OS-level process test outweighs the value.

## Test plan

- [x] `go test -race ./cmd/test-metrics-exporter/...`
- [x] `make test` whole repo
- [x] `make lint` clean