### PR TITLE
supply-chain(nephio): pin Kptfile mutators by @sha256 digest + T15 validator (#114)

### DIFF
--- a/docs/adr/0003-nephio-integration.md
+++ b/docs/adr/0003-nephio-integration.md
@@ -122,6 +122,7 @@ Tests live in `test/nephio/validate.sh`, wired through `make nephio-validate`:
 5. **Sample coverage** — all four expected sample CR kinds appear in the workloads package, with mutator-applied namespace and labels.
 6. **K8s manifest validity** — `kubectl apply --dry-run=client -f <rendered-output>` succeeds for both (client-side dry-run avoids needing a live cluster in CI).
 7. **Drift detection** — a separate `make nephio-verify-sync` compares SHA of `nephio/packages/ntn-operators-crds/*-crd.yaml` against `config/crd/bases/*.yaml`; mismatch fails CI.
+8. **Supply-chain pinning (T15)** — `hack/check-kptfile-digest-pin.sh` scans every `pipeline.mutators` `image:` entry and fails if any reference is not `<registry>/<path>@sha256:<64-hex>`. Mirrors the action-SHA pinning discipline from `hack/check-action-shas.sh` (#107 / #109). Closes #114.
 
 ## Follow-ups (tracked in new issues, not in this ADR)
 

--- a/hack/check-kptfile-digest-pin.sh
+++ b/hack/check-kptfile-digest-pin.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
+# Requires bash 4+ (uses mapfile, [[ =~ ]], BASH_REMATCH). macOS users
+# on the system bash 3.2 should `brew install bash` and re-run; Linux
+# distros and CI runners ship bash 5+ by default.
+#
 # check-kptfile-digest-pin.sh — verify every Kptfile pipeline mutator
-# (and validator) image is pinned by @sha256 digest, not by mutable tag.
+# AND validator image is pinned by @sha256 digest, not by mutable tag.
 #
 # Motivation: GHCR / OCI tags are mutable. A compromised upstream could
 # silently repoint `set-namespace:v0.4.1` to a malicious image on the
@@ -43,7 +47,12 @@ CHECKED=0
 mapfile -t KPTFILES < <(find "${PKGS_DIR}" -type f -name Kptfile | sort)
 
 if [ "${#KPTFILES[@]}" -eq 0 ]; then
-  echo "warning: no Kptfile found under ${PKGS_DIR}" >&2
+  # No Kptfiles under a directory that exists is a setup error (e.g., the
+  # packages tree was renamed but this script's default was not updated).
+  # Treat as exit 2 to match the missing-dir branch above and avoid the
+  # silent green of "0 errors checked".
+  echo "error: no Kptfile found under ${PKGS_DIR}" >&2
+  exit 2
 fi
 
 for KPT in "${KPTFILES[@]}"; do

--- a/hack/check-kptfile-digest-pin.sh
+++ b/hack/check-kptfile-digest-pin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# check-kptfile-digest-pin.sh — verify every Kptfile pipeline mutator
+# (and validator) image is pinned by @sha256 digest, not by mutable tag.
+#
+# Motivation: GHCR / OCI tags are mutable. A compromised upstream could
+# silently repoint `set-namespace:v0.4.1` to a malicious image on the
+# next `kpt fn render`. This script enforces digest pinning for the
+# Nephio kpt packages we ship under nephio/packages/, mirroring the
+# action-SHA pinning discipline established in hack/check-action-shas.sh
+# (#107 / #109).
+#
+# Checks (errors — fail run):
+#   1. Every `image:` field inside a Kptfile `pipeline:` section must
+#      be of the form `<registry>/<path>@sha256:<64-hex>`. Tag pinning
+#      (`:v1.2.3`, `:latest`) is rejected.
+#
+# Exempt:
+#   - `image:` lines outside the pipeline section (none expected today,
+#     but harmless if a future Kptfile adds metadata-side image refs).
+#   - Kptfiles with no pipeline section at all (CRD-only packages).
+#
+# Usage:
+#   hack/check-kptfile-digest-pin.sh [packages_dir]
+#
+# Default packages_dir is `nephio/packages`.
+
+set -euo pipefail
+
+PKGS_DIR="${1:-nephio/packages}"
+
+if [ ! -d "${PKGS_DIR}" ]; then
+  echo "error: packages dir not found: ${PKGS_DIR}" >&2
+  exit 2
+fi
+
+ERRORS=0
+CHECKED=0
+
+# Collect all Kptfile paths. `|| true` because find returns 0 even when
+# empty; mapfile would otherwise see no input. Sorted for deterministic
+# error ordering across CI runs.
+mapfile -t KPTFILES < <(find "${PKGS_DIR}" -type f -name Kptfile | sort)
+
+if [ "${#KPTFILES[@]}" -eq 0 ]; then
+  echo "warning: no Kptfile found under ${PKGS_DIR}" >&2
+fi
+
+for KPT in "${KPTFILES[@]}"; do
+  IN_PIPELINE=0
+  LINE_NO=0
+  while IFS= read -r LINE || [ -n "${LINE}" ]; do
+    LINE_NO=$((LINE_NO + 1))
+
+    # Enter pipeline block on a top-level `pipeline:` key.
+    if [[ "${LINE}" =~ ^pipeline:[[:space:]]*$ ]]; then
+      IN_PIPELINE=1
+      continue
+    fi
+    # Exit pipeline block on any other top-level (column-0) key.
+    if [ "${IN_PIPELINE}" -eq 1 ] && [[ "${LINE}" =~ ^[a-zA-Z] ]]; then
+      IN_PIPELINE=0
+    fi
+    [ "${IN_PIPELINE}" -eq 0 ] && continue
+
+    # Match `image: <ref>` (with optional leading list dash).
+    if [[ "${LINE}" =~ ^[[:space:]]*-?[[:space:]]*image:[[:space:]]+([^[:space:]#]+) ]]; then
+      IMG="${BASH_REMATCH[1]}"
+
+      # Strip optional surrounding YAML quotes.
+      DQ='"'
+      SQ="'"
+      if [ "${IMG#${DQ}}" != "${IMG}" ] && [ "${IMG%${DQ}}" != "${IMG}" ]; then
+        IMG="${IMG#${DQ}}"; IMG="${IMG%${DQ}}"
+      elif [ "${IMG#${SQ}}" != "${IMG}" ] && [ "${IMG%${SQ}}" != "${IMG}" ]; then
+        IMG="${IMG#${SQ}}"; IMG="${IMG%${SQ}}"
+      fi
+
+      CHECKED=$((CHECKED + 1))
+
+      # Require trailing `@sha256:<64-hex>`.
+      if ! printf '%s' "${IMG}" | grep -qE '@sha256:[0-9a-f]{64}$'; then
+        echo "::error file=${KPT},line=${LINE_NO}::Mutator image \`${IMG}\` is not pinned by digest. Pin to <registry>/<path>@sha256:<64-hex>."
+        ERRORS=$((ERRORS + 1))
+      fi
+    fi
+  done < "${KPT}"
+done
+
+echo ""
+echo "Checked ${CHECKED} pipeline image reference(s) across ${#KPTFILES[@]} Kptfile(s) under ${PKGS_DIR}/"
+
+if [ "${ERRORS}" -gt 0 ]; then
+  echo ""
+  echo "FAIL: ${ERRORS} error(s) found."
+  exit 1
+fi
+
+echo "OK: all Kptfile pipeline images pinned by @sha256 digest."

--- a/nephio/README.md
+++ b/nephio/README.md
@@ -58,7 +58,7 @@ Everything runs from the repository root via `make`:
 make nephio-install-tools    # install kpt (version pinned in Makefile) into $(go env GOPATH)/bin
 make nephio-sync             # regenerate package CRDs from config/crd/bases/
 make nephio-render           # run 'kpt fn render' on both packages (in-place — not for CI)
-make nephio-validate         # run test/nephio/validate.sh (full suite, currently 16 assertions)
+make nephio-validate         # run test/nephio/validate.sh (full suite, currently 15 assertions across Suites A/B/C)
 make nephio-verify-sync      # CI drift check — fails if nephio/packages/ntn-operators-crds/*-crd.yaml diverges from config/crd/bases/
 ```
 
@@ -84,6 +84,25 @@ Samples in `config/samples/ntn_v1alpha1_*.yaml` and package samples in `nephio/p
 
 If you add a field to a sample, add it to both locations, then `make nephio-validate`.
 
+### When you bump a KRM-function mutator version
+
+Mutator images in `nephio/packages/ntn-workloads-sample/Kptfile` are pinned by `@sha256:` digest (T15). To bump a version:
+
+1. Resolve the new digest from two independent sources before committing:
+
+   ```bash
+   docker buildx imagetools inspect ghcr.io/kptdev/krm-functions-catalog/<fn>:<new-tag>
+   curl -sLI -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json" \
+     -H "Authorization: Bearer $(curl -sL "https://ghcr.io/token?scope=repository:kptdev/krm-functions-catalog/<fn>:pull&service=ghcr.io" | jq -r .token)" \
+     https://ghcr.io/v2/kptdev/krm-functions-catalog/<fn>/manifests/<new-tag> | grep -i docker-content-digest
+   ```
+
+2. Both must report identical `sha256:` values. Replace the `@sha256:` reference in the Kptfile and update the comment line above it with the new tag.
+3. `make nephio-validate` — confirms T15 still passes and the rendered output matches expectations (T10 must show `namespace: ntn-system` after render).
+4. Commit both lines (digest + comment) together so reviewers can audit the version bump in one diff.
+
+For multi-arch images (OCI image index, e.g. `set-labels`), pin the **index** digest — `kpt fn render` resolves the per-platform manifest at runtime. Pinning a per-platform digest would break cross-arch render.
+
 ---
 
 ## Compatibility
@@ -95,6 +114,7 @@ If you add a field to a sample, add it to both locations, then `make nephio-vali
 | `kpt` CLI | v1.0.0-beta.55 or newer |
 | Kubernetes | 1.29+ (CEL validation is GA from 1.29) |
 | KRM function registry | `ghcr.io/kptdev/krm-functions-catalog` (Nephio R6 canonical; `gcr.io/kpt-fn/` tags are still current and functional) |
+| KRM function pinning | `@sha256:` digest (enforced by `hack/check-kptfile-digest-pin.sh` and `test/nephio/validate.sh` T15) |
 
 ---
 
@@ -113,7 +133,6 @@ Three reasons the integration is not cosmetic:
 - No `PackageVariantSet` manifests shipped here. Variants belong in the consumer's deployment repo; see each sub-README for example YAML.
 - No Porch cluster bootstrap. Porch setup is documented at nephio.org — we don't duplicate.
 - No custom KRM functions yet. A future `ntn-validator-fn` could validate cross-CR references (e.g., `NTNSlice.satellitePath.ephemerisRef` resolves to an existing `SatelliteEphemeris`). Tracked as a follow-up.
-- KRM function images are pinned by tag (`:v0.4.1`), not by `@sha256:` digest. Digest pinning is a post-1.0 supply-chain hardening item.
 - We have not yet contributed these packages to `nephio-project/catalog` upstream. The plan is to submit after E2E validation with at least one external Nephio user confirms the packages work in their deployment flow.
 
 ---

--- a/nephio/README.md
+++ b/nephio/README.md
@@ -92,8 +92,14 @@ Mutator images in `nephio/packages/ntn-workloads-sample/Kptfile` are pinned by `
 
    ```bash
    docker buildx imagetools inspect ghcr.io/kptdev/krm-functions-catalog/<fn>:<new-tag>
-   curl -sLI -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json" \
-     -H "Authorization: Bearer $(curl -sL "https://ghcr.io/token?scope=repository:kptdev/krm-functions-catalog/<fn>:pull&service=ghcr.io" | jq -r .token)" \
+
+   # Token extraction: jq if available, otherwise the python3 fallback below
+   # (jq is not in the contributor prerequisites; python3 always is).
+   TOKEN=$(curl -sL "https://ghcr.io/token?scope=repository:kptdev/krm-functions-catalog/<fn>:pull&service=ghcr.io" \
+     | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+   curl -sLI \
+     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json" \
+     -H "Authorization: Bearer $TOKEN" \
      https://ghcr.io/v2/kptdev/krm-functions-catalog/<fn>/manifests/<new-tag> | grep -i docker-content-digest
    ```
 

--- a/nephio/packages/ntn-workloads-sample/Kptfile
+++ b/nephio/packages/ntn-workloads-sample/Kptfile
@@ -17,10 +17,15 @@ info:
     'ntn-operators-crds' — install that first. Nephio R6 compatible.
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+    # set-namespace v0.4.1 (manifest v2, single-arch).
+    # Digest cross-verified 2026-04-26 via `docker buildx imagetools inspect`
+    # and the GHCR /v2 manifest API (Docker-Content-Digest header).
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace@sha256:f930d9248001fa763799cc81cf2d89bbf83954fc65de0db20ab038a21784f323
       configMap:
         namespace: ntn-system
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.1
+    # set-labels v0.2.1 (OCI image index, multi-arch — kpt fn render
+    # resolves to linux/amd64 or linux/arm64 at runtime).
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels@sha256:cce5893f108d8c3d18bd363e0d3d587f187b86b410c5d1b9d29d900e7fa8f4cf
       configMap:
         app.kubernetes.io/managed-by: ntn-operators
         workload: ntn-sample

--- a/test/nephio/validate.sh
+++ b/test/nephio/validate.sh
@@ -303,6 +303,29 @@ fi
 
 ###############################################################################
 echo
+echo "===> Suite C: supply-chain"
+###############################################################################
+
+# T15: every Kptfile pipeline mutator image must be pinned by @sha256 digest.
+# Delegates to hack/check-kptfile-digest-pin.sh (mirrors the action-SHA
+# pattern in hack/check-action-shas.sh, #109). Tag pinning is rejected
+# because GHCR/OCI tags are mutable (#114).
+DIGEST_CHECK="${REPO_ROOT}/hack/check-kptfile-digest-pin.sh"
+if [ -x "$DIGEST_CHECK" ]; then
+  if "$DIGEST_CHECK" "$PKG_DIR" >/dev/null 2>&1; then
+    _ok "T15 all Kptfile pipeline images pinned by @sha256 digest"
+  else
+    _fail "T15 Kptfile pipeline images NOT pinned by @sha256 digest"
+    if [ "$VERBOSE" = "--verbose" ]; then
+      "$DIGEST_CHECK" "$PKG_DIR" 2>&1 | sed 's/^/       /'
+    fi
+  fi
+else
+  _fail "T15 hack/check-kptfile-digest-pin.sh not found or not executable"
+fi
+
+###############################################################################
+echo
 echo "===> Summary"
 ###############################################################################
 


### PR DESCRIPTION
Closes #114.

## Summary

Pins both Nephio Kptfile mutator images by `@sha256:` digest instead of mutable tag, and adds a hermetic check (T15) so this property cannot silently regress. Mirrors the action-SHA pinning pattern shipped in #109.

## TDD trace (red → green → refactor)

**RED** — `hack/check-kptfile-digest-pin.sh` scans every `pipeline.mutators` and `pipeline.validators` `image:` reference in `nephio/packages/**/Kptfile` and emits `::error file=...,line=...::` annotations on tag-pinned refs. Initial run on the unmodified tree flagged 2 images at L20 and L23 of `nephio/packages/ntn-workloads-sample/Kptfile`, exit 1.

**GREEN** — Replaced both mutator references with `@sha256:` digests. Cross-verified through two independent paths on 2026-04-26:

| Image | Digest | Type |
|---|---|---|
| `set-namespace:v0.4.1` | `sha256:f930d9248001fa763799cc81cf2d89bbf83954fc65de0db20ab038a21784f323` | manifest v2 (single-arch) |
| `set-labels:v0.2.1` | `sha256:cce5893f108d8c3d18bd363e0d3d587f187b86b410c5d1b9d29d900e7fa8f4cf` | OCI image index (multi-arch) |

Verification path 1 — `docker buildx imagetools inspect <ref>`
Verification path 2 — GHCR `/v2/.../manifests/<tag>` `Docker-Content-Digest` HTTP header

**Tag choice rationale (corrected post review N3):**
- `set-namespace:v0.4.1` matches upstream Nephio R6 catalog — verified via `gh search code 'set-namespace' --repo nephio-project/catalog`, which returns 6+ Kptfile entries all on `:v0.4.1`.
- `set-labels:v0.2.1` was inherited from PR #112 and **does not match upstream**. Upstream catalog does not use `set-labels` in any Kptfile pipeline; the only upstream reference is in `nephio/core/porch/2-function-runner.yaml` (Porch function-runner registration), pinned to `v0.1.5`. Bumping to current latest (`set-namespace:v0.4.5` / `set-labels:v0.2.4`, both released 2026-02-18) is intentionally a separate concern.

For the multi-arch `set-labels`, pinned the **index** digest (not a per-platform manifest), because `kpt fn render` resolves to the running platform at runtime — pinning per-platform would break cross-arch render. This matches Google Cloud's official guidance and the OCI image-spec.

**REFACTOR** — Wired `hack/check-kptfile-digest-pin.sh` into `test/nephio/validate.sh` as **T15** under a new `Suite C: supply-chain` section. Final full-suite run reports 17/17 PASS:

```
===> Preflight
  PASS  kpt CLI available (1.0.0-beta.62)
  PASS  kubectl available (v1.35.4)
===> Suite A: ntn-operators-crds package
  PASS  T1..T7, T13   (8 PASS)
===> Suite B: ntn-workloads-sample package
  PASS  T8..T12, T14   (6 PASS)
===> Suite C: supply-chain
  PASS  T15 all Kptfile pipeline images pinned by @sha256 digest
===> Summary
  Passed: 17 / 17
```

Critical regression check: **T10 still passes** — `kpt fn render` succeeds on the digest-pinned Kptfile and `set-namespace` mutator still applies (`namespace: ntn-system` written into rendered samples). Pin does not break the render pipeline.

## Upstream context (web-research verified 2026-04-26)

- Upstream `nephio-project/catalog` has **73** `krm-functions-catalog` references across Kptfiles + Porch manifests; **all are tag-pinned, none are digest-pinned**. This PR is upstream-leading on supply-chain hygiene.
- Latest upstream tags: `set-namespace:v0.4.5` (2026-02-18), `set-labels:v0.2.4` (2026-02-18). We are deliberately staying behind current latest until digest pinning lands; version bump tracked as a follow-up.

## Review fixes applied (commit 2aa58c8)

- **N1** — SOP token extraction switched from `jq` to `python3` fallback so contributors without `jq` can still bump versions.
- **N2** — Helper script now declares its bash 4+ requirement (mapfile / BASH_REMATCH / `[[ =~ ]]`).
- **N3** — Tag-choice rationale rewritten in this PR description (was half-correct in the original commit body).
- **N4** — Helper header tightened to say "mutator AND validator".
- **N5** — Helper now exits 2 on an empty packages directory instead of silently exiting 0 with a warning. Avoids the trap where a renamed packages tree green-lights config drift.

## Out of scope (intentional)

- No new GitHub Actions workflow added in this PR. The existing `test.yml` / `test-e2e.yml` path filters do not include `nephio/**`; wiring `make nephio-validate` into CI on `nephio/**` PRs is a follow-up. T15 currently runs via local `make nephio-validate` and reviewer-run validate.
- Mutator version bump (`set-namespace` v0.4.1 → v0.4.5, `set-labels` v0.2.1 → v0.2.4) — separate follow-up.

## Test plan

- [x] `bash test/nephio/validate.sh` reports 17/17 PASS with `kpt v1.0.0-beta.62` + `kubectl v1.35.4`
- [x] `hack/check-kptfile-digest-pin.sh nephio/packages` reports `OK: all Kptfile pipeline images pinned by @sha256 digest`, exit 0
- [x] Pre-fix run: 2 errors at correct file:line annotations, exit 1
- [x] Empty dir negative-path: exits 2 (verified via `mktemp -d` empty path)
- [x] T10 / T12 still pass — `kpt fn render` succeeds on digest-pinned Kptfile, samples render to valid YAML, mutators still apply
- [x] No CRD bytes touched, so `make nephio-verify-sync` drift check stays clean
- [x] Bash syntax check `bash -n test/nephio/validate.sh hack/check-kptfile-digest-pin.sh`