### PR TITLE
ci(hygiene): add action SHA validator (#107)

### DIFF
--- a/.github/workflows/action-shas.yml
+++ b/.github/workflows/action-shas.yml
@@ -1,0 +1,40 @@
+name: Action SHAs
+
+# Dedicated gate for GitHub Actions SHA pinning. Broken out of lint.yml
+# because lint.yml's paths filter (**.go, go.mod, etc.) would trigger
+# this check on every Go change — unnecessary API traffic + spurious
+# reruns. See Copilot review on PR #109.
+#
+# See hack/check-action-shas.sh for the validation logic and #107 for
+# the motivation (PR #97's typo'd SHAs slipped past human review).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'hack/check-action-shas.sh'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'hack/check-action-shas.sh'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-action-shas:
+    name: Action SHAs pinned
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate action SHAs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./hack/check-action-shas.sh

--- a/.github/workflows/action-shas.yml
+++ b/.github/workflows/action-shas.yml
@@ -1,9 +1,9 @@
 name: Action SHAs
 
-# Dedicated gate for GitHub Actions SHA pinning. Broken out of lint.yml
+# Dedicated gate for GitHub Actions SHA pinning. Kept out of lint.yml
 # because lint.yml's paths filter (**.go, go.mod, etc.) would trigger
-# this check on every Go change — unnecessary API traffic + spurious
-# reruns. See Copilot review on PR #109.
+# this check on every Go-only change — unnecessary API traffic and
+# spurious reruns.
 #
 # See hack/check-action-shas.sh for the validation logic and #107 for
 # the motivation (PR #97's typo'd SHAs slipped past human review).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,3 +47,21 @@ jobs:
 
       - name: Run linter
         run: make lint
+
+  # Gate: every `uses: org/repo@<ref>` in .github/workflows/ must be
+  # a valid SHA-pinned commit. Catches the failure mode from PR #97
+  # where action SHAs were typo'd and slipped past human review.
+  # See #107 and hack/check-action-shas.sh.
+  check-action-shas:
+    name: Action SHAs pinned
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate action SHAs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./hack/check-action-shas.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,21 +47,3 @@ jobs:
 
       - name: Run linter
         run: make lint
-
-  # Gate: every `uses: org/repo@<ref>` in .github/workflows/ must be
-  # a valid SHA-pinned commit. Catches the failure mode from PR #97
-  # where action SHAs were typo'd and slipped past human review.
-  # See #107 and hack/check-action-shas.sh.
-  check-action-shas:
-    name: Action SHAs pinned
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Validate action SHAs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./hack/check-action-shas.sh

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -34,7 +34,7 @@ jobs:
           cache: true
 
       - name: Install Kind
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           install_only: true
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -64,7 +64,7 @@ jobs:
           cache: true
 
       - name: Install Kind
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           install_only: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           cache: true
 
       - name: Cache envtest binaries
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: bin/k8s
           key: envtest-${{ runner.os }}-${{ hashFiles('Makefile', 'go.mod', 'go.sum') }}

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	"$(GOLANGCI_LINT)" config verify
 
+.PHONY: check-action-shas
+check-action-shas: ## Verify all GitHub Actions refs in .github/workflows are SHA-pinned (and resolve when GH_TOKEN is set).
+	./hack/check-action-shas.sh
+
 ##@ Build
 
 .PHONY: build

--- a/hack/check-action-shas.sh
+++ b/hack/check-action-shas.sh
@@ -43,6 +43,15 @@ CHECKED=0
 API_CHECKS=0
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
+# If a token is present we intend to hit the GitHub API. Fail fast with
+# a clear message if `gh` is missing rather than letting every SHA check
+# fall through and mis-attribute the failure to "does not resolve".
+if [ -n "${TOKEN}" ] && ! command -v gh >/dev/null 2>&1; then
+  echo "::error::A GH_TOKEN / GITHUB_TOKEN is set but the 'gh' CLI is not available on PATH." >&2
+  echo "::error::Install https://cli.github.com/ or unset the token to fall back to offline-only checks." >&2
+  exit 2
+fi
+
 # Collect all `uses: ...` lines across *.yml (one per line). Matches both
 # block-style (`    uses: foo@sha`) and one-line step form
 # (`  - uses: foo@sha`). The `|| true` is required because `grep` returns
@@ -63,10 +72,18 @@ while IFS= read -r raw; do
   if [ -z "${USES}" ]; then
     continue
   fi
-  case "${USES}" in
-    \"*\") USES="${USES#\"}"; USES="${USES%\"}" ;;
-    \'*\') USES="${USES#\'}"; USES="${USES%\'}" ;;
-  esac
+  # Strip matched surrounding double or single quotes without relying on
+  # escaped-quote glob patterns (which some shells / reviewers find
+  # ambiguous). Using DQ/SQ variables makes the intent unambiguous.
+  DQ='"'
+  SQ="'"
+  if [ "${USES#${DQ}}" != "${USES}" ] && [ "${USES%${DQ}}" != "${USES}" ]; then
+    USES="${USES#${DQ}}"
+    USES="${USES%${DQ}}"
+  elif [ "${USES#${SQ}}" != "${USES}" ] && [ "${USES%${SQ}}" != "${USES}" ]; then
+    USES="${USES#${SQ}}"
+    USES="${USES%${SQ}}"
+  fi
 
   # Skip local and docker actions.
   case "${USES}" in

--- a/hack/check-action-shas.sh
+++ b/hack/check-action-shas.sh
@@ -43,7 +43,12 @@ CHECKED=0
 API_CHECKS=0
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
-# Collect all `uses: ...` lines across *.yml (one per line).
+# Collect all `uses: ...` lines across *.yml (one per line). Matches both
+# block-style (`    uses: foo@sha`) and one-line step form
+# (`  - uses: foo@sha`). The `|| true` is required because `grep` returns
+# exit code 1 on zero matches, and `set -e` above would otherwise abort
+# the script on an empty workflows dir — valid state we want to handle
+# as "checked 0, exit 0".
 # Format of `grep -nH -E` is `FILE:LINENUM:CONTENT`.
 while IFS= read -r raw; do
   FILE="${raw%%:*}"
@@ -52,11 +57,16 @@ while IFS= read -r raw; do
   CONTENT="${REST#*:}"
 
   # Extract the uses value (everything after `uses:` up to whitespace
-  # or comment marker).
+  # or comment marker). Then normalise optional surrounding YAML
+  # quotes for scalars like `uses: "org/repo@<sha>"`.
   USES=$(printf '%s' "${CONTENT}" | sed -nE 's|.*uses:[[:space:]]+([^[:space:]#]+).*|\1|p')
   if [ -z "${USES}" ]; then
     continue
   fi
+  case "${USES}" in
+    \"*\") USES="${USES#\"}"; USES="${USES%\"}" ;;
+    \'*\') USES="${USES#\'}"; USES="${USES%\'}" ;;
+  esac
 
   # Skip local and docker actions.
   case "${USES}" in
@@ -99,7 +109,7 @@ while IFS= read -r raw; do
   if ! printf '%s' "${CONTENT}" | grep -qE '#[[:space:]]*v[0-9]'; then
     echo "::warning file=${FILE},line=${LINE_NO}::Action \`${REF}@${SHA}\` is missing a trailing \`# v<tag>\` comment (auditability only — not a failure)."
   fi
-done < <(grep -nH -E '^[[:space:]]+uses:' "${WORKFLOWS_DIR}"/*.yml)
+done < <(grep -nH -E '^[[:space:]]*-?[[:space:]]*uses:' "${WORKFLOWS_DIR}"/*.yml 2>/dev/null || true)
 
 echo ""
 echo "Checked ${CHECKED} action references across ${WORKFLOWS_DIR}/*.yml"

--- a/hack/check-action-shas.sh
+++ b/hack/check-action-shas.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# check-action-shas.sh — verify every `uses: org/repo@<ref>` in
+# .github/workflows/ is SHA-pinned, and (when a GitHub token is
+# available) that the SHA resolves to a real commit on the action's
+# repo.
+#
+# Motivation: PR #97 shipped three typo'd action SHAs that passed
+# human review because they're opaque 40-char hex. Three follow-up
+# PRs (#98) were needed to fix them. This script catches that class
+# of error before merge.
+#
+# Checks (errors — fail run):
+#   1. `uses: foo@<ref>` must be a 40-char lowercase hex SHA.
+#      Semver tags (v1, v1.2.3, main, master) are rejected.
+#   2. When GH_TOKEN or GITHUB_TOKEN is set, the SHA must resolve
+#      via `gh api repos/<owner>/<repo>/commits/<sha>`.
+#
+# Checks (warnings — do NOT fail run):
+#   3. Each SHA-pinned ref should have a trailing `# v<tag>` comment
+#      for human auditability.
+#
+# Exempt:
+#   - Local actions (`uses: ./...`).
+#   - Docker-image actions (`uses: docker://...`).
+#
+# Usage:
+#   hack/check-action-shas.sh [workflows_dir]
+#
+# Default workflows_dir is `.github/workflows`.
+
+set -euo pipefail
+
+WORKFLOWS_DIR="${1:-.github/workflows}"
+
+if [ ! -d "${WORKFLOWS_DIR}" ]; then
+  echo "error: workflows dir not found: ${WORKFLOWS_DIR}" >&2
+  exit 2
+fi
+
+ERRORS=0
+CHECKED=0
+API_CHECKS=0
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+# Collect all `uses: ...` lines across *.yml (one per line).
+# Format of `grep -nH -E` is `FILE:LINENUM:CONTENT`.
+while IFS= read -r raw; do
+  FILE="${raw%%:*}"
+  REST="${raw#*:}"
+  LINE_NO="${REST%%:*}"
+  CONTENT="${REST#*:}"
+
+  # Extract the uses value (everything after `uses:` up to whitespace
+  # or comment marker).
+  USES=$(printf '%s' "${CONTENT}" | sed -nE 's|.*uses:[[:space:]]+([^[:space:]#]+).*|\1|p')
+  if [ -z "${USES}" ]; then
+    continue
+  fi
+
+  # Skip local and docker actions.
+  case "${USES}" in
+    ./*|docker://*) continue ;;
+  esac
+
+  # Split on the last `@`.
+  REF="${USES%@*}"
+  SHA="${USES##*@}"
+
+  if [ "${REF}" = "${USES}" ] || [ -z "${SHA}" ]; then
+    echo "::error file=${FILE},line=${LINE_NO}::Action \`${USES}\` is missing an @<ref> pin."
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  CHECKED=$((CHECKED + 1))
+
+  # 1. SHA format check (40 lowercase hex).
+  if ! printf '%s' "${SHA}" | grep -qE '^[0-9a-f]{40}$'; then
+    echo "::error file=${FILE},line=${LINE_NO}::Action \`${REF}\` is not SHA-pinned (ref=\`${SHA}\`). Pin to a 40-char hex commit SHA."
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  # 2. API resolution (only when token available).
+  if [ -n "${TOKEN}" ]; then
+    # Reuse repo slug: owner/repo (strip trailing /subpath for
+    # actions like anchore/sbom-action/download-syft).
+    REPO="$(printf '%s' "${REF}" | awk -F/ '{print $1"/"$2}')"
+    if ! GH_TOKEN="${TOKEN}" gh api "repos/${REPO}/commits/${SHA}" --jq '.sha' >/dev/null 2>&1; then
+      echo "::error file=${FILE},line=${LINE_NO}::Action \`${REF}@${SHA}\` does not resolve to a real commit on repo \`${REPO}\`."
+      ERRORS=$((ERRORS + 1))
+      continue
+    fi
+    API_CHECKS=$((API_CHECKS + 1))
+  fi
+
+  # 3. Auditability: expect a `# v<something>` comment trailing.
+  if ! printf '%s' "${CONTENT}" | grep -qE '#[[:space:]]*v[0-9]'; then
+    echo "::warning file=${FILE},line=${LINE_NO}::Action \`${REF}@${SHA}\` is missing a trailing \`# v<tag>\` comment (auditability only — not a failure)."
+  fi
+done < <(grep -nH -E '^[[:space:]]+uses:' "${WORKFLOWS_DIR}"/*.yml)
+
+echo ""
+echo "Checked ${CHECKED} action references across ${WORKFLOWS_DIR}/*.yml"
+if [ -n "${TOKEN}" ]; then
+  echo "  - SHA format: ${CHECKED} checked"
+  echo "  - GitHub API resolution: ${API_CHECKS} verified"
+else
+  echo "  - SHA format: ${CHECKED} checked"
+  echo "  - GitHub API resolution: SKIPPED (neither GH_TOKEN nor GITHUB_TOKEN set)"
+fi
+
+if [ "${ERRORS}" -gt 0 ]; then
+  echo ""
+  echo "✗ ${ERRORS} error(s) found."
+  exit 1
+fi
+
+echo "✓ All action references valid."


### PR DESCRIPTION
Closes #107.

Prevents the PR #97 class of error — action SHA typos that slip past human review because they're opaque 40-char hex strings — via a CI-enforced check.

## What this adds

### `hack/check-action-shas.sh`

Scans every `uses: org/repo@<ref>` line under `.github/workflows/*.yml` and fails if:

1. `<ref>` is not a 40-char lowercase hex SHA (rejects `v1`, `v1.2.3`, `main`, `master`, etc.)
2. When `GH_TOKEN` or `GITHUB_TOKEN` is set: `<sha>` must resolve to a real commit on `org/repo` via `gh api repos/<owner>/<repo>/commits/<sha>` (the actual defense against PR #97's class of typo)

Warns (non-fatal) when a SHA-pinned ref lacks a trailing `# v<tag>` comment — auditability nicety, not blocking.

Exempts local actions (`./...`) and docker image refs (`docker://...`).

### CI wiring

New `check-action-shas` job in `lint.yml`, `permissions: contents: read`. Runs on every PR that touches `.github/workflows/**` — same path filter as the existing `lint` job.

### Makefile target

`make check-action-shas` for local ergonomics (`GH_TOKEN=$(gh auth token)` will enable the API check if you want it locally).

## What this fixes (pre-existing violations the script flagged)

The script found 3 refs on main that were never SHA-pinned. Fixed in this same PR so the new CI gate passes:

| File:Line | Before | After |
|---|---|---|
| `test-e2e.yml:67` | `helm/kind-action@v1.14.0` | `helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0` |
| `test-chart.yml:37` | same | same |
| `test.yml:43` | `actions/cache@v5.0.5` | `actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5` (matches the already-pinned SHA in `lint.yml`) |

SHAs resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`.

## Design notes

**Why not rely on actionlint?** actionlint has some action-ref sanity checks but doesn't enforce commit-existence against the GitHub API. This script's unique value-add is the API resolution check — that's precisely what would have caught PR #97's typo'd SHAs.

**Why make the API check optional?** Contributors may run the script locally without a GH token. In that mode the format check still catches tag-refs (the common error class), and the API check is deferred to CI where `GITHUB_TOKEN` is always available. Offline-friendly + online-strict.

**Why warnings for missing `# v<tag>` comments?** The tag comment is for humans reading the workflow in a year to know what version they're pinned to. Non-blocking because the SHA itself is the source of truth; the comment is just ergonomics.

## Validation performed

- [x] Local run with GH token: 28/28 SHA format checks + 28/28 API resolutions
- [x] Local run without token: 28/28 SHA format checks (API check correctly skipped)
- [x] `actionlint` clean on all 6 workflow files
- [x] `make check-action-shas` target works and reads the same script
- [x] Dry-run before fixing the 3 refs showed they were all correctly flagged
- [ ] CI on this PR exercises the new `check-action-shas` job end-to-end

## Non-goals / follow-ups

- Not extending to `uses:` references in reusable workflows called from private registries — this repo doesn't use those.
- Not auto-generating the `# v<tag>` comment from the SHA — Dependabot maintains these on bump PRs.
- Not wiring to pre-commit hooks — intentional CI-only gate so local ergonomics stay light.

## Related

- PR #97 → #98 — the exact 2-hour lost-time incident this check would have prevented
- #107 (this issue)

Co-authored-by: junnncct1106 <jun.514114.ee10@nycu.edu.tw>