### PR TITLE
chore(release): promote v0.4.0-rc.1 to v0.4.0 final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-27
+
+Promotion of `0.4.0-rc.1` after a 6-day soak. No CRD or controller breaking
+changes vs rc.1; all additions are backward compatible.
+
+### Added
+
+**Nephio R6 distribution (#51 / #112)**
+- `nephio/packages/ntn-operators-crds` — kpt-installable CRD-only package
+- `nephio/packages/ntn-workloads-sample` — kpt-installable sample CRs with
+  `set-namespace` + `set-labels` mutator pipeline
+- `make nephio-{install-tools,sync,render,validate,verify-sync}` targets
+- ADR 0003 — Nephio integration design rationale
+- README Quick Start Option D — Nephio install path for first-time visitors
+
+**Supply-chain hardening (#114 / #117)**
+- All Kptfile pipeline mutator images pinned by `@sha256:` digest
+  (`set-namespace@sha256:f930…`, `set-labels@sha256:cce5…`)
+- `hack/check-kptfile-digest-pin.sh` enforces digest pinning, mirroring
+  the action-SHA discipline established in `hack/check-action-shas.sh` (#109)
+- `test/nephio/validate.sh` T15 wires the check into the validate suite
+
+**CI gating (#119 / #121)**
+- `.github/workflows/nephio.yml` — dedicated PR/push gate running
+  `make nephio-install-tools` → `nephio-verify-sync` → `nephio-validate`
+- T7 / T12 reimplemented as hermetic python-yaml structural checks
+  (replaces `kubectl apply --dry-run=client`, which required cluster API
+  discovery and failed on hermetic CI runners)
+
+### Changed
+
+- Reconciler 304 status-not-updated bug fix (#110) — SatelliteEphemeris
+  controller now correctly persists status when the upstream returns 304
+- `pkg/netutil/allowlist.go` — private-host SSRF allow-list, OWASP
+  Case 1 hardening (#110)
+- E2E uses in-cluster CelesTrak mock to remove network flake (#105 / #110)
+- OMM test fixture deduplicated between unit and e2e (#111)
+
+### CI hardening (no operator behavior change)
+
+- E2E path filter narrowed; release.yml dry-run dispatch (#102 / #103 / #104)
+- Trivy weekly scheduled scan on main (#108)
+- Action SHA validator catches non-SHA refs at PR time (#107 / #109)
+
+### Upgrade notes from 0.4.0-rc.1
+
+- **No CRD or runtime behavior change** vs rc.1 + the #110 reconciler 304 fix
+- **OLM upgrade**: `spec.skipRange` is `"<0.4.0"` (was `"<0.4.0-rc.1"`).
+  Same reasoning as rc.1 — no rc.1 CSV was published to an OperatorHub
+  catalog, so skipRange is the right pattern.
+
 ## [0.4.0-rc.1] - 2026-04-21
 
 Release candidate for 0.4.0 consolidating the v0.2 Core Hardening, v0.3

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.4.0-rc.1
+VERSION ?= 0.4.0
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Kubernetes-native management framework for Non-Terrestrial Networks (NTN). Declaratively manage satellite constellations, ground stations, NTN cell configurations, and terrestrial-satellite failover — all through standard Kubernetes CRDs.
 
-> **Latest release:** [v0.4.0-rc.1](https://github.com/thc1006/ntn-operators/releases/tag/v0.4.0-rc.1) — Prometheus metrics integration, OLM bundle, signal hysteresis, cosign/SBOM supply chain. See [CHANGELOG.md](CHANGELOG.md) for the v0.2 → v0.3 → v0.4 additions.
+> **Latest release:** [v0.4.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.4.0) — Nephio R6 kpt package integration, Kptfile `@sha256:` digest pinning + T15 supply-chain validator, OWASP private-host allowlist for Prometheus endpoints, and reconciler 304 status fix. See [CHANGELOG.md](CHANGELOG.md) for the full v0.4.0-rc.1 → 0.4.0 delta.
 
 ## Custom Resource Definitions
 

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -47,11 +47,11 @@ metadata:
       ]
     categories: Networking
     capabilities: Full Lifecycle
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.4.0-rc.1
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.4.0
     repository: https://github.com/thc1006/ntn-operators
     createdAt: "2026-04-15T00:00:00Z"
     support: thc1006
-  name: ntn-operators.v0.4.0-rc.1
+  name: ntn-operators.v0.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -138,7 +138,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.4.0-rc.1
+                    image: ghcr.io/thc1006/ntn-operators:v0.4.0
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -214,5 +214,5 @@ spec:
   # point OLM at a CSV it cannot find, failing the install. skipRange
   # says "this CSV can take over from anything older than itself" and
   # is safe whether or not an older CSV exists in the catalog.
-  skipRange: "<0.4.0-rc.1"
-  version: 0.4.0-rc.1
+  skipRange: "<0.4.0"
+  version: 0.4.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.4.0-rc.1
+  newTag: v0.4.0

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.4.0-rc.1
-appVersion: "0.4.0-rc.1"
+version: 0.4.0
+appVersion: "0.4.0"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.4.0-rc.1` | Image tag |
+| `manager.image.tag` | string | `v0.4.0` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.4.0-rc.1
+    tag: v0.4.0
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
Cuts **v0.4.0 final** after a 6-day soak on rc.1. No CRD or controller behavior change; the delta is the supply-chain + Nephio + bug-fix chain landed across **13 PRs** since 2026-04-21.

## Why now

Three real user-facing improvements have been stuck behind the rc.1 tag:

1. 🐛 **#110 reconciler 304 fix** — `SatelliteEphemeris` controller now correctly persists status when the upstream returns HTTP 304
2. 🛡️ **#110 netutil OWASP Case 1 allowlist** — private-host SSRF guard for the Prometheus reader (`pkg/netutil/allowlist.go`, +89 LOC in `safeclient.go`)
3. 📦 **#112 Nephio R6 kpt distribution** — two packages, ADR 0003, full `make nephio-*` toolchain
4. 🔐 **#117 Kptfile @sha256 digest pinning + T15 validator** — upstream-leading supply-chain hardening (verified: 73 catalog refs upstream are tag-pinned, 0 digest-pinned)

These have soaked on `main` with all CI green for 5–6 days. Time to ship.

## Files changed (8, all version-bump only)

| File | Change |
|---|---|
| `CHANGELOG.md` | Added `[0.4.0] - 2026-04-27` section above `[0.4.0-rc.1]` |
| `Makefile` L62 | `VERSION ?= 0.4.0` |
| `README.md` L8 | Latest release line |
| `dist/chart/Chart.yaml` L6+L7 | `version: 0.4.0` + `appVersion: "0.4.0"` |
| `dist/chart/values.yaml` L16 | `tag: v0.4.0` ⚠️ critical (chart 0.4.0 was pulling rc.1 image otherwise) |
| `dist/chart/README.md` L28 | values reference table |
| `config/manager/kustomization.yaml` L8 | `newTag: v0.4.0` ⚠️ critical (`kubectl -k` path) |
| `bundle/manifests/ntn-operators.clusterserviceversion.yaml` L50/L54/L141/L217/L218 | `containerImage`, CSV `name`, deploy template image, `skipRange: "<0.4.0"`, `version: 0.4.0` |

`Chart.yaml` is also auto-overwritten by `release.yml` at publish time (`sed` on `version` + `appVersion`), but committing it consistently at PR time keeps the source tree honest.

## Files intentionally NOT touched

- `docs/whitepaper/ntn-k8s-operators-whitepaper.md` — `skip-worktree` per `project_whitepaper_local_override.md` memory
- `RELEASING.md` L47, `CHANGELOG.md` inside the `[0.4.0-rc.1]` section, `.github/workflows/trivy-scheduled.yml` L13 — historical references, accurate as history

## Out of scope (intentional, separate commit)

- **Post-tag pitch + memory sync**: `docs/pitch/{facts-verified.md,qa-prep.md,visual-qa-log.md}` F9c row + Bonus Q&A + sync log; `MEMORY.md` L5; `project_sprint_plan.md`. Will land in a separate commit after `release.yml` finishes publishing the tag.

## Verified before push

- [x] `bash test/nephio/validate.sh` → **17/17 PASS** (`kpt v1.0.0-beta.62`)
- [x] `grep -rn "0.4.0-rc.1"` from worktree, excluding history-only paths → only the deliberate `v0.4.0-rc.1 → 0.4.0 delta` mention in `README.md`
- [x] `git diff --stat` → 8 files, +63 / −12
- [x] Zero CRD or `internal/controller/` changes
- [x] Worktree off `origin/main` (per `feedback_worktree.md`)
- [x] Co-authored-by junnncct1106 on commit
- [x] No Claude Code footer

## Tag flow after this PR merges

```
git tag -a v0.4.0 -m "v0.4.0 — Nephio R6 + supply-chain digest pin + OWASP allowlist + 304 fix"
git push origin v0.4.0
```

Triggers `release.yml`:

1. **build-scan** (read-only): ko local build, Trivy CRITICAL/HIGH gate
2. **publish** (write tokens): ko multi-arch push to GHCR with `latest` + `v0.4.0` tags, cosign keyless OIDC sign, syft SPDX SBOM, cosign attest, Helm OCI push, GitHub Release with `prerelease=false` (no `-` in tag → marked **Latest**)