### PR TITLE
ci(security): add weekly Trivy scan on main (#106)

### DIFF
--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,18 +1,25 @@
 name: Scheduled Trivy Scan
 
-# Weekly Trivy scan on main's latest image, so CRITICAL/HIGH CVEs
-# surface during the work week — not during a Friday release-cut
-# scramble. v0.4.0-rc.1 needed four publish-attempt fixes (PRs #99,
-# #100) because Trivy caught Go runtime + transitive CVEs at
-# tag-push time; a weekly scan would have landed those fixes earlier,
-# in quiet PRs rather than release-blocker PRs.
+# Weekly Trivy scan to surface CRITICAL/HIGH CVEs during the work
+# week — not at release-cut time. Builds a fresh local image via
+# `ko build` and scans it; no registry credentials in scope.
+#
+# Ref semantics:
+#   - `schedule`: GHA fires scheduled events against the default
+#     branch (main), so the scan runs against main HEAD.
+#   - `workflow_dispatch`: scans whichever ref you dispatch from
+#     (useful for ad-hoc verification before tagging a release).
+#
+# Motivation: v0.4.0-rc.1 took four attempts to cut — the original
+# (#97) plus fix PRs #98 (action SHA typos), #99 (Go runtime CVEs),
+# and #100 (otel/grpc transitive CVEs). The two CVE-driven fixes
+# (#99, #100) would have landed earlier as quiet weekday PRs with
+# this scan in place, avoiding the Friday release-time fire drill.
 #
 # Schedule: Monday 06:00 UTC = Monday 14:00 Taipei. Catches CVEs
-# published on the prior week before the next week's releases.
+# published in the prior week before the next week's releases.
 #
-# Also manually dispatchable for ad-hoc verification.
-#
-# See #106 for the motivation and design notes.
+# See #106 for the full design.
 
 on:
   schedule:
@@ -32,7 +39,9 @@ concurrency:
 
 jobs:
   scan:
-    name: Trivy scan (main latest)
+    # Job name mirrors release.yml's build-scan to make it visually
+    # obvious this is the same gate, just with a different trigger.
+    name: Build and scan
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,0 +1,73 @@
+name: Scheduled Trivy Scan
+
+# Weekly Trivy scan on main's latest image, so CRITICAL/HIGH CVEs
+# surface during the work week — not during a Friday release-cut
+# scramble. v0.4.0-rc.1 needed four publish-attempt fixes (PRs #99,
+# #100) because Trivy caught Go runtime + transitive CVEs at
+# tag-push time; a weekly scan would have landed those fixes earlier,
+# in quiet PRs rather than release-blocker PRs.
+#
+# Schedule: Monday 06:00 UTC = Monday 14:00 Taipei. Catches CVEs
+# published on the prior week before the next week's releases.
+#
+# Also manually dispatchable for ad-hoc verification.
+#
+# See #106 for the motivation and design notes.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Read-only: this workflow never publishes anything. It only builds
+# a local image and scans it.
+permissions:
+  contents: read
+
+concurrency:
+  # Prevent overlapping runs if a scan ever takes longer than a week.
+  # Don't cancel an in-flight run — queuing is fine.
+  group: trivy-scheduled
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Trivy scan (main latest)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup ko
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+      - name: Build local image with ko (no push)
+        id: ko-local
+        env:
+          KO_DOCKER_REPO: ko.local
+        run: |
+          LOCAL_IMAGE=$(ko build ./cmd/ --local --bare)
+          echo "LOCAL_IMAGE=${LOCAL_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "Local image: ${LOCAL_IMAGE}"
+
+      - name: Scan with Trivy (CRITICAL/HIGH)
+        # Pin to known-safe SHA after March 2026 supply chain compromise.
+        # See: https://www.stepsecurity.io/blog/trivy-compromised-a-second-time
+        # Identical gate to release.yml's build-scan job — a finding
+        # here means the next release tag push will also fail, so
+        # fixing it this week avoids a release-time fire drill.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 (safe)
+        with:
+          image-ref: ${{ steps.ko-local.outputs.LOCAL_IMAGE }}
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          timeout: '10m'
+      # Note: amd64-only scan, same as release.yml's build-scan. If
+      # an arm64-specific base-layer CVE ever surfaces, this will
+      # miss it. Per-platform scanning is a future enhancement.


### PR DESCRIPTION
Closes #106.

Surface CRITICAL/HIGH CVEs during the work week, not at the exact moment we're trying to ship a release. After v0.4.0-rc.1 needed four publish-attempt fixes (PRs #97 / #98 / #99 / #100) because Trivy caught Go-runtime + transitive CVEs at tag-push time, a weekly scan on main is cheap insurance against repeating that fire drill.

## What this adds

New workflow: `.github/workflows/trivy-scheduled.yml`.

| Property | Value |
|---|---|
| Trigger (scheduled) | `cron: '0 6 * * 1'` (Monday 06:00 UTC = Monday 14:00 Taipei) |
| Trigger (manual) | `workflow_dispatch` for ad-hoc runs |
| Permissions | `contents: read` only |
| Concurrency group | `trivy-scheduled`, `cancel-in-progress: false` |
| Steps | checkout → setup-go → setup-ko → `ko build --local` → Trivy scan |
| Trivy gate | `severity: CRITICAL,HIGH`, `exit-code: 1` |

Identical gate to `release.yml`'s `build-scan` job, so a finding here is a reliable early warning that the next release tag-push will also fail.

## Why Monday 06:00 UTC?

- 14:00 Taipei time = start of the Taiwan work week → full week to address before next release cycle
- Avoids weekend runner contention
- Matches the cadence at which most vendor security advisories drop (Mon-Tue typical)

## Why `cancel-in-progress: false`

If a scan ever takes longer than a week (unlikely but possible with slow runners), we'd rather queue the next run than cancel the in-flight one.

## Non-goals (deliberately deferred — can be filed as follow-ups)

- Auto-opening a GitHub Issue on CVE finding. Built-in workflow-failure email to the repo admin is enough for pre-1.0.
- `trivy fs` Go-module scan. `release.yml` doesn't do it either; keeping parity so findings translate 1:1 to release-time behavior.
- Per-platform (amd64 + arm64) scan. Current scan is amd64-only, same as `release.yml`.

## Test plan

- [x] `actionlint` clean on the new workflow file
- [x] YAML parses, triggers resolved to `['schedule', 'workflow_dispatch']`
- [x] cron sanity: next fire computed to Mon 2026-04-27 06:00 UTC / 14:00 TW
- [ ] After merge, manually `gh workflow run trivy-scheduled.yml --repo thc1006/ntn-operators` once to prove the schedule-side path works end-to-end without waiting for the next Monday
- [ ] Verify the scan against today's main finds 0 CRITICAL/HIGH (we already passed this gate for v0.4.0-rc.1 at `a32f52c`/`d3f4e0a`)

## Related

- #106 (this issue)
- PR #99, PR #100 — the CVE fire-drill PRs this scan would have front-run
- `release.yml` `build-scan` job — same Trivy invocation, but only at tag push

Co-authored-by: junnncct1106 <jun.514114.ee10@nycu.edu.tw>