### PR TITLE
fix: bump Go to 1.26.2 for Trivy CVE clearance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/test-metrics-exporter/Dockerfile
+++ b/cmd/test-metrics-exporter/Dockerfile
@@ -1,6 +1,6 @@
 # Synthetic Prometheus exporter for NTNSlice E2E tests.
 # Build locally with: docker build -t test-metrics-exporter:latest -f cmd/test-metrics-exporter/Dockerfile .
-FROM golang:1.25-alpine AS build
+FROM golang:1.26.2-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thc1006/ntn-operators
 
-go 1.25.3
+go 1.26.2
 
 require (
 	github.com/akhenakh/sgp4 v0.0.0-20260314155803-8ee03fc877eb


### PR DESCRIPTION
## Summary

`v0.4.0-rc.1` release workflow's Trivy scan gate rejected the image
with 8 HIGH-severity Go-runtime CVEs. All of them require Go
>= 1.25.9 or >= 1.26.2 per the Aqua vulnerability DB. Bumping
`go.mod` from 1.25.3 to 1.26.2 (matching the main `Dockerfile`
and pinning to a specific patch) clears every one.

## CVEs closed

| CVE | Subsystem | Fixed in |
|---|---|---|
| CVE-2025-61726 | `net/url` memory exhaustion | 1.24.12, 1.25.6 |
| CVE-2025-61728 | `archive/zip` CPU consumption | 1.24.12, 1.25.6 |
| CVE-2025-61729 | `crypto/x509` DoS | 1.24.11, 1.25.5 |
| CVE-2025-68121 | TLS session resumption | — |
| CVE-2026-25679 | `net/url` IPv6 literal parse | 1.25.8, 1.26.1 |
| CVE-2026-32280 | `crypto/x509` cert chain DoS | 1.25.9, 1.26.2 |
| CVE-2026-32281 | `crypto/x509` cert chain DoS | 1.25.9, 1.26.2 |
| CVE-2026-32283 | TLS key update DoS | 1.25.9, 1.26.2 |

## What changed

| File | Before | After |
|---|---|---|
| `go.mod` | `go 1.25.3` | `go 1.26.2` |
| `Dockerfile` | `FROM golang:1.26` | `FROM golang:1.26.2` |
| `cmd/test-metrics-exporter/Dockerfile` | `FROM golang:1.25-alpine` | `FROM golang:1.26.2-alpine` |

## What did NOT change

- No Go 1.26-only language features introduced; the bump is a
  toolchain refresh, not a migration.
- No API / CRD / behaviour change.
- Test files unchanged.

## Local test notes

`go mod tidy` clean. `go test ./...` reports every package `ok`
when run inside a clean 1.26.2 environment. On this dev machine
the host Go is still 1.25.3, which produces spurious `compile:
version "go1.26.2" does not match go tool version "go1.25.3"`
output during `go vet` — a stdlib cache-version mismatch that
disappears on CI because `setup-go@v6.4.0 with go-version-file:
go.mod` pulls a clean 1.26.2 toolchain.

## Release context

The `v0.4.0-rc.1` tag was deleted on both local and remote after
the Trivy failure so it can be re-applied cleanly once this PR
lands and the release workflow finally gets a green run.

## Test plan

- [ ] CI green on this PR (pending)
- [ ] After merge: re-tag `v0.4.0-rc.1` on the new main HEAD,
      push, monitor release workflow to `gh release view v0.4.0-rc.1`
      reporting a real prerelease