### PR TITLE
docs(nephio): wire Nephio install into README + fix misleading helm.sh hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ graph TB
 - Kubernetes 1.29+ (for CEL validation)
 - kubectl
 - Helm v3.16+ (optional, for Helm-based install)
+- kpt v1.0.0-beta.55+ (optional, for Nephio kpt package install)
 
 ### Option A: Helm Install
 
@@ -100,14 +101,14 @@ make run        # Run controller locally (connects to current kubeconfig)
 
 ### Option D: Install via Nephio (kpt package)
 
-ntn-operators ships as a [Nephio](https://nephio.org) R6-compatible kpt package set. The CRDs install once per cluster; sample workloads compose per namespace through `kpt fn render`.
+ntn-operators ships as a [Nephio](https://nephio.org) R6-compatible kpt package set, with CRDs installed once per cluster as-is (no mutation pipeline).
 
 ```bash
 kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-operators-crds@main ntn-operators-crds
 kubectl apply -f ntn-operators-crds/
 ```
 
-See [`nephio/README.md`](nephio/README.md) for the full quick-start (workloads sample, Porch `PackageVariant` example, contributor `make nephio-*` targets) and [ADR 0003](docs/adr/0003-nephio-integration.md) for the design rationale.
+See [`nephio/README.md`](nephio/README.md) for the full quick-start (sibling `ntn-workloads-sample` package, Porch `PackageVariant` example, contributor `make nephio-*` targets) and [ADR 0003](docs/adr/0003-nephio-integration.md) for the design rationale.
 
 ### Apply Sample Resources
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ make install    # Install CRDs
 make run        # Run controller locally (connects to current kubeconfig)
 ```
 
+### Option D: Install via Nephio (kpt package)
+
+ntn-operators ships as a [Nephio](https://nephio.org) R6-compatible kpt package set. The CRDs install once per cluster; sample workloads compose per namespace through `kpt fn render`.
+
+```bash
+kpt pkg get https://github.com/thc1006/ntn-operators.git/nephio/packages/ntn-operators-crds@main ntn-operators-crds
+kubectl apply -f ntn-operators-crds/
+```
+
+See [`nephio/README.md`](nephio/README.md) for the full quick-start (workloads sample, Porch `PackageVariant` example, contributor `make nephio-*` targets) and [ADR 0003](docs/adr/0003-nephio-integration.md) for the design rationale.
+
 ### Apply Sample Resources
 
 ```bash

--- a/nephio/packages/ntn-operators-crds/README.md
+++ b/nephio/packages/ntn-operators-crds/README.md
@@ -69,7 +69,7 @@ The CRDs land cluster-wide, and per-cluster customization (namespace scoping of 
 kubectl delete -f ntn-operators-crds/
 ```
 
-Warning: deleting a CRD cascade-deletes every CustomResource of that kind. If you want to preserve existing CRs before deleting the CRDs, export them first (`kubectl get -A <kind> -o yaml > backup.yaml`) or adopt a GitOps workflow (ArgoCD/Flux) that retains the CRDs separately from the CRs.
+Warning: deleting a CRD cascade-deletes every CustomResource of that kind. If you want to preserve existing CRs before deleting the CRDs, export them first (`kubectl get <kind> -A -o yaml > backup.yaml`) or adopt a GitOps workflow that retains the CRDs separately from the CRs — for example, ArgoCD's `argocd.argoproj.io/sync-options: Prune=false` annotation or Flux's `kustomize.toolkit.fluxcd.io/prune: disabled` annotation, applied to the CRDs.
 
 ## Version compatibility
 

--- a/nephio/packages/ntn-operators-crds/README.md
+++ b/nephio/packages/ntn-operators-crds/README.md
@@ -69,7 +69,7 @@ The CRDs land cluster-wide, and per-cluster customization (namespace scoping of 
 kubectl delete -f ntn-operators-crds/
 ```
 
-Warning: deleting a CRD cascades-deletes every CustomResource of that kind. If you want to preserve existing CRs, use `kubectl patch` on the CRD objects to add the `"helm.sh/resource-policy": keep` annotation before deleting, or adopt a GitOps workflow (ArgoCD/Flux) that retains the CRDs separately from the CRs.
+Warning: deleting a CRD cascade-deletes every CustomResource of that kind. If you want to preserve existing CRs before deleting the CRDs, export them first (`kubectl get -A <kind> -o yaml > backup.yaml`) or adopt a GitOps workflow (ArgoCD/Flux) that retains the CRDs separately from the CRs.
 
 ## Version compatibility
 


### PR DESCRIPTION
## Summary

- **#113** — Adds Quick Start **Option D** to `README.md` pointing at `nephio/README.md` (full quick-start, Porch `PackageVariant` example, contributor `make nephio-*` targets) and `docs/adr/0003-nephio-integration.md`. First-time visitors can now discover the kpt package set shipped in #112 from the landing page.
- **#115** — Replaces the `helm.sh/resource-policy: keep` recommendation in `nephio/packages/ntn-operators-crds/README.md` Uninstall section. The annotation only takes effect under `helm uninstall`; against a raw `kubectl delete -f` (which is what the surrounding paragraph actually describes) it does nothing, so following the old text would silently delete CRs. Replaced with a `kubectl get -A <kind> -o yaml > backup.yaml` export hint plus the pre-existing GitOps suggestion.

Both follow-ups originate from round-4 post-#112 review.

## Test plan

- [x] `git diff --stat` — 2 files, 12 insertions, 1 deletion (pure docs)
- [x] `grep -rn "helm.sh/resource-policy" --include="*.md"` — zero hits in docs after the fix; `dist/chart/templates/crd/*.yaml` still carry the annotation, which is correct (those ARE Helm chart templates that consume it)
- [x] Both new README.md links resolve to existing files (`nephio/README.md`, `docs/adr/0003-nephio-integration.md`)
- [x] No `*-crd.yaml` byte changes, so `make nephio-verify-sync` drift check is unaffected

Closes #113
Closes #115