### PR TITLE
release: prepare v0.4.0-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,10 @@ jobs:
         uses: softprops/action-gh-release@c95fe17002a23e40138e5b0a4023b830a3e108c4 # v3.0.0
         with:
           generate_release_notes: true
+          # Mark every -rc / -beta / -alpha / -preview tag as a
+          # pre-release so it does not show up as "Latest" on the
+          # repository page and npm/Helm consumers can opt out.
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-preview') }}
           files: |
             ntn-operators-${{ steps.version.outputs.VERSION }}.tgz
             sbom.spdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,10 +136,12 @@ jobs:
         uses: softprops/action-gh-release@c95fe17002a23e40138e5b0a4023b830a3e108c4 # v3.0.0
         with:
           generate_release_notes: true
-          # Mark every -rc / -beta / -alpha / -preview tag as a
-          # pre-release so it does not show up as "Latest" on the
-          # repository page and npm/Helm consumers can opt out.
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-preview') }}
+          # Any SemVer tag with a pre-release identifier (the "-xxx"
+          # suffix) is flagged as a pre-release, so it does not show up
+          # as "Latest" on the Releases page and Helm OCI consumers can
+          # skip it via version constraints. Matches -rc / -beta /
+          # -alpha / -dev / -snapshot / etc. in one expression.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             ntn-operators-${{ steps.version.outputs.VERSION }}.tgz
             sbom.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,17 @@ is optional with the prior behaviour as its default.
 - **New operator flag** `--prometheus-allowed-endpoint-hosts` defaults to
   empty (permit-all) — existing deployments that did not set it before
   continue to work without change.
-- **OLM upgrade** path is explicit: CSV `ntn-operators.v0.4.0-rc.1`
-  declares `replaces: ntn-operators.v0.1.0`; the channel graph skips
-  directly from 0.1.0 → 0.4.0-rc.1. No intermediate CSVs are published
-  because v0.2 / v0.3 were never cut as standalone tags.
+- **OLM upgrade** path uses `spec.skipRange: "<0.4.0-rc.1"`, not an
+  explicit `replaces:`, because the OLM bundle infrastructure
+  landed in PR #91 (after the v0.1.0 tag) so no published
+  `ntn-operators.v0.1.0` CSV exists to replace. skipRange lets this
+  CSV take over from any earlier-installed bundle if one is ever
+  cataloged, without requiring v0.1.0 to exist.
+- **External `NTNProvider` implementers** must add three methods
+  (`EnsureOwnership`, `Cleanup`, `PushEphemerisUpdate`) to satisfy
+  the interface (#20, #72). In practice nobody does — only
+  `pkg/provider/ocudu` implements it — but the break is real for
+  anyone who built a downstream provider against v0.1.0.
 
 ### Known deferrals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ is optional with the prior behaviour as its default.
 - Controller benchmarks and `--max-concurrent-reconciles` (#59)
 - Container image scanning (Trivy) + cosign signing + SPDX SBOM (#61, #62)
 - Validating admission webhook for NTNSlice trigger syntax (#70)
-- OLM bundle for OperatorHub publishing (#60; CSV replaces v0.1.0)
+- OLM bundle for OperatorHub publishing (#60; CSV uses `spec.skipRange: "<0.4.0-rc.1"` because v0.1.0 never published a catalog entry)
 
 **Observability**
 - `ntn_operators_reader_query_duration_seconds{source,outcome}` histogram

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,103 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0-rc.1] - 2026-04-21
+
+Release candidate for 0.4.0 consolidating the v0.2 Core Hardening, v0.3
+Dynamic Ephemeris, and v0.4 Production Readiness milestones into a single
+publishable artifact. No breaking CRD changes vs 0.1.0 — every new field
+is optional with the prior behaviour as its default.
+
+### Added
+
+**Dynamic ephemeris (v0.3)**
+- SpaceTrack dynamic GP fetcher with Secret-backed credentials (#22, #23)
+- SGP4 propagator — OMM → 3GPP ECEF conversion (#37 via #75)
+- `NTNCellConfig.spec.ephemerisRef` — re-reconcile on SatelliteEphemeris update (#20)
+- `NTNProvider.PushEphemerisUpdate` interface method (#20)
+
+**Failover and metrics (v0.4)**
+- Signal-hysteresis dead-band for trigger anti-flapping (#50)
+- `NTNSlice.spec.metricsSource` pluggable metrics source — annotations or
+  Prometheus, with per-UID stale-cache and reader-layer observability (#67)
+- Synthetic `cmd/test-metrics-exporter` for deterministic E2E (#67 / #94)
+- `--prometheus-allowed-endpoint-hosts` operator flag — optional SSRF
+  allow-list for multi-tenant deployments (#93)
+- `MetricsStale` / `EndpointNotAllowed` / `MetricsUnavailable` /
+  `MetricsReaderError` failover-ready reasons, each distinct and actionable
+
+**Production readiness (v0.4)**
+- Helm NetworkPolicy template (#58)
+- Controller benchmarks and `--max-concurrent-reconciles` (#59)
+- Container image scanning (Trivy) + cosign signing + SPDX SBOM (#61, #62)
+- Validating admission webhook for NTNSlice trigger syntax (#70)
+- OLM bundle for OperatorHub publishing (#60; CSV replaces v0.1.0)
+
+**Observability**
+- `ntn_operators_reader_query_duration_seconds{source,outcome}` histogram
+- `ntn_operators_reader_errors_total{source,reason}` counter (5 reasons)
+- `ntn_operators_reader_stale_value_used_total{namespace,name}` counter;
+  evicted on CR deletion
+- Grafana dashboard (6 panels) shipped under `config/grafana/`
+
+**API additions (all backward compatible)**
+- SIB19 Stage 2/3 multi-cell NTN fields (#19 via #33 #34)
+- `NTNCellConfig.spec.ntn.ephemerisOrbital` alternative (#21 via #30)
+- `FailoverPolicy.hysteresisMargin` string field (#50)
+- `NTNSlice.spec.metricsSource` block (#67)
+- 12 CEL XValidation rules (was 7 at 0.1.0), including `MetricsSource`
+  type-requires-prometheus, queries-non-empty, endpoint-URL-pattern
+
+### Changed
+
+- Controller decoupled from OCUDU-specific imports; `NTNProvider` interface
+  gained `EnsureOwnership` / `Cleanup` methods (#72)
+- Package-level structured logging across all runtime packages (#7, #39)
+- NTNSlice reconciler now calls `ReaderProvider.For(ns).Read()` in place
+  of the inline `readMetrics()` (#67); behaviour change is gated on
+  `spec.metricsSource.type=prometheus` so existing annotation-driven CRs
+  continue unchanged
+
+### Fixed
+
+- SpaceTrack credentials no longer interleave across concurrent reconciles (#8)
+- `ConfigMapNameFor` adds hash suffix, preventing truncation collisions (#9)
+- Firmware version sync drift → `UpdateInterrupted`/`Degraded` transition (#14)
+- Global `os.Chdir` in test util removed (#16)
+- `nodeToGroundStation` handles hashed labels for long namespace/name (#41)
+- Chart.yaml stale `srsran` keyword removed (#42)
+- Polarization schema aligned with OCUDU YAML + TS 38.331 enum values (#45)
+
+### Security
+
+- All CI action versions pinned to commit SHA (#17 via #27)
+- Dependabot enabled for automated dependency updates (#63)
+- SSRF allow-list for user-supplied Prometheus endpoints (#93)
+- IP-level SSRF hardening lives in operator Pod NetworkPolicy, not in CRD
+  schema — explicit non-goal per design doc `docs/design/metrics-source.md`
+
+### Upgrade notes from 0.1.0
+
+- **CRD schema is backward compatible**. Existing NTNSlice/NTNCellConfig
+  CRs remain valid. No conversion webhook required.
+- **NTNSlice behaviour** is unchanged unless `spec.metricsSource.type` is
+  set to `prometheus`. Annotation-based simulation is still the default.
+- **New operator flag** `--prometheus-allowed-endpoint-hosts` defaults to
+  empty (permit-all) — existing deployments that did not set it before
+  continue to work without change.
+- **OLM upgrade** path is explicit: CSV `ntn-operators.v0.4.0-rc.1`
+  declares `replaces: ntn-operators.v0.1.0`; the channel graph skips
+  directly from 0.1.0 → 0.4.0-rc.1. No intermediate CSVs are published
+  because v0.2 / v0.3 were never cut as standalone tags.
+
+### Known deferrals
+
+- `#49` multi-satellite failover — moved to v0.5 (engineering freeze)
+- `#65` OAI gNB provider — moved to v1.0 (1-week+ scope)
+- `#68` real antenna readiness probe — moved to v1.0 (requires hardware)
+- `#69` SessionContinuity during failover — v1.0, paused
+- `#47` / `#52` / `#53` — blocked on upstream OCUDU parser, v1.0
+
 ## [0.1.0] - 2026-04-17
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.1.0
+VERSION ?= 0.4.0-rc.1
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,8 +40,13 @@ Pre-requisites:
   chart version from the tag at publish time; source consistency is
   still required so `helm template` off `main` produces sensible
   output.)
-- The CSV's `spec.replaces` points at the previous **published** CSV
-  so OLM's upgrade graph is continuous.
+- The CSV's upgrade-graph metadata is correct for the catalog state:
+  prefer `spec.replaces: ntn-operators.vX.Y.Z-prev` when the previous
+  CSV was actually published to an OperatorHub catalog; fall back to
+  `spec.skipRange: "<X.Y.Z"` when no prior CSV was published (which
+  was the case for v0.4.0-rc.1 — v0.1.0 predated the bundle
+  infrastructure). Do not set `replaces:` pointing at a CSV that
+  never existed in a catalog — OLM will reject the bundle.
 
 Steps:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,106 @@
+# Release process
+
+This project follows [SemVer](https://semver.org) with the pre-1.0
+relaxations documented below, and uses tag-triggered automation to
+publish every release artifact.
+
+## Cadence
+
+- **Minor releases** every 2-4 weeks, covering a milestone worth of
+  features (see `gh milestone list`).
+- **Patch releases** within 24-72 hours when a critical fix lands.
+- **Release candidates** precede every minor release — tag
+  `vX.Y.Z-rc.N` before the final `vX.Y.Z`. Soak ≥ 3 days unless the
+  change set is trivial.
+
+Main must stay releasable. Any merged PR should be such that cutting
+a tag at HEAD would produce a shippable artifact.
+
+## SemVer while pre-1.0
+
+- Major stays at 0.
+- Minor may carry breaking CRD changes with a migration note in
+  CHANGELOG.
+- Patch is backwards-compatible fixes only.
+- 1.0 will freeze the v1alpha1 → v1beta1 transition policy and commit
+  to API stability.
+
+## Cutting a release
+
+Pre-requisites:
+- CI green on `main`.
+- `gh milestone list` shows the target milestone has no blocking open
+  issues (paused / aspirational items moved to the next milestone).
+- `CHANGELOG.md` has a dated entry for the new version under the
+  `## [X.Y.Z] - YYYY-MM-DD` heading.
+- `dist/chart/Chart.yaml`, `dist/chart/values.yaml`,
+  `bundle/manifests/*.clusterserviceversion.yaml`,
+  `config/manager/kustomization.yaml`, and `Makefile VERSION` all
+  reference the new version. (The release workflow double-bumps the
+  chart version from the tag at publish time; source consistency is
+  still required so `helm template` off `main` produces sensible
+  output.)
+- The CSV's `spec.replaces` points at the previous **published** CSV
+  so OLM's upgrade graph is continuous.
+
+Steps:
+
+1. Open a `release/vX.Y.Z` branch with the version bumps above.
+2. Run `make test lint` locally. Review the bumped CSV under
+   `operator-sdk bundle validate` if available.
+3. Open a PR, land it, then:
+   ```
+   git tag -a vX.Y.Z-rc.1 -m "vX.Y.Z release candidate 1"
+   git push origin vX.Y.Z-rc.1
+   ```
+4. Monitor `.github/workflows/release.yml`. It will:
+   - ko build + Trivy scan + push multi-arch image to GHCR
+   - cosign sign (keyless OIDC)
+   - generate SPDX SBOM and attest it to the image index
+   - package + push the Helm chart to `oci://ghcr.io/<owner>`
+   - create the GitHub Release (auto-generated notes + chart tarball
+     + SBOM JSON attached)
+5. Smoke-test the RC:
+   - Pull the image and run against a test cluster.
+   - Install the chart via OCI and verify CRDs apply cleanly.
+   - If there is a running cluster with the previous version, test
+     OLM upgrade via the bundle image.
+6. After soak, tag the final version:
+   ```
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+7. Mark the RC GitHub Release as pre-release (should be automatic
+   because of the `-rc` suffix).
+
+## Breaking changes
+
+While pre-1.0 a minor bump may carry a breaking CRD change. When it
+does:
+
+- Add an **Upgrade notes** section to the CHANGELOG entry spelling
+  out what changed and how to migrate.
+- Provide a manual migration path (kubectl patch, in-place edit,
+  migration pod) — conversion webhooks are deferred until 1.0.
+- Announce the break in the GitHub Release body prominently.
+
+## Artifacts a release produces
+
+- Git tag, annotated
+- GitHub Release with auto-generated notes + chart `.tgz` + SBOM
+- Multi-arch container image at `ghcr.io/thc1006/ntn-operators:vX.Y.Z`
+  plus `:latest`
+- cosign signature attached to the image index
+- SPDX SBOM attested to the image index
+- Helm chart at `oci://ghcr.io/thc1006/ntn-operators`, version
+  `X.Y.Z`, appVersion `X.Y.Z`
+- OLM bundle image at
+  `ghcr.io/thc1006/ntn-operators-bundle:vX.Y.Z`
+  (after `make bundle-build bundle-push VERSION=X.Y.Z`)
+
+## CNCF Sandbox / OperatorHub expectations
+
+The project targets CNCF Sandbox and OperatorHub listing. Both value
+release cadence over single-release novelty — the second release
+matters as much as the first. Keep cadence tight and the CHANGELOG
+honest.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,8 +70,9 @@ Steps:
    git tag -a vX.Y.Z -m "vX.Y.Z"
    git push origin vX.Y.Z
    ```
-7. Mark the RC GitHub Release as pre-release (should be automatic
-   because of the `-rc` suffix).
+7. The GitHub Release is auto-flagged as pre-release whenever the
+   tag carries any pre-release identifier (the `-rc` / `-beta` /
+   similar suffix), so nothing further is required on the UI.
 
 ## Breaking changes
 

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -208,4 +208,11 @@ spec:
   provider:
     name: ntn-operators
     url: https://github.com/thc1006/ntn-operators
+  # skipRange, not replaces: no v0.1.0 CSV was ever published to an
+  # OperatorHub catalog (the bundle infrastructure landed in PR #91,
+  # after the v0.1.0 tag). An explicit `replaces:` would therefore
+  # point OLM at a CSV it cannot find, failing the install. skipRange
+  # says "this CSV can take over from anything older than itself" and
+  # is safe whether or not an older CSV exists in the catalog.
+  skipRange: "<0.4.0-rc.1"
   version: 0.4.0-rc.1

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -47,11 +47,11 @@ metadata:
       ]
     categories: Networking
     capabilities: Full Lifecycle
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.1.0
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.4.0-rc.1
     repository: https://github.com/thc1006/ntn-operators
     createdAt: "2026-04-15T00:00:00Z"
     support: thc1006
-  name: ntn-operators.v0.1.0
+  name: ntn-operators.v0.4.0-rc.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -138,7 +138,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.1.0
+                    image: ghcr.io/thc1006/ntn-operators:v0.4.0-rc.1
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -208,4 +208,4 @@ spec:
   provider:
     name: ntn-operators
     url: https://github.com/thc1006/ntn-operators
-  version: 0.1.0
+  version: 0.4.0-rc.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.1.0
+  newTag: v0.4.0-rc.1

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.4.0-rc.1
+appVersion: "0.4.0-rc.1"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.1.0` | Image tag |
+| `manager.image.tag` | string | `v0.4.0-rc.1` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.1.0
+    tag: v0.4.0-rc.1
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
## Summary

Release prep PR for `v0.4.0-rc.1`. Bumps every version-pinned
location, adds the OLM upgrade-graph edge, writes a release policy
doc, and teaches the release workflow to flag RC tags as GitHub
pre-releases.

**Landing this PR does not publish anything.** The release itself
happens only after the `v0.4.0-rc.1` tag is pushed, which triggers
`.github/workflows/release.yml` to ko-build + cosign + SBOM +
helm-push + GitHub Release.

## Version bumps (10 locations)

| File | Change |
|---|---|
| `Makefile` `VERSION` | `0.1.0` → `0.4.0-rc.1` |
| `dist/chart/Chart.yaml` `version` | `0.1.0` → `0.4.0-rc.1` |
| `dist/chart/Chart.yaml` `appVersion` | `"0.1.0"` → `"0.4.0-rc.1"` |
| `dist/chart/values.yaml` `image.tag` | `v0.1.0` → `v0.4.0-rc.1` |
| `dist/chart/README.md` doc example | `v0.1.0` → `v0.4.0-rc.1` |
| `config/manager/kustomization.yaml` `newTag` | `v0.1.0` → `v0.4.0-rc.1` |
| CSV `containerImage` | `:v0.1.0` → `:v0.4.0-rc.1` |
| CSV `metadata.name` | `ntn-operators.v0.1.0` → `ntn-operators.v0.4.0-rc.1` |
| CSV deployment `image` | `:v0.1.0` → `:v0.4.0-rc.1` |
| CSV `spec.version` | `0.1.0` → `0.4.0-rc.1` |

## OLM upgrade graph — `skipRange`, not `replaces`

New CSV field: `spec.skipRange: "<0.4.0-rc.1"`.

Crucially, **not** `spec.replaces: ntn-operators.v0.1.0`. The v0.1.0
tag predates the OLM bundle infrastructure (added in PR #91), so no
`ntn-operators.v0.1.0` CSV was ever published to an OperatorHub
catalog. An explicit `replaces:` pointing at a non-existent CSV
would fail OperatorHub ingest. `skipRange` expresses the same intent
("this CSV takes over from anything older") while staying valid
whether or not an older catalog entry exists.

## Content summary (v0.1.0 → v0.4.0-rc.1)

237 commits, 258 files, zero breaking CRD changes. The `NTNProvider`
interface did gain three methods (`EnsureOwnership`, `Cleanup`,
`PushEphemerisUpdate`), which is a compile-break for anyone who
implemented the interface outside this repo; in practice only
`pkg/provider/ocudu` does, but the break is disclosed in the
CHANGELOG upgrade notes.

See `CHANGELOG.md` for the grouped list (Added / Changed / Fixed /
Security / Upgrade notes / Known deferrals).

Highlights:
- Dynamic ephemeris: SpaceTrack fetcher + SGP4 propagator
- Pluggable metrics source with stale-cache + observability
- Signal hysteresis, benchmarks, NetworkPolicy, cosign/SBOM, OLM bundle
- Validating webhook for trigger syntax
- SSRF allow-list flag for multi-tenant

## Release-workflow change

`.github/workflows/release.yml` Create-GitHub-Release step sets
`prerelease: true` whenever the tag carries a pre-release identifier
— any SemVer `-xxx` suffix (`-rc`, `-beta`, `-alpha`, `-dev`,
`-snapshot`, ...). Without this, an RC would show up as "Latest" on
the Releases page.

## New doc: `RELEASING.md`

Captures cadence (minor every 2-4 weeks, patch within 24-72h),
SemVer-pre-1.0 policy, exact cut steps, and what the automation
produces per release. Covers both `replaces:` and `skipRange:`
upgrade-graph strategies so future releases don't re-learn this.

## Milestone housekeeping

Moved `#49` multi-satellite failover from v0.4 → v0.5 (engineering
freeze) so v0.4 closes out 10 closed / 0 open.

## Test plan

- [x] `make test` full repo green
- [x] `make lint` clean
- [x] All 0.1.0 references under source control bumped (grep)
- [x] CSV `spec.skipRange` present (not `replaces`, per catalog state)
- [x] CI green on this PR
- [ ] After merge: `git tag v0.4.0-rc.1 && git push` triggers the
      release workflow
- [ ] Post-release: soak RC ≥ 3 days, then tag `v0.4.0` final