### PR TITLE
chore(nephio): bump KRM mutators to set-namespace v0.4.5 + set-labels v0.2.4 (#118)

### DIFF
--- a/nephio/packages/ntn-workloads-sample/Kptfile
+++ b/nephio/packages/ntn-workloads-sample/Kptfile
@@ -17,15 +17,17 @@ info:
     'ntn-operators-crds' — install that first. Nephio R6 compatible.
 pipeline:
   mutators:
-    # set-namespace v0.4.1 (manifest v2, single-arch).
-    # Digest cross-verified 2026-04-26 via `docker buildx imagetools inspect`
-    # and the GHCR /v2 manifest API (Docker-Content-Digest header).
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace@sha256:f930d9248001fa763799cc81cf2d89bbf83954fc65de0db20ab038a21784f323
+    # set-namespace v0.4.5 (OCI image index, multi-arch — amd64 + arm64).
+    # Bumped from v0.4.1 in #118; v0.4.x is now distributed as a manifest
+    # list. Digest cross-verified 2026-05-01 via `docker buildx imagetools
+    # inspect` and the GHCR /v2 manifest API (Docker-Content-Digest header).
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace@sha256:2f596c0b4c703a1649a80e0921ded857e507a3aeac497835b75f18937fbb120a
       configMap:
         namespace: ntn-system
-    # set-labels v0.2.1 (OCI image index, multi-arch — kpt fn render
-    # resolves to linux/amd64 or linux/arm64 at runtime).
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels@sha256:cce5893f108d8c3d18bd363e0d3d587f187b86b410c5d1b9d29d900e7fa8f4cf
+    # set-labels v0.2.4 (OCI image index, multi-arch — kpt fn render
+    # resolves to linux/amd64 or linux/arm64 at runtime). Bumped from
+    # v0.2.1 in #118. Digest cross-verified 2026-05-01 (same SOP).
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels@sha256:e68caa56d3e7857ae28892a49051daa7393aa13e7806bf67e5c5ab3488540208
       configMap:
         app.kubernetes.io/managed-by: ntn-operators
         workload: ntn-sample


### PR DESCRIPTION
## Summary

- Bump `set-namespace` mutator pin from `v0.4.1` → `v0.4.5` (released 2026-02-18)
- Bump `set-labels` mutator pin from `v0.2.1` → `v0.2.4` (released 2026-02-18)
- Both pinned by `@sha256:` digest per the supply-chain discipline established in PR #117

Closes #118.

## Digest verification (dual-source SOP per `nephio/README.md`)

| Image | Source A: `docker buildx imagetools inspect` | Source B: GHCR `/v2` `Docker-Content-Digest` |
|---|---|---|
| `set-namespace:v0.4.5` | `sha256:2f596c0b...20a` | `sha256:2f596c0b...20a` ✅ match |
| `set-labels:v0.2.4` | `sha256:e68caa56...208` | `sha256:e68caa56...208` ✅ match |

Both sources agreed exactly for both images. Verified 2026-05-01.

## Validation

- `hack/check-kptfile-digest-pin.sh`: **T15 PASS** (2 / 2 pipeline images pinned by `@sha256`)
- `make nephio-validate`: **17 / 17 PASS** — including:
  - T10 `kpt fn render` still writes `namespace: ntn-system` after the bump (mutator behavior idempotent across the v0.4.1 → v0.4.5 minor releases)
  - T15 supply-chain digest-pin invariant preserved

## Notes for reviewers

- `set-namespace v0.4.x` is now distributed as an OCI image index (multi-arch amd64 + arm64), an upgrade from `v0.4.1` which shipped as a single-arch manifest. The Kptfile comment is updated to reflect that.
- Upstream Nephio R6 catalog still uses `set-namespace:v0.4.1` across 6+ Kptfiles; this PR deliberately desyncs from upstream for two minor releases of bug fixes — acceptable trade-off per #118 issue body.
- `set-labels` is not used in any upstream Nephio R6 Kptfile pipeline; only in Porch function-runner registration (at `v0.1.5`). Bumping ours is fully an internal decision.
- Diff scope is exactly what #118 promised: 1 file (`nephio/packages/ntn-workloads-sample/Kptfile`), 9 insertions / 7 deletions.

## Test plan

- [x] `bash hack/check-kptfile-digest-pin.sh` — passes
- [x] `make nephio-validate` — 17/17 passes
- [x] Manual diff inspection — only Kptfile mutator block touched, no behavior change downstream
- [ ] CI nephio.yml workflow — to verify on PR