### PR TITLE
ci: tighten e2e path filter, add release dry-run dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dispatch lets us validate the build/scan pipeline without
+  # cutting a real tag. Default is dry_run=true (no image push, no
+  # Helm push, no GitHub Release). After v0.4.0-rc.1 needed four
+  # publish-time fixes (action SHAs, then Trivy CVEs), having a way
+  # to dry-run the full pipeline pre-tag is worth the small surface.
+  # Real releases still come from tag pushes.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip pushing image, chart, and GitHub Release.'
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -39,15 +51,34 @@ jobs:
         uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
       - name: Login to GHCR
+        # Skip on dispatch dry-run: nothing will be pushed.
+        # Truth table: push event → publish; dispatch dry_run=true → skip;
+        # dispatch dry_run=false → publish (with synthetic version below).
+        if: github.event_name == 'push' || inputs.dry_run == false
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get version from tag
+      - name: Resolve version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Synthetic version for dispatch builds. The image push is
+            # gated below on dry_run=false, so this only ever lands in
+            # the registry on an explicit override — and never clobbers
+            # a real tag thanks to the SHA suffix.
+            VERSION="0.0.0-dispatch-${GITHUB_SHA::7}"
+            TAG="v${VERSION}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#v}"
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=${VERSION} tag=${TAG}"
 
       # --- Scan before publish: build locally, scan, then push ---
 
@@ -76,13 +107,22 @@ jobs:
       # gate; for full coverage, per-platform scanning would be needed.
 
       - name: Push multi-arch image to GHCR
+        if: github.event_name == 'push' || inputs.dry_run == false
         id: ko-push
         env:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
+          set -euo pipefail
+          # `latest` is reserved for tag pushes — dispatch builds use the
+          # synthetic SHA-suffixed tag only, never `latest`.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAGS="${{ steps.version.outputs.TAG }}"
+          else
+            TAGS="${{ steps.version.outputs.TAG }},latest"
+          fi
           IMAGE_REF=$(ko build ./cmd/ \
             --platform=linux/amd64,linux/arm64 \
-            --tags=${{ github.ref_name }},latest \
+            --tags="${TAGS}" \
             --bare)
           echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
           echo "Image ref: ${IMAGE_REF}"
@@ -90,16 +130,19 @@ jobs:
       # --- Supply chain attestation: sign + SBOM ---
 
       - name: Sign image with cosign (keyless OIDC)
+        if: github.event_name == 'push' || inputs.dry_run == false
         run: cosign sign --yes --recursive ${{ steps.ko-push.outputs.IMAGE_REF }}
 
       - name: Generate SBOM (SPDX)
         # Syft resolves multi-arch ref to the runner's platform (amd64).
         # The SBOM is attached to the index digest only (not per-platform).
+        if: github.event_name == 'push' || inputs.dry_run == false
         run: |
           syft ${{ steps.ko-push.outputs.IMAGE_REF }} \
             -o spdx-json=sbom.spdx.json
 
       - name: Attest SBOM to image index
+        if: github.event_name == 'push' || inputs.dry_run == false
         run: |
           cosign attest --yes \
             --type spdxjson \
@@ -109,6 +152,7 @@ jobs:
       # --- Helm chart packaging ---
 
       - name: Install Helm
+        if: github.event_name == 'push' || inputs.dry_run == false
         env:
           HELM_VERSION: v3.17.4
         run: |
@@ -123,16 +167,19 @@ jobs:
           helm version
 
       - name: Update Chart version
+        if: github.event_name == 'push' || inputs.dry_run == false
         run: |
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" dist/chart/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" dist/chart/Chart.yaml
 
       - name: Package and push Helm chart to OCI
+        if: github.event_name == 'push' || inputs.dry_run == false
         run: |
           helm package dist/chart --version ${{ steps.version.outputs.VERSION }}
           helm push ntn-operators-${{ steps.version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
 
       - name: Create GitHub Release
+        if: github.event_name == 'push' || inputs.dry_run == false
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
@@ -141,7 +188,7 @@ jobs:
           # as "Latest" on the Releases page and Helm OCI consumers can
           # skip it via version constraints. Matches -rc / -beta /
           # -alpha / -dev / -snapshot / etc. in one expression.
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(steps.version.outputs.TAG, '-') }}
           files: |
             ntn-operators-${{ steps.version.outputs.VERSION }}.tgz
             sbom.spdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,28 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
-      - name: Login to GHCR
-        # Skip on dispatch dry-run: nothing will be pushed.
+      - name: Determine publish mode
+        # Single source of truth for the "should this run publish?" gate.
+        # All publish-side steps below reference steps.publish.outputs.publish
+        # so adding a new step can't accidentally drift from the others.
         # Truth table: push event → publish; dispatch dry_run=true → skip;
         # dispatch dry_run=false → publish (with synthetic version below).
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        # On push, `inputs.dry_run` is empty, so the string compare branches
+        # through the first clause only.
+        id: publish
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ] || { [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$DRY_RUN" = "false" ]; }; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Login to GHCR
+        if: steps.publish.outputs.publish == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -107,7 +124,7 @@ jobs:
       # gate; for full coverage, per-platform scanning would be needed.
 
       - name: Push multi-arch image to GHCR
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         id: ko-push
         env:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -130,19 +147,19 @@ jobs:
       # --- Supply chain attestation: sign + SBOM ---
 
       - name: Sign image with cosign (keyless OIDC)
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         run: cosign sign --yes --recursive ${{ steps.ko-push.outputs.IMAGE_REF }}
 
       - name: Generate SBOM (SPDX)
         # Syft resolves multi-arch ref to the runner's platform (amd64).
         # The SBOM is attached to the index digest only (not per-platform).
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         run: |
           syft ${{ steps.ko-push.outputs.IMAGE_REF }} \
             -o spdx-json=sbom.spdx.json
 
       - name: Attest SBOM to image index
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         run: |
           cosign attest --yes \
             --type spdxjson \
@@ -152,7 +169,7 @@ jobs:
       # --- Helm chart packaging ---
 
       - name: Install Helm
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         env:
           HELM_VERSION: v3.17.4
         run: |
@@ -167,19 +184,19 @@ jobs:
           helm version
 
       - name: Update Chart version
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         run: |
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" dist/chart/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" dist/chart/Chart.yaml
 
       - name: Package and push Helm chart to OCI
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         run: |
           helm package dist/chart --version ${{ steps.version.outputs.VERSION }}
           helm push ntn-operators-${{ steps.version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
 
       - name: Create GitHub Release
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        if: steps.publish.outputs.publish == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           # Pin to the resolved tag so dispatch builds (which run from a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         # Skip on dispatch dry-run: nothing will be pushed.
         # Truth table: push event → publish; dispatch dry_run=true → skip;
         # dispatch dry_run=false → publish (with synthetic version below).
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -107,7 +107,7 @@ jobs:
       # gate; for full coverage, per-platform scanning would be needed.
 
       - name: Push multi-arch image to GHCR
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         id: ko-push
         env:
           KO_DOCKER_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -130,19 +130,19 @@ jobs:
       # --- Supply chain attestation: sign + SBOM ---
 
       - name: Sign image with cosign (keyless OIDC)
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: cosign sign --yes --recursive ${{ steps.ko-push.outputs.IMAGE_REF }}
 
       - name: Generate SBOM (SPDX)
         # Syft resolves multi-arch ref to the runner's platform (amd64).
         # The SBOM is attached to the index digest only (not per-platform).
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: |
           syft ${{ steps.ko-push.outputs.IMAGE_REF }} \
             -o spdx-json=sbom.spdx.json
 
       - name: Attest SBOM to image index
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: |
           cosign attest --yes \
             --type spdxjson \
@@ -152,7 +152,7 @@ jobs:
       # --- Helm chart packaging ---
 
       - name: Install Helm
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         env:
           HELM_VERSION: v3.17.4
         run: |
@@ -167,21 +167,25 @@ jobs:
           helm version
 
       - name: Update Chart version
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: |
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" dist/chart/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" dist/chart/Chart.yaml
 
       - name: Package and push Helm chart to OCI
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: |
           helm package dist/chart --version ${{ steps.version.outputs.VERSION }}
           helm push ntn-operators-${{ steps.version.outputs.VERSION }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
 
       - name: Create GitHub Release
-        if: github.event_name == 'push' || inputs.dry_run == false
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          # Pin to the resolved tag so dispatch builds (which run from a
+          # branch ref, not a tag ref) don't accidentally create a tag
+          # named after the branch. On tag pushes TAG == github.ref_name.
+          tag_name: ${{ steps.version.outputs.TAG }}
           generate_release_notes: true
           # Any SemVer tag with a pre-release identifier (the "-xxx"
           # suffix) is flagged as a pre-release, so it does not show up

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,7 +8,18 @@ on:
       - 'pkg/**'
       - 'api/**'
       - 'cmd/**'
-      - 'config/**'
+      # config/** narrowed to subdirectories that actually affect
+      # controller behaviour. Skips config/samples/ (sample CRs) and
+      # config/grafana/ (dashboard JSON) which have zero impact on the
+      # reconciler — they used to trigger e2e on doc-only PRs and
+      # collide with CelesTrak network flake.
+      - 'config/crd/**'
+      - 'config/default/**'
+      - 'config/manager/**'
+      - 'config/network-policy/**'
+      - 'config/prometheus/**'
+      - 'config/rbac/**'
+      - 'config/webhook/**'
       - 'test/**'
       - 'hack/**'
       - 'go.mod'
@@ -21,7 +32,13 @@ on:
       - 'pkg/**'
       - 'api/**'
       - 'cmd/**'
-      - 'config/**'
+      - 'config/crd/**'
+      - 'config/default/**'
+      - 'config/manager/**'
+      - 'config/network-policy/**'
+      - 'config/prometheus/**'
+      - 'config/rbac/**'
+      - 'config/webhook/**'
       - 'test/**'
       - 'hack/**'
       - 'go.mod'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,14 +12,14 @@ on:
       # controller behaviour. Skips config/samples/ (sample CRs) and
       # config/grafana/ (dashboard JSON) which have zero impact on the
       # reconciler — they used to trigger e2e on doc-only PRs and
-      # collide with CelesTrak network flake.
+      # collide with CelesTrak network flake. If config/webhook/ or
+      # other controller-affecting subdirs land later, add them here.
       - 'config/crd/**'
       - 'config/default/**'
       - 'config/manager/**'
       - 'config/network-policy/**'
       - 'config/prometheus/**'
       - 'config/rbac/**'
-      - 'config/webhook/**'
       - 'test/**'
       - 'hack/**'
       - 'go.mod'
@@ -38,7 +38,6 @@ on:
       - 'config/network-policy/**'
       - 'config/prometheus/**'
       - 'config/rbac/**'
-      - 'config/webhook/**'
       - 'test/**'
       - 'hack/**'
       - 'go.mod'


### PR DESCRIPTION
Two coupled CI quality-of-life fixes after the v0.4.0-rc.1 release.

## Why now

- **#1 — E2E false positives**: PR #101 was a docs-only refresh (README + dashboard + sample YAML + generated API ref) yet triggered the full E2E job, which then flaked on a CelesTrak fetch inside the SatelliteEphemeris controller. The path filter was too permissive — `config/**` included `config/samples/` (sample CRs) and `config/grafana/` (dashboard JSON), neither of which can affect reconciler behaviour.
- **#2 — Release pipeline dry-run**: v0.4.0-rc.1 needed *four* publish-attempt fixes before it cut: three action-SHA typos (PR #98), eight HIGH Go runtime CVEs surfaced by Trivy (PR #99), three transitive otel/grpc CVEs (PR #100). The pipeline only runs on `push: tags: [v*]`, so each fix required a new tag push to validate. A `workflow_dispatch` with a default-true dry-run input lets us iterate on Trivy/SBOM/cosign without minting tags.

## Changes

### `.github/workflows/test-e2e.yml`
Replaces `config/**` with a 6-dir allowlist: `config/crd/`, `config/default/`, `config/manager/`, `config/network-policy/`, `config/prometheus/`, `config/rbac/` (dropped `config/webhook/` in 1c4bb32 per Copilot review — re-add when validating webhook work lands from `feat/validating-webhooks`). Same allowlist on both `push` and `pull_request`.

### `.github/workflows/release.yml`
- Adds `workflow_dispatch:` trigger with `dry_run` boolean input (default `true`).
- Replaces "Get version from tag" with "Resolve version" that emits both `VERSION` and `TAG` for both event types. Dispatch builds get a synthetic version `0.0.0-dispatch-<sha7>` so they cannot collide with a real tag if the dry-run gate is overridden.
- Always runs: Checkout, Setup Go/ko/cosign/syft, Trivy scan.
- Gated on `github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)`: GHCR login, image push, cosign sign, SBOM, attest, Helm install/package/push, GitHub Release. The explicit `event_name == 'workflow_dispatch'` clause prevents a future `schedule:` trigger from accidentally publishing because of GHA expression null-to-bool coercion (`null == false` → true).
- ko push only adds the `latest` tag on real tag pushes — dispatch builds get the SHA-suffixed tag only.
- `prerelease` flag and `tag_name` both read from `steps.version.outputs.TAG` so dispatch builds don't create a GitHub Release pointing at the branch ref.

## What I deliberately did not do

- No `paths-ignore` switch — `paths` allowlist + GitHub's required-status-checks pitfall (skipped jobs report as success) means the allowlist is the safer pattern given main has no branch protection currently and may grow it later.
- No mock CelesTrak in E2E — that's the proper fix but a much bigger PR. Filed as a follow-up issue.
- No `concurrency:` block on release.yml — back-to-back dispatches could race, but the worst case is wasted CI minutes (dry-run) or a `latest` tag race that ko handles. Follow-up.

## Local validation

- `actionlint` exit 0 on both workflow files.
- `python3 yaml.safe_load` on both files → triggers `['push', 'workflow_dispatch']` and `['push', 'pull_request']`.
- Shell-branch dry-run of the version-resolve logic: dispatch (sha=de09b43...) → `VERSION=0.0.0-dispatch-de09b43 TAG=v0.0.0-dispatch-de09b43`; tag push (ref=v0.4.0-rc.1) → `VERSION=0.4.0-rc.1 TAG=v0.4.0-rc.1` (matches existing behaviour).
- `grep -c` confirms all 9 publish-step gates use the tightened condition.

## Test plan

- [x] actionlint passes locally
- [x] YAML parses; both branches of resolve-version produce expected output
- [x] CI green on first commit (E2E + Lint + Helm + Tests)
- [ ] After merge, dispatch the workflow with `dry_run=true` from the Actions tab — pipeline should run through Trivy, then skip the publish steps cleanly
- [ ] Next tag push (v0.4.0-rc.2 or v0.4.0) still produces image + signed SBOM + Helm OCI chart + GitHub Release
- [ ] Next docs-only PR no longer triggers test-e2e