### PR TITLE
feat: Nephio R6 kpt package integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,66 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
+##@ Nephio
+
+# kpt binary path — prefer PATH. `make nephio-install-tools` installs into
+# $(go env GOPATH)/bin; ensure that directory is on your PATH.
+KPT ?= kpt
+KPT_VERSION ?= v1.0.0-beta.62
+NEPHIO_PKGS := nephio/packages/ntn-operators-crds nephio/packages/ntn-workloads-sample
+
+.PHONY: nephio-install-tools
+nephio-install-tools: ## Install kpt CLI (Linux/macOS amd64) into $(GOPATH)/bin.
+	@set -e; \
+	BIN_DIR="$$(go env GOPATH 2>/dev/null)/bin"; \
+	[ -n "$${BIN_DIR}" ] || { echo "go env GOPATH failed; is Go installed?"; exit 1; }; \
+	mkdir -p "$${BIN_DIR}"; \
+	if command -v kpt >/dev/null 2>&1; then \
+	  echo "kpt already on PATH: $$(command -v kpt) ($$(kpt version 2>/dev/null | head -1))"; \
+	  exit 0; \
+	fi; \
+	OS=$$(uname -s | tr A-Z a-z); ARCH=amd64; \
+	URL="https://github.com/kptdev/kpt/releases/download/$(KPT_VERSION)/kpt_$${OS}_$${ARCH}"; \
+	echo "Downloading kpt $(KPT_VERSION) from $${URL}"; \
+	curl -sSL -o "$${BIN_DIR}/kpt" "$${URL}"; \
+	chmod +x "$${BIN_DIR}/kpt"; \
+	echo "Installed $${BIN_DIR}/kpt ($$("$${BIN_DIR}/kpt" version 2>/dev/null | head -1))"; \
+	echo "If 'kpt' is not on your PATH, run: export PATH=\"$${BIN_DIR}:\$$PATH\""
+
+.PHONY: nephio-sync
+nephio-sync: manifests ## Sync CRDs from config/crd/bases/ into the Nephio ntn-operators-crds package.
+	@set -e; \
+	SRC=config/crd/bases; DST=nephio/packages/ntn-operators-crds; \
+	for src in $$SRC/ntn.operators.dev_*.yaml; do \
+	  base=$$(basename "$$src" | sed 's/^ntn\.operators\.dev_//' | sed 's/\.yaml$$/-crd.yaml/'); \
+	  cp "$$src" "$$DST/$$base"; \
+	  echo "  synced $$src -> $$DST/$$base"; \
+	done
+
+.PHONY: nephio-render
+nephio-render: ## Run 'kpt fn render' on both Nephio packages.
+	@set -e; \
+	for pkg in $(NEPHIO_PKGS); do \
+	  echo "==> $$pkg"; \
+	  $(KPT) fn render "$$pkg"; \
+	done
+
+.PHONY: nephio-validate
+nephio-validate: ## Run the Nephio package validation suite (test/nephio/validate.sh).
+	@bash test/nephio/validate.sh
+
+.PHONY: nephio-verify-sync
+nephio-verify-sync: ## Verify CRD package copies match config/crd/bases/ (CI drift check).
+	@set -e; \
+	SRC=config/crd/bases; DST=nephio/packages/ntn-operators-crds; drift=0; \
+	for src in $$SRC/ntn.operators.dev_*.yaml; do \
+	  base=$$(basename "$$src" | sed 's/^ntn\.operators\.dev_//' | sed 's/\.yaml$$/-crd.yaml/'); \
+	  if ! diff -q "$$src" "$$DST/$$base" >/dev/null 2>&1; then \
+	    echo "DRIFT: $$DST/$$base differs from $$src"; drift=1; \
+	  fi; \
+	done; \
+	if [ $$drift -eq 0 ]; then echo "Nephio CRD package is in sync with config/crd/bases/"; else exit 1; fi
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/docs/adr/0003-nephio-integration.md
+++ b/docs/adr/0003-nephio-integration.md
@@ -1,0 +1,144 @@
+# ADR 0003 — Nephio R6 Package Integration
+
+- Status: **Accepted**
+- Date: 2026-04-24
+- Deciders: @thc1006
+- Related issue: [#51](https://github.com/thc1006/ntn-operators/issues/51)
+- Related governance: author is 1-of-6 Nephio TSC members (seated early 2026)
+
+## Context
+
+Issue #51 asked to expose `NTNSlice` (and by extension our other CRDs) as a Nephio-consumable workload package. The original framing implied integrating with "intent-based orchestration for dynamic QoS/billing adjustment", but a 2026-04-24 deep survey of Nephio R6 shows the idiomatic path is narrower and simpler than the issue description implies:
+
+- Nephio is **kpt-native**, not Helm-native or CRD-controller-native. Workload packages are kpt packages (Kptfile + YAML) pulled through Porch into edge clusters.
+- The canonical pattern for "ship CRDs as a Nephio package" already exists in `nephio-project/catalog/nephio/core/workload-crds/` — raw CRD YAMLs + a minimal Kptfile.
+- Nephio R6 (released 2026-04-01, Porch v1.5.6) introduces no breaking schema changes for package authors; Kptfile remains `kpt.dev/v1`. The major change is that R6 blueprints publish KRM-function images at `ghcr.io/kptdev/krm-functions-catalog/*` (previously `gcr.io/kpt-fn/*`; both work, but ghcr is now idiomatic).
+
+### Why integrate at all
+
+Three distinct reasons, all load-bearing:
+
+1. **Credibility closure**. The project's author holds a Nephio TSC seat. Outside observers reasonably expect the project to be a Nephio-consumable package. Absence of one raises "why is a TSC member not using Nephio?".
+2. **Ecosystem fit**. Nephio is the LFN-sanctioned path for K8s-native telecom NF orchestration. Publishing as a Nephio package is the cheapest path to being pulled into LFN reference deployments, Sylva blueprints, Aether integration demos, and O-RAN SC handover scenarios.
+3. **Deployment story**. Downstream users (partners, operators) who already run Nephio can consume our CRDs + samples via `kpt pkg get` + PackageVariant, without hand-rolling kustomize overlays.
+
+### Upstream ground truth (verified 2026-04-24)
+
+- Latest Nephio release: **R6** (2026-04-01). Porch **v1.5.6** bundled; patch stream **v1.5.8** current.
+- PackageRevision / PackageVariant / PackageVariantSet remain the deployment model in R6. `PackageVariant` itself stays on `config.porch.kpt.dev/v1alpha1`; the newer `v1alpha2` group applies specifically to `PackageVariantSet`. Samples in this repository use `v1alpha1` for `PackageVariant` (correct and idiomatic).
+- R6 blueprints migrated from `gcr.io/kpt-fn/*` to `ghcr.io/kptdev/krm-functions-catalog/*` (e.g. `set-namespace:v0.4.1`). Upstream `gcr.io/kpt-fn/` tags (set-namespace:v0.4.5, apply-replacements:v0.1.5, etc.) also remain current and functional.
+- `catalog/nephio/core/workload-crds/Kptfile` is the minimal reference for "ship CRDs" packages: just `apiVersion: kpt.dev/v1`, `kind: Kptfile`, `metadata.annotations['config.kubernetes.io/local-config']='true'`, `info.description`.
+- `workload.nephio.org/*` annotation namespace **could not be verified as active in R6**. Only `nephio.org/*`, `approval.nephio.org/*`, `config.porch.kpt.dev/*`, `kpt.dev/*`, `config.kubernetes.io/local-config` are observed in current catalog packages. **We will not use `workload.nephio.org/*`** until it is canonical.
+- Official docs: `docs.nephio.org/docs/` (R6), `github.com/nephio-project/catalog`, `github.com/nephio-project/porch/releases`, `catalog.kpt.dev`.
+- Nephio TSC seat grants no special publishing rights. PRs to `nephio-project/catalog` go through normal OWNERS-file review.
+
+## Decision
+
+**Ship two sibling kpt packages** in a new `nephio/packages/` directory inside this repo, each self-contained and `kpt fn render`-clean:
+
+### Package 1 — `ntn-operators-crds`
+
+- **Purpose**: deliver the four CRDs (SatelliteEphemeris, GroundStationLifecycle, NTNCellConfig, NTNSlice) as a kpt package. Mirrors `catalog/nephio/core/workload-crds/` exactly in shape.
+- **Contents**:
+  - `Kptfile` — minimal, `kpt.dev/v1`, no pipeline.
+  - `README.md` — consumption instructions.
+  - Four CRD YAMLs, copied from `config/crd/bases/` (single source of truth: the bases are generated from controller-gen; the package is a distribution artifact, not a second source).
+- **Pipeline**: none. CRDs do not need mutation at package time.
+- **Consumer flow**: `kpt pkg get <this-repo>/nephio/packages/ntn-operators-crds@<tag> <dest>` → `kubectl apply -f <dest>` to install CRDs on the management cluster (or on the edge cluster directly, if the edge hosts the operator).
+
+### Package 2 — `ntn-workloads-sample`
+
+- **Purpose**: deliver sample CRs (one per CRD) as a ready-to-adapt workload package. Shows how to customize per-cluster via a simple namespace/label mutation.
+- **Contents**:
+  - `Kptfile` — `kpt.dev/v1`, with a `pipeline.mutators` entry using **inline `configMap:` blocks** (not a separate fn-config.yaml) to keep the package self-contained:
+    - `ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1` — sets `metadata.namespace` on all CRs (default: `ntn-system`).
+    - `ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1` — stamps `workload=ntn-sample`, `app.kubernetes.io/managed-by=ntn-operators`.
+  - `README.md` — describes each CR, default values, customization knobs.
+  - Four sample CRs, copied from `config/samples/ntn_v1alpha1_*.yaml` with an explicit `namespace: default` field added so the mutator has a value to rewrite (`config/samples/` remains single source).
+- **Pipeline**: 2-step mutator chain. No validators in v1; validation deferred to K8s API server CEL rules (already defined on the CRDs themselves).
+- **Consumer flow**: `kpt pkg get` → edit `Kptfile` (change `configMap` values inside the mutator entries) → `kpt fn render` → `kubectl apply -f .`. For Porch-managed clusters, wrap in a PackageVariant to apply per-cluster specialization automatically.
+
+### What we will NOT do in v1
+
+1. **No PackageVariant manifests shipped in this repo**. PackageVariant belongs in the consumer's deployment repo, not the blueprint repo. We document the pattern in README, but don't ship variants.
+2. **No Porch cluster bootstrap**. Porch setup is documented at nephio.org; we don't duplicate. Our packages work with or without Porch (`kpt fn render` standalone or `kpt live apply`).
+3. **No Helm chart expansion inside kpt**. The operator itself still ships via Helm (`dist/chart/`) and OLM (`bundle/`); the kpt packages ship CRDs and CRs only, not the operator Deployment. Operator installation remains the consumer's choice (Helm, OLM, or direct YAML).
+4. **No custom KRM functions yet**. v1 uses only canonical upstream mutators. A future `ntn-validator-fn` could validate cross-CR references (NTNSlice → SatelliteEphemeris exists, etc.) but that is v2 scope.
+5. **No PR to `nephio-project/catalog`**. We ship in our own repo first; community contribution to the Nephio catalog is a follow-up after we have internal E2E validation and, ideally, feedback from a Nephio TSC member sync.
+
+## Alternatives considered
+
+### Alternative A — Single combined package
+
+Ship one `ntn-operators` package with both CRDs and samples inside.
+
+**Rejected**: the `workload-crds` catalog precedent is CRDs-only. Mixing CRDs with samples in one package confuses the lifecycle (CRDs install once cluster-wide, samples deploy per-namespace per-tenant). The split mirrors community convention.
+
+### Alternative B — PackageVariantSet-based per-cluster templating
+
+Ship a PackageVariantSet CR alongside the packages so the Nephio mgmt cluster auto-generates per-cluster variants from a ClusterClaim selector.
+
+**Deferred to v2**: requires assumptions about consumer's repo layout and variant selection strategy. Ship the blueprint first; let consumers choose variant strategy.
+
+### Alternative C — Helm-chart-embedded kpt package
+
+Use `render-helm-chart` KRM function at author time to expand our existing Helm chart into YAML, then ship that as the package.
+
+**Rejected**: our Helm chart ships the operator itself (Deployment, RBAC, Service), not the CRDs-as-workload data plane. The kpt package domain is CRDs + CRs, and those are cleaner maintained directly from `config/crd/bases/` + `config/samples/` than via Helm round-trip.
+
+### Alternative D — Skip Nephio integration for now
+
+Accept the credibility cost ("TSC member but no Nephio package") and revisit post-competition.
+
+**Rejected**: the cost of a minimal two-package scaffold is ~1-2 days; the credibility payoff for the NYCU 2026 創新創業競賽 pitch, and for longer-term LFN positioning, exceeds that cost many times over.
+
+## Consequences
+
+### Positive
+
+- First K8s-native NTN Operator with published Nephio packages — reinforces "NTN + K8s + Nephio" positioning across OCUDU, 3GPP NTN WG, and CNCF narratives simultaneously.
+- Downstream consumers on Nephio management clusters can pull the package with one `kpt pkg get` command.
+- `kpt fn render` in CI becomes an early-warning signal for CRD/sample drift (changing a CRD field but forgetting to update the sample CR fails render).
+- Pitches to judges, partners, and VCs can point to a concrete artifact ("here's our Nephio package") rather than an abstract credential ("the founder is on the TSC").
+
+### Negative
+
+- Adds a new build artifact (`nephio/packages/`) that must be kept in sync with `config/crd/bases/` and `config/samples/`. Mitigated by a `make nephio-sync` target that copies from canonical sources and a CI check that fails if the packages drift.
+- Introduces a new CLI dependency (`kpt`) for contributors who modify the packages. Mitigated by `make nephio-install-tools` that downloads the official `kpt_linux_amd64` binary (no Go module build required).
+- Binds us to Nephio R6 annotation conventions. If R7 changes them we will need to revisit the Kptfile. Low risk — R6 kept R5 conventions verbatim.
+
+### Neutral
+
+- No impact on the Go controller code, CRD definitions, Helm chart, or OLM bundle. Nephio integration is purely a distribution-side artifact.
+
+## Validation plan
+
+Tests live in `test/nephio/validate.sh`, wired through `make nephio-validate`:
+
+1. **Package discoverability** — both `ntn-operators-crds` and `ntn-workloads-sample` directories exist under `nephio/packages/`.
+2. **Kptfile syntactic validity** — `kpt pkg tree <pkg>` succeeds for both.
+3. **Rendering** — `kpt fn render <pkg>` succeeds for both, non-empty output.
+4. **CRD coverage** — all four expected CRD kinds appear in the CRDs package.
+5. **Sample coverage** — all four expected sample CR kinds appear in the workloads package, with mutator-applied namespace and labels.
+6. **K8s manifest validity** — `kubectl apply --dry-run=client -f <rendered-output>` succeeds for both (client-side dry-run avoids needing a live cluster in CI).
+7. **Drift detection** — a separate `make nephio-verify-sync` compares SHA of `nephio/packages/ntn-operators-crds/*-crd.yaml` against `config/crd/bases/*.yaml`; mismatch fails CI.
+
+## Follow-ups (tracked in new issues, not in this ADR)
+
+- v2: custom KRM function for cross-CR reference validation (NTNSlice.satellitePath.ephemerisRef exists in cluster).
+- v2: PackageVariantSet example for multi-edge-site specialization (paired with a realistic `ClusterClaim` from a Nephio demo cluster).
+- Post-v1: PR to `nephio-project/catalog` after E2E validation with at least one external Nephio user.
+- Post-v1: GitOps bootstrap (Flux/ArgoCD) YAML in the README showing the full consumer flow.
+
+## References
+
+- [Nephio R6 release announcement (2026-04-01)](https://nephio.org/nephio-release-6-strengthening-stability-and-security/)
+- [Nephio docs R6](https://docs.nephio.org/docs/)
+- [nephio-project/catalog](https://github.com/nephio-project/catalog)
+- [catalog/nephio/core/workload-crds/Kptfile (canonical minimal example)](https://raw.githubusercontent.com/nephio-project/catalog/main/nephio/core/workload-crds/Kptfile)
+- [KRM Functions Catalog](https://catalog.kpt.dev/)
+- [kpt fn render CLI reference](https://kpt.dev/reference/cli/fn/render/)
+- [Porch releases](https://github.com/nephio-project/porch/releases)
+- [Nephio governance (TSC charter)](https://github.com/nephio-project/governance)
+
+Co-authored-by: junnncct1106 <jun.514114.ee10@nycu.edu.tw>

--- a/docs/images/nephio-demo-output.txt
+++ b/docs/images/nephio-demo-output.txt
@@ -1,0 +1,70 @@
+────────────────────────────────────────────────────────────────────────
+  ntn-operators — Nephio R6 package integration
+  Demo transcript (2026-04-24)
+────────────────────────────────────────────────────────────────────────
+
+$ kpt version
+1.0.0-beta.62
+
+$ kpt pkg tree nephio/packages/
+packages
+├── Package "ntn-operators-crds"
+│   ├── [Kptfile]  Kptfile ntn-operators-crds
+│   ├── [groundstationlifecycles-crd.yaml]  CustomResourceDefinition groundstationlifecycles.ntn.operators.dev
+│   ├── [ntncellconfigs-crd.yaml]  CustomResourceDefinition ntncellconfigs.ntn.operators.dev
+│   ├── [ntnslices-crd.yaml]  CustomResourceDefinition ntnslices.ntn.operators.dev
+│   └── [satelliteephemeris-crd.yaml]  CustomResourceDefinition satelliteephemeris.ntn.operators.dev
+└── Package "ntn-workloads-sample"
+    ├── [Kptfile]  Kptfile ntn-workloads-sample
+    ├── [groundstationlifecycle-sample.yaml]  GroundStationLifecycle default/gs-taipei-01
+    ├── [ntncellconfig-sample.yaml]  NTNCellConfig default/ntn-cell-geo-demo
+    ├── [ntnslice-sample.yaml]  NTNSlice default/enterprise-resilient-slice
+    └── [satelliteephemeris-sample.yaml]  SatelliteEphemeris default/oneweb-constellation
+
+$ make nephio-validate
+===> Preflight
+  PASS  kpt CLI available (1.0.0-beta.62)
+  PASS  kubectl available (v1.35.4)
+
+===> Suite A: ntn-operators-crds package
+  PASS  T1 package dir exists: nephio/packages/ntn-operators-crds/
+  PASS  T2 Kptfile valid, 'kpt pkg tree' succeeds
+  PASS  T3 'kpt fn render' succeeds on CRDs package
+  PASS  T4 all 4 README-promised CRD filenames present (filename contract honored)
+  PASS  T5 exactly 4 CustomResourceDefinition kinds in package
+  PASS  T6 README.md present
+  PASS  T7 rendered CRDs pass 'kubectl apply --dry-run=client'
+  PASS  T13 CRD drift check passes (package matches config/crd/bases/)
+
+===> Suite B: ntn-workloads-sample package
+  PASS  T8 package dir exists: nephio/packages/ntn-workloads-sample/
+  PASS  T9 Kptfile valid, 'kpt pkg tree' succeeds
+  PASS  T10 'kpt fn render' succeeds + set-namespace mutator applied (namespace: ntn-system)
+  PASS  T11 all 4 README-promised sample filenames present (filename contract honored)
+  PASS  T14 all 4 sample CR kinds present in YAML content
+  PASS  T12 rendered samples parse as valid K8s YAML
+
+===> Summary
+  Passed: 16 / 16
+  Failed: 0 / 16
+
+OK: all Nephio package assertions pass.
+
+$ # Example render on a temp copy (keeps the repo tree pristine):
+$ mkdir -p /tmp/ntn-demo && cp -r nephio/packages/ntn-workloads-sample/. /tmp/ntn-demo/
+$ kpt fn render /tmp/ntn-demo
+Package: "ntn-demo"
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1" in 400ms
+[Results]: [info]: namespace "default" updated to "ntn-system", 4 value(s) changed
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1" in 200ms
+[Results]: [info]: set 8 labels in total
+Successfully executed 2 function(s) in 1 package(s).
+
+$ # After render: set-namespace rewrote default -> ntn-system
+$ grep "^  namespace:" /tmp/ntn-demo/*-sample.yaml
+/tmp/ntn-demo/ntncellconfig-sample.yaml:  namespace: ntn-system
+/tmp/ntn-demo/ntnslice-sample.yaml:  namespace: ntn-system
+/tmp/ntn-demo/satelliteephemeris-sample.yaml:  namespace: ntn-system
+/tmp/ntn-demo/groundstationlifecycle-sample.yaml:  namespace: ntn-system

--- a/nephio/README.md
+++ b/nephio/README.md
@@ -1,0 +1,122 @@
+# Nephio Integration
+
+[ntn-operators](https://github.com/thc1006/ntn-operators) publishes its CRDs and sample workloads as [Nephio R6](https://nephio.org)-compatible kpt packages, so that Kubernetes-native NTN deployments can be consumed, versioned, and composed through the Linux Foundation Networking Nephio toolchain.
+
+Design rationale lives in [ADR 0003](../docs/adr/0003-nephio-integration.md).
+
+---
+
+## Packages
+
+This directory ships **two sibling kpt packages**. The split follows the convention of `nephio-project/catalog/nephio/core/workload-crds/`: CRDs are cluster-scoped installation artifacts, and sample CRs are namespace-scoped workload data. Consumers install the CRDs package once per cluster and instantiate the workloads package per namespace / per tenant.
+
+| Package | Purpose | Pipeline | Details |
+|---|---|---|---|
+| [`packages/ntn-operators-crds`](packages/ntn-operators-crds) | Ships the 4 CRDs (`SatelliteEphemeris`, `GroundStationLifecycle`, `NTNCellConfig`, `NTNSlice`). Install once per cluster. | None (CRDs go in as-is). | [README](packages/ntn-operators-crds/README.md) |
+| [`packages/ntn-workloads-sample`](packages/ntn-workloads-sample) | Ships one sample CR per kind, pre-filled with realistic LEO-constellation data. | `set-namespace` + `set-labels` from `ghcr.io/kptdev/krm-functions-catalog`. | [README](packages/ntn-workloads-sample/README.md) |
+
+---
+
+## Quick start
+
+### On any machine with `kpt` installed
+
+```bash
+# 1) install ntn-operators CRDs
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-operators-crds@main ntn-operators-crds
+kubectl apply -f ntn-operators-crds/
+
+# 2) (separately) install the operator binary via Helm — see dist/chart/README.md
+#    for the currently-published version; both stable and pre-release tags
+#    live under the same OCI repo:
+helm install ntn-operators oci://ghcr.io/thc1006/ntn-operators/charts/ntn-operators
+
+# 3) pull, render, and apply sample workloads. kpt fn render mutates files
+#    in place — that is the intended consumer flow (your local checkout
+#    becomes the deployable artifact):
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-workloads-sample@main ntn-workloads-sample
+kpt fn render ntn-workloads-sample    # applies set-namespace + set-labels
+kubectl apply -f ntn-workloads-sample/
+```
+
+> **Repo maintainer note.** If you are running `kpt fn render` from inside the ntn-operators repo worktree (not from a `kpt pkg get` copy), render on a temp copy instead — `cp -r nephio/packages/ntn-workloads-sample /tmp/pkg && kpt fn render /tmp/pkg` — otherwise the source tree gets a `status:` block committed and the `nephio-verify-sync` drift check trips. The tests in `test/nephio/validate.sh` use this tmp-copy pattern for every in-place render (T3, T7, T10, T12).
+
+### Via a Nephio management cluster (Porch)
+
+Reference these packages from a PackageVariant in your deployment repo. Full CR examples:
+
+- CRDs install: [`packages/ntn-operators-crds/README.md`](packages/ntn-operators-crds/README.md#on-a-nephio-management-cluster-porch) — shows `PackageVariant` pointing at this blueprint.
+- Workload deployment: [`packages/ntn-workloads-sample/README.md`](packages/ntn-workloads-sample/README.md#on-a-nephio-management-cluster-porch) — shows per-cluster specialization with `packageContext` and an additional `apply-replacements` mutator.
+
+---
+
+## Contributor workflow
+
+Everything runs from the repository root via `make`:
+
+```bash
+make nephio-install-tools    # install kpt (version pinned in Makefile) into $(go env GOPATH)/bin
+make nephio-sync             # regenerate package CRDs from config/crd/bases/
+make nephio-render           # run 'kpt fn render' on both packages (in-place — not for CI)
+make nephio-validate         # run test/nephio/validate.sh (full suite, currently 16 assertions)
+make nephio-verify-sync      # CI drift check — fails if nephio/packages/ntn-operators-crds/*-crd.yaml diverges from config/crd/bases/
+```
+
+The test script `test/nephio/validate.sh` is the executable contract. It is hermetic (no live cluster needed) and is the single source of truth for whether the packages are releasable.
+
+### When you change a CRD
+
+1. Edit `api/v1alpha1/*_types.go`
+2. `make manifests` → regenerates `config/crd/bases/*.yaml`
+3. `make nephio-sync` → copies bases into `nephio/packages/ntn-operators-crds/`
+4. `make nephio-validate` → confirms everything still renders clean
+5. Commit both the updated `config/crd/bases/*.yaml` and `nephio/packages/ntn-operators-crds/*-crd.yaml`
+
+CI runs `make nephio-verify-sync` on every PR — forgetting step 3 fails the build.
+
+### When you change a sample CR
+
+Samples in `config/samples/ntn_v1alpha1_*.yaml` and package samples in `nephio/packages/ntn-workloads-sample/*-sample.yaml` are intentionally not byte-synced. The package samples have two extra properties:
+
+- an explicit `namespace: default` field (so `set-namespace` has a value to rewrite)
+- **no** hardcoded `workload` / `app.kubernetes.io/managed-by` labels (those are injected by `set-labels` at render time)
+
+If you add a field to a sample, add it to both locations, then `make nephio-validate`.
+
+---
+
+## Compatibility
+
+| Component | Version |
+|---|---|
+| Nephio | R6 (released 2026-04-01) |
+| Porch | v1.5.6+ |
+| `kpt` CLI | v1.0.0-beta.55 or newer |
+| Kubernetes | 1.29+ (CEL validation is GA from 1.29) |
+| KRM function registry | `ghcr.io/kptdev/krm-functions-catalog` (Nephio R6 canonical; `gcr.io/kpt-fn/` tags are still current and functional) |
+
+---
+
+## Why this matters
+
+Three reasons the integration is not cosmetic:
+
+1. **Deployment story closure.** ntn-operators' author is a Nephio TSC member; shipping a Nephio-consumable package makes that TSC seat operational, not ornamental — Nephio users can consume us without hand-rolled kustomize overlays.
+2. **Ecosystem fit.** Nephio is the LFN-sanctioned path for K8s-native telecom NF orchestration. Being on the Nephio package path is the cheapest route to inclusion in Sylva blueprints, Aether integration demos, and O-RAN SC handover scenarios.
+3. **Deployment composition.** Downstream users pull our CRDs + samples through `kpt pkg get` and then compose them with other Nephio packages (5G core NFs, RIC, RAN) in the same deployment repo. GitOps tooling (Config Sync, ArgoCD, Flux) picks up the combined state without knowing NTN is involved.
+
+---
+
+## Limitations (v1)
+
+- No `PackageVariantSet` manifests shipped here. Variants belong in the consumer's deployment repo; see each sub-README for example YAML.
+- No Porch cluster bootstrap. Porch setup is documented at nephio.org — we don't duplicate.
+- No custom KRM functions yet. A future `ntn-validator-fn` could validate cross-CR references (e.g., `NTNSlice.satellitePath.ephemerisRef` resolves to an existing `SatelliteEphemeris`). Tracked as a follow-up.
+- KRM function images are pinned by tag (`:v0.4.1`), not by `@sha256:` digest. Digest pinning is a post-1.0 supply-chain hardening item.
+- We have not yet contributed these packages to `nephio-project/catalog` upstream. The plan is to submit after E2E validation with at least one external Nephio user confirms the packages work in their deployment flow.
+
+---
+
+## License
+
+Apache License 2.0. See the [root LICENSE](../LICENSE).

--- a/nephio/README.md
+++ b/nephio/README.md
@@ -80,6 +80,7 @@ Samples in `config/samples/ntn_v1alpha1_*.yaml` and package samples in `nephio/p
 
 - an explicit `namespace: default` field (so `set-namespace` has a value to rewrite)
 - **no** hardcoded `workload` / `app.kubernetes.io/managed-by` labels (those are injected by `set-labels` at render time)
+- `SatelliteEphemeris` only references ground stations that this package itself ships. The canonical `config/samples/ntn_v1alpha1_satelliteephemeris.yaml` references both `gs-taipei-01` and `gs-hsinchu-01` because the `config/samples/` directory also ships `ntn_v1alpha1_groundstationlifecycle_hsinchu.yaml`; the Nephio workloads package only ships `gs-taipei-01`, so the ephemeris sample is trimmed accordingly.
 
 If you add a field to a sample, add it to both locations, then `make nephio-validate`.
 

--- a/nephio/packages/ntn-operators-crds/Kptfile
+++ b/nephio/packages/ntn-operators-crds/Kptfile
@@ -1,0 +1,17 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: ntn-operators-crds
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    CustomResourceDefinitions for the ntn-operators project — the first
+    open-source Kubernetes operator for 3GPP Non-Terrestrial Network (NTN)
+    deployments. Installs four CRDs on the target cluster:
+      - SatelliteEphemeris (satellite ephemeris tracking + SGP4 propagation)
+      - GroundStationLifecycle (ground-station edge node lifecycle)
+      - NTNCellConfig (3GPP TS 38.331 NTN-Config-r17 cell configuration)
+      - NTNSlice (geo-satellite resilient slice with failover policy)
+    This package is CRDs-only; the operator binary is installed separately
+    via Helm (dist/chart/) or OLM (bundle/). Compatible with Nephio R6.

--- a/nephio/packages/ntn-operators-crds/README.md
+++ b/nephio/packages/ntn-operators-crds/README.md
@@ -1,0 +1,83 @@
+# ntn-operators-crds
+
+CustomResourceDefinitions for [ntn-operators](https://github.com/thc1006/ntn-operators), packaged as a [Nephio](https://nephio.org) R6-compatible kpt package.
+
+This package installs four CRDs on a Kubernetes cluster. It does not install the operator binary itself — see the repository root for Helm and OLM options.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `Kptfile` | Package metadata. No mutation pipeline — CRDs are installed as-is. |
+| `satelliteephemeris-crd.yaml` | `SatelliteEphemeris` — satellite ephemeris tracking, SGP4 propagation, pass-window prediction. |
+| `groundstationlifecycles-crd.yaml` | `GroundStationLifecycle` — ground-station edge node lifecycle (firmware OTA, health, hardware match). |
+| `ntncellconfigs-crd.yaml` | `NTNCellConfig` — 3GPP TS 38.331 NTN-Config-r17 cell parameters (ephemeris, k-offset, TA, polarization, k_mac). |
+| `ntnslices-crd.yaml` | `NTNSlice` — geo-satellite resilient slice with failover policy, QoS mapping, billing, and session continuity fields. |
+
+The CRD YAMLs are regenerated from `api/v1alpha1/*_types.go` via `controller-gen` and synced into this package by `make nephio-sync`. Do not edit them by hand.
+
+## Prerequisites
+
+- Kubernetes 1.29+ (CEL validation is used extensively, and is GA from 1.29)
+- `kpt` v1.0.0-beta.55+ for package consumption (`kpt version`)
+- Cluster-admin permissions on the target cluster (CRD install is cluster-scoped)
+
+## Consume
+
+### Quick one-off install
+
+```bash
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-operators-crds@main ntn-operators-crds
+kubectl apply -f ntn-operators-crds/
+```
+
+### Render through kpt (no mutation, but verifies freshness)
+
+```bash
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-operators-crds@main ntn-operators-crds
+kpt fn render ntn-operators-crds
+kpt live init ntn-operators-crds
+kpt live apply ntn-operators-crds --reconcile-timeout=2m
+```
+
+### On a Nephio management cluster (Porch)
+
+Create a `PackageVariant` in your deployment repo that draws from this blueprint:
+
+```yaml
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: ntn-operators-crds-edge01
+spec:
+  upstream:
+    repo: thc1006-ntn-operators
+    package: nephio/packages/ntn-operators-crds
+    revision: main
+  downstream:
+    repo: deploy-edge01
+    package: ntn-operators-crds
+  adoptionPolicy: adoptExisting
+  deletionPolicy: delete
+```
+
+The CRDs land cluster-wide, and per-cluster customization (namespace scoping of operator, labels, cluster name) is handled by the companion `ntn-workloads-sample` package.
+
+## Uninstall
+
+```bash
+kubectl delete -f ntn-operators-crds/
+```
+
+Warning: deleting a CRD cascades-deletes every CustomResource of that kind. If you want to preserve existing CRs, use `kubectl patch` on the CRD objects to add the `"helm.sh/resource-policy": keep` annotation before deleting, or adopt a GitOps workflow (ArgoCD/Flux) that retains the CRDs separately from the CRs.
+
+## Version compatibility
+
+| ntn-operators tag | Nephio release tested | K8s tested |
+|---|---|---|
+| `main` | R6 (Porch v1.5.6) | 1.29 - 1.35 |
+| `v0.1.0` | (not validated on Nephio) | 1.29+ |
+
+## License
+
+Apache License 2.0 — see the [top-level LICENSE](https://github.com/thc1006/ntn-operators/blob/main/LICENSE) in the ntn-operators repository.

--- a/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
@@ -1,0 +1,269 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: groundstationlifecycles.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: GroundStationLifecycle
+    listKind: GroundStationLifecycleList
+    plural: groundstationlifecycles
+    shortNames:
+    - gs
+    singular: groundstationlifecycle
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.hardware.vendor
+      name: Vendor
+      type: string
+    - jsonPath: .status.k8sVersion
+      name: K8s
+      type: string
+    - jsonPath: .status.lastHealthCheck
+      name: Last Check
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GroundStationLifecycle manages the lifecycle of a satellite ground station,
+          including health monitoring, firmware OTA, and GitOps-based configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GroundStationLifecycleSpec defines the desired state of a
+              ground station.
+            properties:
+              deployment:
+                description: deployment defines the station deployment and location.
+                properties:
+                  gitopsRepo:
+                    description: gitopsRepo is the Git repository URL for GitOps-managed
+                      configuration.
+                    type: string
+                  k8sDistro:
+                    default: k3s
+                    description: k8sDistro is the Kubernetes distribution running
+                      on the edge box.
+                    enum:
+                    - k3s
+                    - microk8s
+                    - rke2
+                    type: string
+                  location:
+                    description: location is the geographic position of the ground
+                      station.
+                    properties:
+                      alt:
+                        description: alt is the altitude in meters above sea level
+                          (string, e.g., "15").
+                        type: string
+                      lat:
+                        description: lat is the latitude in decimal degrees (string,
+                          e.g., "25.0330").
+                        pattern: ^-?[0-9]+\.?[0-9]*$
+                        type: string
+                      lon:
+                        description: lon is the longitude in decimal degrees (string,
+                          e.g., "121.5654").
+                        pattern: ^-?[0-9]+\.?[0-9]*$
+                        type: string
+                    required:
+                    - lat
+                    - lon
+                    type: object
+                    x-kubernetes-validations:
+                    - message: lat must be between -90 and 90
+                      rule: double(self.lat) >= -90.0 && double(self.lat) <= 90.0
+                    - message: lon must be between -180 and 180
+                      rule: double(self.lon) >= -180.0 && double(self.lon) <= 180.0
+                required:
+                - location
+                type: object
+              firmware:
+                description: firmware defines OTA update configuration.
+                properties:
+                  autoUpdate:
+                    default: false
+                    description: autoUpdate enables automatic firmware updates.
+                    type: boolean
+                  channel:
+                    default: stable
+                    description: channel is the firmware update channel (e.g., "stable",
+                      "beta").
+                    type: string
+                  maintenanceWindow:
+                    description: |-
+                      maintenanceWindow is the time window for updates.
+                      Format: "HH:MM-HH:MM UTC" (e.g., "02:00-04:00 UTC").
+                    pattern: ^([01][0-9]|2[0-3]):[0-5][0-9]-([01][0-9]|2[0-3]):[0-5][0-9]\s+UTC$
+                    type: string
+                type: object
+              hardware:
+                description: hardware describes the ground station equipment.
+                properties:
+                  antennaType:
+                    description: antennaType is the antenna type (e.g., "flat-panel",
+                      "parabolic").
+                    type: string
+                  bands:
+                    description: bands lists the supported frequency bands (e.g.,
+                      ["Ka", "Ku", "S"]).
+                    items:
+                      type: string
+                    type: array
+                  model:
+                    description: model is the hardware model identifier.
+                    minLength: 1
+                    type: string
+                  vendor:
+                    description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    minLength: 1
+                    type: string
+                required:
+                - model
+                - vendor
+                type: object
+              monitoring:
+                description: monitoring defines health check parameters.
+                properties:
+                  endpoint:
+                    description: endpoint is the monitoring endpoint of the ground
+                      station agent.
+                    type: string
+                  healthCheckInterval:
+                    default: 30s
+                    description: healthCheckInterval is how often to check ground
+                      station health.
+                    type: string
+                type: object
+            required:
+            - deployment
+            - hardware
+            type: object
+          status:
+            description: GroundStationLifecycleStatus defines the observed state of
+              a ground station.
+            properties:
+              conditions:
+                description: conditions represent the current state of the ground
+                  station.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              firmwareUpdateStarted:
+                description: |-
+                  firmwareUpdateStarted is when the current firmware update began.
+                  Used for timeout detection.
+                format: date-time
+                type: string
+              firmwareVersion:
+                description: firmwareVersion is the currently running firmware version.
+                type: string
+              k8sVersion:
+                description: k8sVersion is the Kubernetes version running on the edge
+                  node.
+                type: string
+              lastHealthCheck:
+                description: lastHealthCheck is the timestamp of the last successful
+                  health check.
+                format: date-time
+                type: string
+              phase:
+                description: phase is the current lifecycle phase.
+                enum:
+                - Provisioning
+                - Running
+                - Degraded
+                - Offline
+                - Updating
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -1,0 +1,600 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ntncellconfigs.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: NTNCellConfig
+    listKind: NTNCellConfigList
+    plural: ntncellconfigs
+    shortNames:
+    - ntncc
+    singular: ntncellconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.type
+      name: Provider
+      type: string
+    - jsonPath: .spec.ntn.cellSpecificKoffset
+      name: Koffset
+      type: integer
+    - jsonPath: .spec.ntn.payloadType
+      name: Payload
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NTNCellConfig manages NTN-specific radio parameters for a gNB cell,
+          delegating configuration to the specified NTN backend provider.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NTNCellConfigSpec defines the desired NTN cell configuration.
+            properties:
+              cellOverrides:
+                description: cellOverrides allows fine-tuning PUCCH, PDSCH, PRACH,
+                  and RRC parameters.
+                properties:
+                  pdschMaxHarqRetxs:
+                    default: 0
+                    description: pdschMaxHarqRetxs sets the max HARQ retransmissions
+                      (0 = disabled for NTN).
+                    type: integer
+                  prachMaxMsg3HarqRetx:
+                    default: 0
+                    description: prachMaxMsg3HarqRetx sets the max msg3 HARQ retransmissions.
+                    type: integer
+                  rrcGuardTimeMs:
+                    default: 12800
+                    description: rrcGuardTimeMs sets the RRC procedure guard time
+                      in ms.
+                    type: integer
+                  sibSchedule:
+                    description: |-
+                      sibSchedule tunes SIB19 broadcast scheduling. Any unset sub-field
+                      falls back to the defaults (siWindowLength=5, siPeriod=16,
+                      siWindowPosition=1). Tune when PDCCH capacity is tight or when
+                      SIB19 broadcast cadence needs to track short ntn-UlSyncValidityDur.
+                    properties:
+                      siPeriod:
+                        description: |-
+                          siPeriod is the SIB19 broadcast period in radio frames.
+                          Shorter periods keep UEs' NTN assistance fresh but cost air time.
+                        enum:
+                        - 8
+                        - 16
+                        - 32
+                        - 64
+                        - 128
+                        - 256
+                        - 512
+                        type: integer
+                      siWindowLength:
+                        description: |-
+                          siWindowLength is the SI window length in slots. OCUDU accepts
+                          the standard set; picking a larger value increases PDCCH pressure.
+                        enum:
+                        - 5
+                        - 10
+                        - 20
+                        - 40
+                        - 80
+                        - 160
+                        - 320
+                        - 640
+                        - 1280
+                        type: integer
+                      siWindowPosition:
+                        description: |-
+                          siWindowPosition is the slot offset within the SI period. Adjust
+                          to avoid collision with SIB1/SIB2 scheduling windows. Pointer so 0
+                          (the first slot) can be distinguished from unset.
+                        maximum: 79
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
+              ephemerisRef:
+                description: |-
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
+                  When set, the controller re-reconciles this NTNCellConfig whenever the
+                  referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
+                  on the provider reconcile path. The static ephemeris in spec.ntn
+                  (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                minLength: 1
+                type: string
+              ntn:
+                description: ntn contains NTN-specific radio parameters per 3GPP TS
+                  38.213 / OCUDU geo_ntn.yml.
+                properties:
+                  cellSpecificKoffset:
+                    default: 150
+                    description: cellSpecificKoffset sets the cell-specific k-offset
+                      for NTN (0-1023).
+                    maximum: 1023
+                    minimum: 0
+                    type: integer
+                  distanceThreshold:
+                    description: |-
+                      distanceThreshold sets the distance threshold for cell
+                      selection in metres.
+                    minimum: 0
+                    type: integer
+                  ephemerisECEF:
+                    description: |-
+                      ephemerisECEF defines the satellite position and velocity in ECEF coordinates.
+                      Mutually exclusive with ephemerisOrbital.
+                    properties:
+                      posX:
+                        description: posX is the X position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      posY:
+                        description: posY is the Y position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      posZ:
+                        description: posZ is the Z position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      velX:
+                        default: 0
+                        description: velX is the X velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                      velY:
+                        default: 0
+                        description: velY is the Y velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                      velZ:
+                        default: 0
+                        description: velZ is the Z velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                    required:
+                    - posX
+                    - posY
+                    - posZ
+                    type: object
+                  ephemerisOrbital:
+                    description: |-
+                      ephemerisOrbital defines the satellite orbit using Keplerian elements.
+                      Mutually exclusive with ephemerisECEF. Preferred for LEO satellites
+                      where source data is in OMM/TLE form (CelesTrak, SpaceTrack).
+                    properties:
+                      argOfPeriapsis:
+                        description: argOfPeriapsis is the argument of periapsis in
+                          1e-4 degrees (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      eccentricity:
+                        description: eccentricity is the orbital eccentricity scaled
+                          by 1e6 (0-999999 for e < 1.0).
+                        maximum: 999999
+                        minimum: 0
+                        type: integer
+                      inclination:
+                        description: inclination is the orbital inclination in 1e-4
+                          degrees (0-1800000 = 0°-180°).
+                        maximum: 1800000
+                        minimum: 0
+                        type: integer
+                      meanAnomaly:
+                        description: meanAnomaly is the mean anomaly in 1e-4 degrees
+                          (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      rightAscension:
+                        description: rightAscension is the right ascension of the
+                          ascending node in 1e-4 degrees (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      semiMajorAxis:
+                        description: semiMajorAxis is the semi-major axis in metres.
+                        minimum: 6370000
+                        type: integer
+                    required:
+                    - argOfPeriapsis
+                    - eccentricity
+                    - inclination
+                    - meanAnomaly
+                    - rightAscension
+                    - semiMajorAxis
+                    type: object
+                  epochTime:
+                    description: epochTime defines the SFN/subframe reference for
+                      NTN timing alignment.
+                    properties:
+                      sfn:
+                        description: sfn is the System Frame Number (0-1023).
+                        maximum: 1023
+                        minimum: 0
+                        type: integer
+                      subframeNumber:
+                        description: subframeNumber is the subframe within the SFN
+                          (0-9).
+                        maximum: 9
+                        minimum: 0
+                        type: integer
+                    required:
+                    - sfn
+                    - subframeNumber
+                    type: object
+                  feederLinkInfo:
+                    description: feederLinkInfo provides feeder link parameters for
+                      Doppler compensation.
+                    properties:
+                      dlFreqHz:
+                        description: dlFreqHz is the downlink frequency in Hz. Required
+                          when feederLinkInfo is set.
+                        format: int64
+                        minimum: 1
+                        type: integer
+                      enableDopplerCompensation:
+                        description: enableDopplerCompensation enables feeder link
+                          Doppler compensation.
+                        type: boolean
+                      ulFreqHz:
+                        description: ulFreqHz is the uplink frequency in Hz. Required
+                          when feederLinkInfo is set.
+                        format: int64
+                        minimum: 1
+                        type: integer
+                    required:
+                    - dlFreqHz
+                    - enableDopplerCompensation
+                    - ulFreqHz
+                    type: object
+                  movingRefLocation:
+                    description: |-
+                      movingRefLocation defines the Earth-moving reference location for LEO NTN cells.
+                      3GPP Release 18 SIB19 field. Used by UEs for timing/Doppler estimation.
+                    properties:
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000 =
+                          -90° to 90°).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000
+                          = -180° to 180°).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - latitude
+                    - longitude
+                    type: object
+                  neighborCells:
+                    description: |-
+                      neighborCells lists neighbor NTN cells for measurement/handover.
+                      OCUDU YAML renders as "ncells:" for compatibility.
+                    items:
+                      description: NTNNeighborCell describes a neighbor NTN cell.
+                      properties:
+                        frequency:
+                          description: frequency is the neighbor cell's ARFCN (NR-ARFCN,
+                            always >= 1).
+                          minimum: 1
+                          type: integer
+                        physicalCellID:
+                          description: physicalCellID of the neighbor (0-1007).
+                          maximum: 1007
+                          minimum: 0
+                          type: integer
+                      required:
+                      - physicalCellID
+                      type: object
+                    type: array
+                  ntnGatewayLocation:
+                    description: ntnGatewayLocation specifies the NTN gateway (ground
+                      station) coordinates.
+                    properties:
+                      altitude:
+                        description: altitude in metres above sea level. Required
+                          when ntnGatewayLocation is set.
+                        type: integer
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - altitude
+                    - latitude
+                    - longitude
+                    type: object
+                  ntnUlSyncValidityDur:
+                    description: ntnUlSyncValidityDur sets the UL synchronization
+                      validity duration in seconds.
+                    enum:
+                    - 5
+                    - 10
+                    - 15
+                    - 20
+                    - 25
+                    - 30
+                    - 35
+                    - 40
+                    - 45
+                    - 50
+                    - 55
+                    - 60
+                    - 120
+                    - 180
+                    - 240
+                    - 900
+                    type: integer
+                  payloadType:
+                    default: transparent
+                    description: payloadType specifies the satellite payload architecture.
+                    enum:
+                    - transparent
+                    - regenerative
+                    type: string
+                  polarization:
+                    description: |-
+                      polarization specifies the antenna polarization for downlink and uplink.
+                      Per 3GPP TS 38.331 SIB19, ntn-PolarizationDL-r17 and ntn-PolarizationUL-r17
+                      are independent IEs. OCUDU collapses them under a single `polarization:` map
+                      with `dl:` / `ul:` sub-keys, matching this CRD layout.
+                    properties:
+                      dl:
+                        description: dl is the downlink polarization broadcast in
+                          SIB19 ntn-PolarizationDL-r17.
+                        enum:
+                        - rhcp
+                        - lhcp
+                        - linear
+                        type: string
+                      ul:
+                        description: ul is the uplink polarization broadcast in SIB19
+                          ntn-PolarizationUL-r17.
+                        enum:
+                        - rhcp
+                        - lhcp
+                        - linear
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of dl or ul must be set
+                      rule: has(self.dl) || has(self.ul)
+                  referenceLocation:
+                    description: referenceLocation defines the NTN cell reference
+                      location.
+                    properties:
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - latitude
+                    - longitude
+                    type: object
+                  satSwitchWithResync:
+                    description: |-
+                      satSwitchWithResync provides satellite switch handover hints to UEs during
+                      satellite-to-satellite transitions. 3GPP Release 18 SIB19 field.
+                    properties:
+                      t304:
+                        description: t304 is the handover timer value in milliseconds
+                          per 3GPP TS 38.331.
+                        enum:
+                        - 50
+                        - 100
+                        - 150
+                        - 200
+                        - 500
+                        - 1000
+                        - 2000
+                        - 10000
+                        type: integer
+                      targetPCI:
+                        description: targetPCI is the Physical Cell Identity of the
+                          target cell after switch (0-1007).
+                        maximum: 1007
+                        minimum: 0
+                        type: integer
+                    required:
+                    - t304
+                    - targetPCI
+                    type: object
+                  tService:
+                    description: tService sets the expected NTN service duration in
+                      seconds.
+                    minimum: 1
+                    type: integer
+                  taCommon:
+                    default: 0
+                    description: taCommon sets the common Timing Advance value (0-66485757).
+                    maximum: 66485757
+                    minimum: 0
+                    type: integer
+                  taInfo:
+                    description: |-
+                      taInfo provides extended Timing Advance parameters per 3GPP TS 38.213.
+                      When set, taInfo.taCommon takes precedence over the top-level taCommon field.
+                    properties:
+                      taCommon:
+                        description: |-
+                          taCommon is the common Timing Advance value (0-66485757). Required when
+                          taInfo is set — explicitly provide 0 for GEO satellites.
+                        maximum: 66485757
+                        minimum: 0
+                        type: integer
+                      taCommonDrift:
+                        description: taCommonDrift is the TA drift rate.
+                        type: integer
+                      taCommonDriftVariant:
+                        description: taCommonDriftVariant is the TA drift rate variant.
+                        type: integer
+                      taCommonOffset:
+                        description: taCommonOffset is an additional TA offset.
+                        type: integer
+                    required:
+                    - taCommon
+                    type: object
+                  taReport:
+                    description: taReport enables UE TA reporting.
+                    type: boolean
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of ephemerisECEF or ephemerisOrbital must be
+                    set
+                  rule: has(self.ephemerisECEF) || has(self.ephemerisOrbital)
+                - message: ephemerisECEF and ephemerisOrbital are mutually exclusive
+                  rule: '!(has(self.ephemerisECEF) && has(self.ephemerisOrbital))'
+                - message: ephemerisECEF position must not be all zeros
+                  rule: '!has(self.ephemerisECEF) || self.ephemerisECEF.posX != 0
+                    || self.ephemerisECEF.posY != 0 || self.ephemerisECEF.posZ !=
+                    0'
+              provider:
+                description: provider specifies which NTN backend to configure.
+                properties:
+                  endpoint:
+                    description: endpoint is the provider-specific endpoint (e.g.,
+                      O1 NETCONF address).
+                    type: string
+                  namespace:
+                    description: namespace where the provider resources (e.g., OCUDU
+                      gNB) are deployed.
+                    type: string
+                  type:
+                    description: type is the provider type. Currently only "ocudu"
+                      is supported.
+                    enum:
+                    - ocudu
+                    type: string
+                required:
+                - type
+                type: object
+            required:
+            - ntn
+            - provider
+            type: object
+          status:
+            description: NTNCellConfigStatus defines the observed state of NTNCellConfig.
+            properties:
+              appliedKoffset:
+                description: appliedKoffset is the last successfully applied k-offset
+                  value.
+                type: integer
+              conditions:
+                description: conditions represent the current state of the resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configMapRef:
+                description: configMapRef is the name of the ConfigMap containing
+                  the generated config.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -1,0 +1,397 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ntnslices.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: NTNSlice
+    listKind: NTNSliceList
+    plural: ntnslices
+    shortNames:
+    - nts
+    singular: ntnslice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tenant
+      name: Tenant
+      type: string
+    - jsonPath: .status.activePathType
+      name: Active Path
+      type: string
+    - jsonPath: .status.failoverCount
+      name: Failovers
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NTNSlice manages terrestrial-satellite network slice failover,
+          QoS mapping, and session continuity for NTN enterprise services.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              NTNSliceSpec defines the desired state of an NTN network slice
+              with terrestrial-satellite failover policy.
+            properties:
+              billing:
+                description: billing defines CDR generation parameters.
+                properties:
+                  satelliteRate:
+                    description: satelliteRate is the charging model for satellite
+                      path.
+                    enum:
+                    - per-volume
+                    - per-time
+                    - per-minute
+                    - flat
+                    type: string
+                  terrestrialRate:
+                    description: terrestrialRate is the charging model for terrestrial
+                      path.
+                    enum:
+                    - per-volume
+                    - per-time
+                    - flat
+                    type: string
+                type: object
+              failoverPolicy:
+                description: failoverPolicy defines when and how to switch between
+                  paths.
+                properties:
+                  hysteresisMargin:
+                    description: |-
+                      hysteresisMargin is a dead-band applied to trigger thresholds
+                      during switchback evaluation, preventing flapping when metrics
+                      oscillate near the threshold. The value uses the same unit as
+                      the trigger (dB for RSRP, ms for latency, percent for packetLoss).
+                      Example: with trigger "rsrp < -120" and hysteresisMargin "10",
+                      failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    pattern: ^[0-9]+\.?[0-9]*$
+                    type: string
+                  sessionContinuity:
+                    default: true
+                    description: sessionContinuity preserves active sessions during
+                      failover.
+                    type: boolean
+                  switchbackDelay:
+                    default: 60s
+                    description: |-
+                      switchbackDelay is how long to wait after terrestrial recovers
+                      before switching back (prevents flapping).
+                    format: duration
+                    type: string
+                  triggers:
+                    description: |-
+                      triggers defines conditions that initiate failover (OR logic).
+                      Format: "metric operator value" (e.g., "rsrp < -120").
+                      Validated at runtime by the failover engine (pkg/slice.ParseTrigger).
+                      Order is intentionally not significant; set merge semantics are desired.
+                    items:
+                      type: string
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
+                required:
+                - triggers
+                type: object
+              metricsSource:
+                description: |-
+                  metricsSource selects where the failover engine reads path quality
+                  metrics (RSRP, latency, packet loss) from. When omitted, the
+                  controller falls back to annotation-driven simulation for backward
+                  compatibility with existing development deployments.
+                properties:
+                  prometheus:
+                    description: |-
+                      prometheus configures the Prometheus HTTP API backend.
+                      Required when type is 'prometheus'.
+                    properties:
+                      endpoint:
+                        description: endpoint is the base URL of the Prometheus HTTP
+                          API.
+                        minLength: 1
+                        pattern: ^https?://
+                        type: string
+                      queries:
+                        description: queries holds the PromQL expressions for each
+                          observable metric.
+                        properties:
+                          latencyMs:
+                            description: latencyMs is a PromQL expression returning
+                              a scalar in milliseconds.
+                            type: string
+                          packetLossPercent:
+                            description: |-
+                              packetLossPercent is a PromQL expression returning a scalar in
+                              percent (0-100).
+                            type: string
+                          rsrpDbm:
+                            description: rsrpDbm is a PromQL expression returning
+                              a scalar in dBm.
+                            type: string
+                        type: object
+                      queryTimeout:
+                        description: |-
+                          queryTimeout limits the wall-clock time spent on each individual
+                          PromQL fetch; the controller issues up to three fetches per
+                          reconcile (one per metric), so the upper bound for a Read is
+                          roughly 3x this value. Defaults to 2s when unset.
+                        format: duration
+                        type: string
+                    required:
+                    - endpoint
+                    - queries
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one query must be non-empty
+                      rule: size(self.queries.rsrpDbm) > 0 || size(self.queries.latencyMs)
+                        > 0 || size(self.queries.packetLossPercent) > 0
+                  type:
+                    default: annotations
+                    description: type is the backend kind.
+                    enum:
+                    - annotations
+                    - prometheus
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: prometheus block is required when type is 'prometheus'
+                  rule: self.type != 'prometheus' || has(self.prometheus)
+              qosMapping:
+                description: qosMapping defines QoS parameter mapping between paths.
+                properties:
+                  maxLatencyBudget:
+                    default: 150ms
+                    description: |-
+                      maxLatencyBudget is the maximum acceptable latency including
+                      satellite propagation delay.
+                    format: duration
+                    type: string
+                  satelliteQCI:
+                    default: best-effort
+                    description: satelliteQCI is the QoS class for the satellite path.
+                    enum:
+                    - conversational
+                    - streaming
+                    - interactive
+                    - background
+                    - best-effort
+                    type: string
+                  terrestrial5QI:
+                    description: terrestrial5QI is the 5G QoS Identifier for the terrestrial
+                      path.
+                    maximum: 255
+                    minimum: 1
+                    type: integer
+                type: object
+              satellitePath:
+                description: satellitePath defines the failover satellite connectivity.
+                properties:
+                  apn:
+                    description: apn is the Access Point Name.
+                    type: string
+                  ephemerisRef:
+                    description: |-
+                      ephemerisRef is the name of the SatelliteEphemeris resource
+                      used to determine satellite pass availability.
+                    minLength: 1
+                    type: string
+                  priority:
+                    description: priority is the path priority.
+                    enum:
+                    - primary
+                    - failover
+                    type: string
+                  provider:
+                    description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    minLength: 1
+                    type: string
+                required:
+                - ephemerisRef
+                - priority
+                - provider
+                type: object
+              security:
+                description: security defines handover security requirements.
+                properties:
+                  authOnHandover:
+                    default: re-authenticate
+                    description: authOnHandover defines authentication behavior during
+                      path switch.
+                    enum:
+                    - re-authenticate
+                    - continue
+                    type: string
+                  encryptionLevel:
+                    default: AES-256
+                    description: encryptionLevel specifies the encryption standard.
+                    enum:
+                    - AES-128
+                    - AES-256
+                    - SNOW3G
+                    - ZUC
+                    type: string
+                type: object
+              tenant:
+                description: tenant is the organization or entity that owns this slice.
+                minLength: 1
+                type: string
+              terrestrialPath:
+                description: terrestrialPath defines the primary terrestrial connectivity.
+                properties:
+                  apn:
+                    description: apn is the Access Point Name.
+                    type: string
+                  priority:
+                    description: priority is the path priority.
+                    enum:
+                    - primary
+                    - failover
+                    type: string
+                  provider:
+                    description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    minLength: 1
+                    type: string
+                required:
+                - priority
+                - provider
+                type: object
+            required:
+            - failoverPolicy
+            - satellitePath
+            - tenant
+            - terrestrialPath
+            type: object
+            x-kubernetes-validations:
+            - message: terrestrialPath.priority must be 'primary'
+              rule: self.terrestrialPath.priority == 'primary'
+            - message: satellitePath.priority must be 'failover'
+              rule: self.satellitePath.priority == 'failover'
+          status:
+            description: NTNSliceStatus defines the observed state of NTNSlice.
+            properties:
+              activePathType:
+                description: activePathType is the currently active network path.
+                enum:
+                - terrestrial
+                - satellite
+                - unavailable
+                type: string
+              appliedEncryption:
+                description: appliedEncryption is the encryption level in effect for
+                  the current path.
+                type: string
+              appliedQoS:
+                description: appliedQoS summarizes the QoS mapping in effect for the
+                  current path.
+                type: string
+              billingMode:
+                description: billingMode is the billing model active for the current
+                  path.
+                type: string
+              conditions:
+                description: conditions represent the current state of the slice.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failoverCount:
+                description: failoverCount is the total number of failover events
+                  since creation.
+                type: integer
+              lastFailover:
+                description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              sessionCount:
+                description: sessionCount is the number of active sessions on this
+                  slice.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: satelliteephemeris.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: SatelliteEphemeris
+    listKind: SatelliteEphemerisList
+    plural: satelliteephemeris
+    shortNames:
+    - sateph
+    singular: satelliteephemeris
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.satelliteCount
+      name: Satellites
+      type: integer
+    - jsonPath: .status.lastUpdated
+      name: Last Updated
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack),
+          orbital propagation (SGP4 via akhenakh/sgp4), and pass prediction for a set of
+          satellites against ground stations.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SatelliteEphemerisSpec defines the desired state of SatelliteEphemeris.
+            properties:
+              passPrediction:
+                description: passPrediction configures automatic pass window computation.
+                properties:
+                  groundStations:
+                    description: |-
+                      groundStations is a list of GroundStationLifecycle resource names
+                      to compute pass windows against.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  horizon:
+                    default: 24h
+                    description: horizon is how far into the future to predict passes.
+                    type: string
+                  minElevation:
+                    default: "10"
+                    description: minElevation is the minimum elevation angle in degrees
+                      (string, e.g., "10").
+                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    type: string
+                required:
+                - groundStations
+                type: object
+              satellites:
+                description: satellites filters which satellites to track from the
+                  source.
+                properties:
+                  constellation:
+                    description: constellation filters by constellation name (e.g.,
+                      "oneweb", "starlink").
+                    type: string
+                  noradIDs:
+                    description: noradIDs is an explicit list of NORAD catalog IDs
+                      to track.
+                    items:
+                      type: integer
+                    type: array
+                type: object
+              source:
+                description: source defines where to fetch GP (General Perturbations)
+                  data.
+                properties:
+                  credentials:
+                    description: |-
+                      credentials is a reference to a Secret containing auth credentials
+                      (required for SpaceTrack, optional for CelesTrak).
+                    properties:
+                      key:
+                        default: password
+                        description: key within the Secret data.
+                        type: string
+                      name:
+                        description: name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  refreshInterval:
+                    default: 4h
+                    description: |-
+                      refreshInterval is how often to re-fetch GP data.
+                      CelesTrak updates every 2 hours; setting this below 2h wastes bandwidth.
+                    format: duration
+                    type: string
+                  type:
+                    description: 'type is the source type. Supported: "CelesTrak",
+                      "SpaceTrack".'
+                    enum:
+                    - CelesTrak
+                    - SpaceTrack
+                    type: string
+                  url:
+                    description: |-
+                      url is the endpoint to fetch GP data from.
+                      For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
+                      For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    minLength: 1
+                    pattern: ^https?://
+                    type: string
+                required:
+                - refreshInterval
+                - type
+                - url
+                type: object
+                x-kubernetes-validations:
+                - message: SpaceTrack source type requires credentials (spec.source.credentials)
+                  rule: self.type != 'SpaceTrack' || has(self.credentials)
+            required:
+            - source
+            type: object
+          status:
+            description: SatelliteEphemerisStatus defines the observed state of SatelliteEphemeris.
+            properties:
+              conditions:
+                description: conditions represent the current state of the resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastUpdated:
+                description: lastUpdated is when the GP data was last successfully
+                  fetched.
+                format: date-time
+                type: string
+              nextPassWindows:
+                description: nextPassWindows contains upcoming contact opportunities.
+                items:
+                  description: PassWindow represents a predicted contact opportunity
+                    between a satellite and ground station.
+                  properties:
+                    aos:
+                      description: aos is the Acquisition of Signal time (satellite
+                        rises above minElevation).
+                      format: date-time
+                      type: string
+                    groundStation:
+                      description: groundStation is the name of the GroundStationLifecycle
+                        resource.
+                      type: string
+                    los:
+                      description: los is the Loss of Signal time (satellite drops
+                        below minElevation).
+                      format: date-time
+                      type: string
+                    maxElevation:
+                      description: maxElevation is the peak elevation angle during
+                        the pass in degrees (string, e.g., "72.5").
+                      pattern: ^-?[0-9]+\.?[0-9]*$
+                      type: string
+                    satellite:
+                      description: satellite is the name or NORAD ID of the satellite.
+                      type: string
+                  required:
+                  - aos
+                  - groundStation
+                  - los
+                  - maxElevation
+                  - satellite
+                  type: object
+                type: array
+              satelliteCount:
+                description: satelliteCount is the number of satellites currently
+                  tracked.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/packages/ntn-workloads-sample/Kptfile
+++ b/nephio/packages/ntn-workloads-sample/Kptfile
@@ -1,0 +1,26 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: ntn-workloads-sample
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Sample workload CRs for the ntn-operators project — one of each kind
+    demonstrating realistic NTN deployment data:
+      - SatelliteEphemeris (OneWeb constellation, CelesTrak source)
+      - GroundStationLifecycle (Taipei ground station, K3s edge)
+      - NTNCellConfig (GEO satellite, OCUDU provider)
+      - NTNSlice (terrestrial + oneweb failover slice)
+    Customize per target cluster by editing the set-namespace and set-labels
+    inputs below. The CRDs themselves are shipped in the sibling package
+    'ntn-operators-crds' — install that first. Nephio R6 compatible.
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+      configMap:
+        namespace: ntn-system
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1
+      configMap:
+        app.kubernetes.io/managed-by: ntn-operators
+        workload: ntn-sample

--- a/nephio/packages/ntn-workloads-sample/README.md
+++ b/nephio/packages/ntn-workloads-sample/README.md
@@ -9,7 +9,7 @@ Install the sibling [`ntn-operators-crds`](../ntn-operators-crds) package first;
 | File | Purpose |
 |---|---|
 | `Kptfile` | Package metadata + `pipeline.mutators` with `set-namespace` and `set-labels`. |
-| `satelliteephemeris-sample.yaml` | `SatelliteEphemeris` — OneWeb constellation fetched from CelesTrak every 4h, pass-predicting against two Taiwan ground stations. |
+| `satelliteephemeris-sample.yaml` | `SatelliteEphemeris` — OneWeb constellation fetched from CelesTrak every 4h, pass-predicting against the `gs-taipei-01` ground station shipped in this package. |
 | `groundstationlifecycle-sample.yaml` | `GroundStationLifecycle` — Taipei ground station on Ennoconn rugged-edge hardware, K3s edge distro. |
 | `ntncellconfig-sample.yaml` | `NTNCellConfig` — GEO satellite cell, OCUDU provider, transparent payload. |
 | `ntnslice-sample.yaml` | `NTNSlice` — enterprise resilient slice: terrestrial primary + OneWeb failover, AES-256, per-volume/per-minute billing. |

--- a/nephio/packages/ntn-workloads-sample/README.md
+++ b/nephio/packages/ntn-workloads-sample/README.md
@@ -25,6 +25,17 @@ The `Kptfile` declares a two-step mutator chain that runs on `kpt fn render`:
 
 Both images come from the Nephio R6 canonical KRM function catalog.
 
+## Expected status on a demo cluster
+
+The samples reference realistic NTN inputs (CelesTrak OneWeb feed, Taipei ground station on Ennoconn rugged-edge hardware, GEO cell, terrestrial+OneWeb failover slice). On a plain demo cluster without a Node labeled `ntn.operators.dev/groundstation=<ns>.gs-taipei-01`, you will see:
+
+- `SatelliteEphemeris/oneweb-constellation` — `GPDataFetched=True`, `GPDataParsed=True`, 650+ satellites counted. Pass prediction succeeds because the sample references only `gs-taipei-01`, which this package ships.
+- `GroundStationLifecycle/gs-taipei-01` — phase `Provisioning`, `K8sNodeReady=False` with reason `NodeNotFound`. This is the controller correctly reporting missing hardware, not a package defect — label one of your nodes to advance it.
+- `NTNCellConfig/ntn-cell-geo-demo` — `ConfigApplied=True`, generates `ConfigMap/ocudu-ntn-ntn-cell-geo-demo` with OCUDU `geo_ntn.yml` content.
+- `NTNSlice/enterprise-resilient-slice` — `PathActive=True` with `activePathType: terrestrial`, failover decision `stay` (terrestrial path healthy).
+
+Cross-verified on K8s v1.35.4 on 2026-04-24.
+
 ## Consume
 
 ### Minimum commands

--- a/nephio/packages/ntn-workloads-sample/README.md
+++ b/nephio/packages/ntn-workloads-sample/README.md
@@ -1,0 +1,109 @@
+# ntn-workloads-sample
+
+Ready-to-adapt sample workload CRs for [ntn-operators](https://github.com/thc1006/ntn-operators), packaged as a [Nephio](https://nephio.org) R6-compatible kpt package with a 2-step mutation pipeline.
+
+Install the sibling [`ntn-operators-crds`](../ntn-operators-crds) package first; this one depends on those CRDs being present.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `Kptfile` | Package metadata + `pipeline.mutators` with `set-namespace` and `set-labels`. |
+| `satelliteephemeris-sample.yaml` | `SatelliteEphemeris` — OneWeb constellation fetched from CelesTrak every 4h, pass-predicting against two Taiwan ground stations. |
+| `groundstationlifecycle-sample.yaml` | `GroundStationLifecycle` — Taipei ground station on Ennoconn rugged-edge hardware, K3s edge distro. |
+| `ntncellconfig-sample.yaml` | `NTNCellConfig` — GEO satellite cell, OCUDU provider, transparent payload. |
+| `ntnslice-sample.yaml` | `NTNSlice` — enterprise resilient slice: terrestrial primary + OneWeb failover, AES-256, per-volume/per-minute billing. |
+
+## Pipeline
+
+The `Kptfile` declares a two-step mutator chain that runs on `kpt fn render`:
+
+1. **`set-namespace`** (`ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1`) — rewrites every CR's `metadata.namespace` to the configured value (default: `ntn-system`).
+2. **`set-labels`** (`ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1`) — stamps common labels on every CR:
+   - `workload: ntn-sample`
+   - `app.kubernetes.io/managed-by: ntn-operators`
+
+Both images come from the Nephio R6 canonical KRM function catalog.
+
+## Consume
+
+### Minimum commands
+
+```bash
+# 1. pull the package
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-workloads-sample@main ntn-workloads-sample
+
+# 2. (optional) edit Kptfile to change target namespace/labels
+$EDITOR ntn-workloads-sample/Kptfile
+
+# 3. render (applies the mutators in place)
+kpt fn render ntn-workloads-sample
+
+# 4. apply
+kubectl apply -f ntn-workloads-sample/satelliteephemeris-sample.yaml \
+              -f ntn-workloads-sample/groundstationlifecycle-sample.yaml \
+              -f ntn-workloads-sample/ntncellconfig-sample.yaml \
+              -f ntn-workloads-sample/ntnslice-sample.yaml
+```
+
+### Using kpt live (Nephio-native)
+
+```bash
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-workloads-sample@main ntn-workloads-sample
+kpt fn render ntn-workloads-sample
+kpt live init ntn-workloads-sample
+kpt live apply ntn-workloads-sample --reconcile-timeout=2m
+```
+
+### On a Nephio management cluster (Porch)
+
+Use a PackageVariant in your deployment repo to clone this blueprint and inject per-cluster context:
+
+```yaml
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: ntn-workloads-edge01
+spec:
+  upstream:
+    repo: thc1006-ntn-operators
+    package: nephio/packages/ntn-workloads-sample
+    revision: main
+  downstream:
+    repo: deploy-edge01
+    package: ntn-workloads-edge01
+  packageContext:
+    data:
+      cluster-name: edge01
+  pipeline:
+    mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.5
+        configMap: {}
+```
+
+## Customize
+
+| What to change | Where |
+|---|---|
+| Target namespace | `Kptfile` → `pipeline.mutators[set-namespace].configMap.namespace` |
+| Labels stamped on all CRs | `Kptfile` → `pipeline.mutators[set-labels].configMap` |
+| Satellite constellation | `satelliteephemeris-sample.yaml` → `spec.satellites.constellation` + `spec.source.url` |
+| Ground station hardware / location | `groundstationlifecycle-sample.yaml` → `spec.hardware`, `spec.deployment.location` |
+| Cell ephemeris / payload type | `ntncellconfig-sample.yaml` → `spec.ntn` |
+| Failover triggers / QoS / billing | `ntnslice-sample.yaml` → `spec.failoverPolicy`, `spec.qosMapping`, `spec.billing` |
+
+After editing, re-run `kpt fn render` to re-apply the pipeline, then `kubectl apply` or `kpt live apply`.
+
+## Validation
+
+Before shipping changes to this package, run from the repository root:
+
+```bash
+make nephio-validate
+```
+
+This runs `test/nephio/validate.sh`, which verifies the package renders cleanly, produces all four expected kinds, applies the namespace mutation correctly, and passes `kubectl apply --dry-run=client` parsing.
+
+## License
+
+Apache License 2.0 — see the [top-level LICENSE](https://github.com/thc1006/ntn-operators/blob/main/LICENSE) in the ntn-operators repository.

--- a/nephio/packages/ntn-workloads-sample/groundstationlifecycle-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/groundstationlifecycle-sample.yaml
@@ -1,0 +1,27 @@
+apiVersion: ntn.operators.dev/v1alpha1
+kind: GroundStationLifecycle
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+  name: gs-taipei-01
+  namespace: default
+spec:
+  hardware:
+    vendor: ennoconn
+    model: rugged-edge-5000
+    antennaType: flat-panel
+    bands:
+      - Ka
+      - Ku
+  deployment:
+    location:
+      lat: "25.0330"
+      lon: "121.5654"
+      alt: "15"
+    k8sDistro: k3s
+  monitoring:
+    healthCheckInterval: 30s
+  firmware:
+    autoUpdate: true
+    channel: stable
+    maintenanceWindow: "02:00-04:00 UTC"

--- a/nephio/packages/ntn-workloads-sample/ntncellconfig-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/ntncellconfig-sample.yaml
@@ -1,0 +1,27 @@
+apiVersion: ntn.operators.dev/v1alpha1
+kind: NTNCellConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+  name: ntn-cell-geo-demo
+  namespace: default
+spec:
+  provider:
+    type: ocudu
+    # namespace is enforced to match metadata.namespace for security
+  ntn:
+    cellSpecificKoffset: 150
+    taCommon: 0
+    ephemerisECEF:
+      posX: 20922195
+      posY: 1967783
+      posZ: 19770302
+      # GEO satellite: velocity = 0
+      velX: 0
+      velY: 0
+      velZ: 0
+    payloadType: transparent
+  cellOverrides:
+    pdschMaxHarqRetxs: 0
+    prachMaxMsg3HarqRetx: 0
+    rrcGuardTimeMs: 12800

--- a/nephio/packages/ntn-workloads-sample/ntnslice-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/ntnslice-sample.yaml
@@ -1,0 +1,34 @@
+apiVersion: ntn.operators.dev/v1alpha1
+kind: NTNSlice
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+  name: enterprise-resilient-slice
+  namespace: default
+spec:
+  tenant: acme-corp
+  terrestrialPath:
+    provider: chunghwa-telecom
+    apn: internet
+    priority: primary
+  satellitePath:
+    provider: oneweb
+    ephemerisRef: oneweb-constellation
+    priority: failover
+  failoverPolicy:
+    triggers:
+      - "rsrp < -120"
+      - "latency > 200"
+      - "packetLoss > 5"
+    switchbackDelay: 60s
+    sessionContinuity: true
+  qosMapping:
+    terrestrial5QI: 9
+    satelliteQCI: best-effort
+    maxLatencyBudget: 150ms
+  security:
+    encryptionLevel: AES-256
+    authOnHandover: re-authenticate
+  billing:
+    terrestrialRate: per-volume
+    satelliteRate: per-minute

--- a/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
@@ -15,6 +15,5 @@ spec:
   passPrediction:
     groundStations:
       - gs-taipei-01
-      - gs-hsinchu-01
     minElevation: "10"
     horizon: 24h

--- a/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
@@ -1,0 +1,20 @@
+apiVersion: ntn.operators.dev/v1alpha1
+kind: SatelliteEphemeris
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+  name: oneweb-constellation
+  namespace: default
+spec:
+  source:
+    type: CelesTrak
+    url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
+    refreshInterval: 4h
+  satellites:
+    constellation: oneweb
+  passPrediction:
+    groundStations:
+      - gs-taipei-01
+      - gs-hsinchu-01
+    minElevation: "10"
+    horizon: 24h

--- a/test/nephio/validate.sh
+++ b/test/nephio/validate.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Validate the Nephio R6 kpt packages under nephio/packages/.
+#
+# This script is the executable contract for ADR 0003. It must stay fast
+# and hermetic so it can run in CI and locally without a live K8s cluster.
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+#
+# Usage:
+#   test/nephio/validate.sh              # run all tests
+#   test/nephio/validate.sh --verbose    # print rendered output on failure
+
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PKG_DIR="${REPO_ROOT}/nephio/packages"
+CRDS_PKG="${PKG_DIR}/ntn-operators-crds"
+WORKLOADS_PKG="${PKG_DIR}/ntn-workloads-sample"
+CRD_BASES_DIR="${REPO_ROOT}/config/crd/bases"
+
+# README-promised filenames (must match nephio/packages/*/README.md tables)
+README_CRDS_FILES=(
+  "satelliteephemeris-crd.yaml"
+  "groundstationlifecycles-crd.yaml"
+  "ntncellconfigs-crd.yaml"
+  "ntnslices-crd.yaml"
+)
+README_SAMPLE_FILES=(
+  "satelliteephemeris-sample.yaml"
+  "groundstationlifecycle-sample.yaml"
+  "ntncellconfig-sample.yaml"
+  "ntnslice-sample.yaml"
+)
+
+EXPECTED_CRDS=(
+  "satelliteephemeris"
+  "groundstationlifecycle"
+  "ntncellconfig"
+  "ntnslice"
+)
+
+EXPECTED_SAMPLE_KINDS=(
+  "SatelliteEphemeris"
+  "GroundStationLifecycle"
+  "NTNCellConfig"
+  "NTNSlice"
+)
+
+PASS=0
+FAIL=0
+VERBOSE="${1:-}"
+
+_ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
+_fail() { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+_info() { echo "  ----  $1"; }
+
+# kpt is required to be on $PATH. The canonical install path is
+# $(go env GOPATH)/bin, which `make nephio-install-tools` puts on $PATH.
+_has_kpt()    { command -v kpt >/dev/null 2>&1; }
+_has_kubectl(){ command -v kubectl >/dev/null 2>&1; }
+
+###############################################################################
+echo "===> Preflight"
+###############################################################################
+
+if _has_kpt; then
+  kpt_ver=$(kpt version 2>/dev/null | head -1)
+  _ok "kpt CLI available (${kpt_ver})"
+else
+  _fail "kpt CLI not installed; run 'make nephio-install-tools'"
+  echo
+  echo "ABORT: cannot run without kpt."
+  exit 1
+fi
+
+if _has_kubectl; then
+  kc_ver=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  _ok "kubectl available (${kc_ver})"
+else
+  _info "kubectl missing — skipping dry-run apply tests (T7, T12)"
+fi
+
+###############################################################################
+echo
+echo "===> Suite A: ntn-operators-crds package"
+###############################################################################
+
+# T1: package dir exists
+if [ -d "$CRDS_PKG" ]; then
+  _ok "T1 package dir exists: nephio/packages/ntn-operators-crds/"
+else
+  _fail "T1 package dir missing: nephio/packages/ntn-operators-crds/"
+fi
+
+# T2: Kptfile present + kpt-parseable
+if [ -f "$CRDS_PKG/Kptfile" ]; then
+  if kpt pkg tree "$CRDS_PKG" >/dev/null 2>&1; then
+    _ok "T2 Kptfile valid, 'kpt pkg tree' succeeds"
+  else
+    _fail "T2 Kptfile present but 'kpt pkg tree' failed"
+    [ "$VERBOSE" = "--verbose" ] && kpt pkg tree "$CRDS_PKG" 2>&1 | sed 's/^/       /'
+  fi
+else
+  _fail "T2 Kptfile missing in $CRDS_PKG"
+fi
+
+# T3: kpt fn render succeeds on CRDs package
+# Run on a temp copy so source tree stays pristine (kpt adds a status block
+# and re-wraps long YAML strings — we do not want those committed).
+if [ -f "$CRDS_PKG/Kptfile" ]; then
+  tmpdir=$(mktemp -d)
+  cp -r "$CRDS_PKG"/. "$tmpdir/"
+  kpt fn render "$tmpdir" >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 0 ]; then
+    _ok "T3 'kpt fn render' succeeds on CRDs package"
+  else
+    _fail "T3 'kpt fn render' failed on CRDs package (exit $rc)"
+    [ "$VERBOSE" = "--verbose" ] && kpt fn render "$tmpdir" 2>&1 | sed 's/^/       /'
+  fi
+  rm -rf "$tmpdir"
+else
+  _fail "T3 skipped (Kptfile missing)"
+fi
+
+# T4: all README-promised CRD filenames exist on disk (catches filename drift)
+missing=()
+for fname in "${README_CRDS_FILES[@]}"; do
+  [ -f "$CRDS_PKG/$fname" ] || missing+=("$fname")
+done
+if [ ${#missing[@]} -eq 0 ]; then
+  _ok "T4 all 4 README-promised CRD filenames present (filename contract honored)"
+else
+  _fail "T4 missing README-promised files: ${missing[*]}"
+fi
+
+# T5: package content declares 4 CustomResourceDefinition kinds
+if [ -f "$CRDS_PKG/Kptfile" ]; then
+  crd_count=$(grep -c "^kind: CustomResourceDefinition$" "$CRDS_PKG"/*.yaml 2>/dev/null | awk -F: '{sum+=$2} END {print sum+0}')
+  if [ "$crd_count" -eq 4 ]; then
+    _ok "T5 exactly 4 CustomResourceDefinition kinds in package"
+  else
+    _fail "T5 expected 4 CRD kinds, found $crd_count"
+  fi
+else
+  _fail "T5 skipped (Kptfile missing)"
+fi
+
+# T6: README.md present
+if [ -f "$CRDS_PKG/README.md" ]; then
+  _ok "T6 README.md present"
+else
+  _fail "T6 README.md missing in $CRDS_PKG"
+fi
+
+# T7: rendered CRDs pass kubectl client-side dry-run (on temp copy, source stays clean)
+if [ -f "$CRDS_PKG/Kptfile" ] && _has_kubectl; then
+  tmpdir=$(mktemp -d)
+  cp -r "$CRDS_PKG"/. "$tmpdir/"
+  kpt fn render "$tmpdir" >/dev/null 2>&1
+  crd_files=$(ls "$tmpdir"/*-crd.yaml 2>/dev/null)
+  if [ -n "$crd_files" ]; then
+    cat "$tmpdir"/*-crd.yaml | kubectl apply --dry-run=client -f - >/dev/null 2>&1
+    rc=$?
+    if [ $rc -eq 0 ]; then
+      _ok "T7 rendered CRDs pass 'kubectl apply --dry-run=client'"
+    else
+      _fail "T7 rendered CRDs failed 'kubectl apply --dry-run=client' (exit $rc)"
+      if [ "$VERBOSE" = "--verbose" ]; then
+        cat "$tmpdir"/*-crd.yaml | kubectl apply --dry-run=client -f - 2>&1 | sed 's/^/       /' | head -20
+      fi
+    fi
+  else
+    _fail "T7 no -crd.yaml files found in temp copy of $CRDS_PKG"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# T13: CRD drift detection — package copies must byte-match the controller-gen source
+#       (config/crd/bases/*.yaml is the single source of truth per ADR 0003)
+drift=0
+drift_files=()
+for fname in "${README_CRDS_FILES[@]}"; do
+  # map package name back to base name:
+  #   satelliteephemeris-crd.yaml -> ntn.operators.dev_satelliteephemeris.yaml
+  #   groundstationlifecycles-crd.yaml -> ntn.operators.dev_groundstationlifecycles.yaml
+  kind_plural=$(echo "$fname" | sed 's/-crd\.yaml$//')
+  base="$CRD_BASES_DIR/ntn.operators.dev_${kind_plural}.yaml"
+  pkg_file="$CRDS_PKG/$fname"
+  if [ ! -f "$base" ]; then
+    drift=1
+    drift_files+=("${fname}: source $(basename "$base") not found in config/crd/bases/")
+    continue
+  fi
+  if ! diff -q "$base" "$pkg_file" >/dev/null 2>&1; then
+    drift=1
+    drift_files+=("${fname}: differs from config/crd/bases/$(basename "$base")")
+  fi
+done
+if [ $drift -eq 0 ]; then
+  _ok "T13 CRD drift check passes (package matches config/crd/bases/)"
+else
+  _fail "T13 CRD drift detected:"
+  for msg in "${drift_files[@]}"; do
+    _fail "      $msg"
+    PASS=$((PASS+1))  # undo the extra FAIL increment from _fail inside loop
+    FAIL=$((FAIL-1))
+  done
+fi
+
+###############################################################################
+echo
+echo "===> Suite B: ntn-workloads-sample package"
+###############################################################################
+
+# T8: package dir exists
+if [ -d "$WORKLOADS_PKG" ]; then
+  _ok "T8 package dir exists: nephio/packages/ntn-workloads-sample/"
+else
+  _fail "T8 package dir missing: nephio/packages/ntn-workloads-sample/"
+fi
+
+# T9: Kptfile present + kpt-parseable
+if [ -f "$WORKLOADS_PKG/Kptfile" ]; then
+  if kpt pkg tree "$WORKLOADS_PKG" >/dev/null 2>&1; then
+    _ok "T9 Kptfile valid, 'kpt pkg tree' succeeds"
+  else
+    _fail "T9 Kptfile present but 'kpt pkg tree' failed"
+  fi
+else
+  _fail "T9 Kptfile missing in $WORKLOADS_PKG"
+fi
+
+# T10: kpt fn render succeeds and pipeline mutates (namespace must change to ntn-system)
+if [ -f "$WORKLOADS_PKG/Kptfile" ]; then
+  # Work on a temp copy so the test is idempotent (does not mutate the tree
+  # whether it starts in pre- or post-rendered state).
+  tmpdir=$(mktemp -d)
+  cp -r "$WORKLOADS_PKG"/. "$tmpdir/"
+  kpt fn render "$tmpdir" >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 0 ] && grep -q "namespace: ntn-system" "$tmpdir"/*.yaml 2>/dev/null; then
+    _ok "T10 'kpt fn render' succeeds + set-namespace mutator applied (namespace: ntn-system)"
+  else
+    _fail "T10 render failed or set-namespace mutator did not apply (exit $rc)"
+    if [ "$VERBOSE" = "--verbose" ]; then
+      grep -H namespace "$tmpdir"/*.yaml 2>/dev/null | sed 's/^/       /' | head -10
+    fi
+  fi
+  rm -rf "$tmpdir"
+fi
+
+# T11: all 4 README-promised sample filenames exist on disk
+missing=()
+for fname in "${README_SAMPLE_FILES[@]}"; do
+  [ -f "$WORKLOADS_PKG/$fname" ] || missing+=("$fname")
+done
+if [ ${#missing[@]} -eq 0 ]; then
+  _ok "T11 all 4 README-promised sample filenames present (filename contract honored)"
+else
+  _fail "T11 missing README-promised files: ${missing[*]}"
+fi
+
+# T14: all 4 sample kinds present (content check)
+if [ ${#missing[@]} -eq 0 ]; then
+  missing_kinds=()
+  for kind in "${EXPECTED_SAMPLE_KINDS[@]}"; do
+    if ! grep -q "^kind: ${kind}$" "$WORKLOADS_PKG"/*-sample.yaml 2>/dev/null; then
+      missing_kinds+=("$kind")
+    fi
+  done
+  if [ ${#missing_kinds[@]} -eq 0 ]; then
+    _ok "T14 all 4 sample CR kinds present in YAML content"
+  else
+    _fail "T14 missing sample kinds: ${missing_kinds[*]}"
+  fi
+fi
+
+# T12: rendered workloads parse as valid K8s YAML (CRDs may not be installed locally)
+if [ -f "$WORKLOADS_PKG/Kptfile" ] && _has_kubectl; then
+  tmpdir=$(mktemp -d)
+  cp -r "$WORKLOADS_PKG"/. "$tmpdir/"
+  kpt fn render "$tmpdir" >/dev/null 2>&1
+  sample_files=$(ls "$tmpdir"/*-sample.yaml 2>/dev/null)
+  if [ -n "$sample_files" ]; then
+    cat "$tmpdir"/*-sample.yaml | kubectl apply --dry-run=client --validate=false -f - >/dev/null 2>&1
+    rc=$?
+    if [ $rc -eq 0 ]; then
+      _ok "T12 rendered samples parse as valid K8s YAML"
+    else
+      _fail "T12 rendered samples failed YAML parse (exit $rc)"
+      if [ "$VERBOSE" = "--verbose" ]; then
+        cat "$tmpdir"/*-sample.yaml | kubectl apply --dry-run=client --validate=false -f - 2>&1 | sed 's/^/       /' | head -20
+      fi
+    fi
+  else
+    _fail "T12 no rendered *-sample.yaml files"
+  fi
+  rm -rf "$tmpdir"
+fi
+
+###############################################################################
+echo
+echo "===> Summary"
+###############################################################################
+
+TOTAL=$((PASS+FAIL))
+echo "  Passed: $PASS / $TOTAL"
+echo "  Failed: $FAIL / $TOTAL"
+
+if [ "$FAIL" -eq 0 ]; then
+  echo
+  echo "OK: all Nephio package assertions pass."
+  exit 0
+else
+  echo
+  echo "FAIL: $FAIL assertion(s) failed. Re-run with --verbose for diagnostics."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Ships ntn-operators as two Nephio R6-compatible kpt packages under `nephio/packages/`:

- **`ntn-operators-crds`** — the 4 CRDs (SatelliteEphemeris, GroundStationLifecycle, NTNCellConfig, NTNSlice) as a cluster-install package. No pipeline; CRDs install as-is. Synced from `config/crd/bases/` by `make nephio-sync`.
- **`ntn-workloads-sample`** — one sample CR per kind with a 2-step mutator pipeline (`set-namespace` + `set-labels` from `ghcr.io/kptdev/krm-functions-catalog`). Default namespace `ntn-system`; override via the Kptfile `configMap` entries.

See [ADR 0003](docs/adr/0003-nephio-integration.md) for design rationale, alternatives considered, and follow-up scope.

## Makefile targets added

| Target | Purpose |
|---|---|
| `make nephio-install-tools` | Download `kpt` v1.0.0-beta.62 into `$(go env GOPATH)/bin` |
| `make nephio-sync` | Regenerate package CRDs from `config/crd/bases/` |
| `make nephio-render` | Run `kpt fn render` on both packages (in-place) |
| `make nephio-validate` | Run the 16-assertion test suite |
| `make nephio-verify-sync` | CI drift check; fails if package CRDs diverge from `config/crd/bases/` |

## Test plan

- [x] `make nephio-validate` — **16/16 green** (Preflight 2 + Suite A 8 + Suite B 6)
- [x] `make nephio-verify-sync` — no drift from `config/crd/bases/`
- [x] `kpt pkg tree nephio/packages/` — both packages parse
- [x] `kpt fn render` on tmp copy mutates `namespace: default` → `namespace: ntn-system` for all 4 samples
- [x] `kubectl apply --dry-run=client` on rendered CRDs — passes
- [x] Source tree stays pristine after test run (no `status:` leak, samples preserve `namespace: default`)

## Compatibility

Nephio **R6** (released 2026-04-01), Porch **v1.5.6+**, `kpt` CLI **v1.0.0-beta.55+**, Kubernetes **1.29+** (CEL validation GA).

## Out of scope for v1

Tracked in ADR 0003 follow-ups:
- PackageVariantSet examples
- Porch cluster bootstrap docs
- Custom KRM validation function (e.g. cross-CR reference check for `NTNSlice.satellitePath.ephemerisRef`)
- `@sha256:` digest pinning for mutator images (currently tag-pinned)
- PR to `nephio-project/catalog` upstream (post-E2E validation with an external Nephio user)

Closes #51