### PR TITLE
fix(ci): correct action SHAs broken in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372be43b8aaf1a781145e41e40d45c4a91e0 # v3.8.2
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e3c8f0c08 # v0.18.0
+        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -133,7 +133,7 @@ jobs:
           helm push ntn-operators-${{ steps.version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe17002a23e40138e5b0a4023b830a3e108c4 # v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           # Any SemVer tag with a pre-release identifier (the "-xxx"


### PR DESCRIPTION
## Context

`v0.4.0-rc.1` tag was pushed at 08:24 UTC and the release workflow
failed immediately at **Set up job** with three
`Unable to resolve action` errors ([failed run](https://github.com/thc1006/ntn-operators/actions/runs/24712078257)):

- `sigstore/cosign-installer@3454372be43b8aaf1a781145e41e40d45c4a91e0`
- `anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e3c8f0c08`
- `softprops/action-gh-release@c95fe17002a23e40138e5b0a4023b830a3e108c4`

Each diverges from the real SHA of the tag named in the trailing
comment. Looked up via `gh api repos/<action>/git/ref/tags/<tag>`:

| Action | tag | SHA in release.yml | Real SHA |
|---|---|---|---|
| sigstore/cosign-installer | v3.8.2 | `3454372b…4a91e0` | `3454372f…ca52bb` |
| anchore/sbom-action | v0.18.0 | `f325610c…8f0c08` | `f325610c…f4de0` |
| softprops/action-gh-release | v3.0.0 | `c95fe170…e108c4` | `b4309332…bfbfda` |

Presumably hand-typed in the original supply-chain-pinning PR
(#27) without a round-trip verification. The release workflow runs
only on `v*` tags and no tag had been cut between #27 and today's
v0.4.0-rc.1, so the regression was invisible until now.

## What changed

Three one-line SHA corrections in `.github/workflows/release.yml`.
No other functional change.

## Blast radius of the failed run

- Failed at "Prepare all required actions" step, before checkout.
- No container image pushed to GHCR.
- No Helm chart published.
- No GitHub Release created (`gh release view v0.4.0-rc.1` →
  "release not found").
- No SBOM attested.

Nothing leaked. The `v0.4.0-rc.1` tag has been deleted on local and
remote so it can be re-applied cleanly once this PR lands.

## Test plan

- [x] Verified each correct SHA via `gh api repos/<action>/git/ref/tags/<tag>`
- [x] Existing lint / test workflows unchanged; only release.yml touched
- [ ] After merge: `git tag -a v0.4.0-rc.1 <merge-sha> -m ... && git push origin v0.4.0-rc.1`
- [ ] Monitor release workflow run end-to-end