### PR TITLE
test(e2e): allow running suite against an existing cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	esac
 
 .PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
+test-e2e: manifests generate fmt vet ## Run the e2e tests. Defaults to a Kind environment; set E2E_USE_EXISTING_CLUSTER=true (and MANAGER_IMAGE) to target an existing cluster instead.
+	@if [ -z "$$E2E_USE_EXISTING_CLUSTER" ]; then $(MAKE) setup-test-e2e; \
+	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind setup"; fi
 	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
-	$(MAKE) cleanup-test-e2e
+	@if [ -z "$$E2E_USE_EXISTING_CLUSTER" ]; then $(MAKE) cleanup-test-e2e; \
+	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind teardown"; fi
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,7 +34,14 @@ import (
 
 var (
 	// managerImage is the manager image to be built and loaded for testing.
-	managerImage = "example.com/ntn-operators:v0.0.1"
+	// Override with the MANAGER_IMAGE env var when targeting an existing
+	// cluster so the controller Deployment pulls from a reachable registry.
+	managerImage = func() string {
+		if v := os.Getenv("MANAGER_IMAGE"); v != "" {
+			return v
+		}
+		return "example.com/ntn-operators:v0.0.1"
+	}()
 	// shouldCleanupCertManager tracks whether CertManager was installed by this suite.
 	shouldCleanupCertManager = false
 )
@@ -48,6 +55,9 @@ const celestrakMockHost = "celestrak-mock.default.svc.cluster.local"
 // The default setup requires Kind and CertManager.
 //
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// To run against a pre-existing cluster (e.g. kubeadm) with the manager
+// image already pushed to a registry the cluster can pull from, set:
+//   E2E_USE_EXISTING_CLUSTER=1 MANAGER_IMAGE=<your-registry>/ntn-operators:v0.0.1
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting ntn-operators e2e test suite\n")
@@ -55,16 +65,18 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	By("building the manager image")
-	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
-	_, err := utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager image")
+	if os.Getenv("E2E_USE_EXISTING_CLUSTER") == "" {
+		By("building the manager image")
+		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager image")
 
-	// TODO(user): If you want to change the e2e test vendor from Kind,
-	// ensure the image is built and available, then remove the following block.
-	By("loading the manager image on Kind")
-	err = utils.LoadImageToKindClusterWithName(managerImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
+		By("loading the manager image on Kind")
+		err = utils.LoadImageToKindClusterWithName(managerImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "E2E_USE_EXISTING_CLUSTER=1 — skipping docker-build / Kind load (image expected at %s)\n", managerImage)
+	}
 
 	setupCertManager()
 	setupCelestrakMock()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,18 +33,44 @@ import (
 )
 
 var (
+	// defaultManagerImage is the placeholder used when MANAGER_IMAGE is not
+	// set. Intentionally a non-pullable hostname so a forgotten override
+	// fails fast on Pod ImagePullBackOff rather than silently using stale
+	// state.
+	defaultManagerImage = "example.com/ntn-operators:v0.0.1"
+
 	// managerImage is the manager image to be built and loaded for testing.
 	// Override with the MANAGER_IMAGE env var when targeting an existing
 	// cluster so the controller Deployment pulls from a reachable registry.
-	managerImage = func() string {
-		if v := os.Getenv("MANAGER_IMAGE"); v != "" {
-			return v
-		}
-		return "example.com/ntn-operators:v0.0.1"
-	}()
+	// Resolved once at init() so a single env value is observed for the
+	// whole suite (BeforeSuite + every spec).
+	managerImage string
+
 	// shouldCleanupCertManager tracks whether CertManager was installed by this suite.
 	shouldCleanupCertManager = false
 )
+
+func init() {
+	if v := os.Getenv("MANAGER_IMAGE"); v != "" {
+		managerImage = v
+	} else {
+		managerImage = defaultManagerImage
+	}
+}
+
+// envTrue returns true iff the named env var is set to a value the wider
+// k8s ecosystem treats as true ("true"/"1"/"yes", case-insensitive). This
+// matches controller-runtime's USE_EXISTING_CLUSTER convention so an
+// E2E_USE_EXISTING_CLUSTER=false value disables the new path as readers
+// expect.
+func envTrue(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
 
 // celestrakMockHost is the in-cluster DNS name the mock server answers on.
 // Must match the Service FQDN in test/e2e/fixtures/celestrak-mock.yaml AND
@@ -65,17 +91,36 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if os.Getenv("E2E_USE_EXISTING_CLUSTER") == "" {
+	useExisting := envTrue("E2E_USE_EXISTING_CLUSTER")
+
+	// Fail fast: if the user opted into the existing-cluster path but
+	// forgot to point MANAGER_IMAGE at a registry the cluster can pull
+	// from, the controller Deployment will eventually ImagePullBackOff
+	// against the placeholder. Surface that mistake here, before any
+	// CRDs/RBAC are applied.
+	if useExisting && managerImage == defaultManagerImage {
+		Fail(fmt.Sprintf(
+			"E2E_USE_EXISTING_CLUSTER is set but MANAGER_IMAGE was not overridden — "+
+				"refusing to deploy placeholder %q. Set MANAGER_IMAGE=<your-registry>/ntn-operators:<tag>.",
+			defaultManagerImage,
+		))
+	}
+
+	if !useExisting {
 		By("building the manager image")
 		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
 		_, err := utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager image")
 
+		// E2E_USE_EXISTING_CLUSTER offers an opt-out for non-Kind setups
+		// (kubeadm/k3s/EKS/...); see the doc comment above TestE2E.
 		By("loading the manager image on Kind")
 		err = utils.LoadImageToKindClusterWithName(managerImage)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 	} else {
-		_, _ = fmt.Fprintf(GinkgoWriter, "E2E_USE_EXISTING_CLUSTER=1 — skipping docker-build / Kind load (image expected at %s)\n", managerImage)
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"E2E_USE_EXISTING_CLUSTER=%q — skipping docker-build / Kind load (image expected at %s)\n",
+			os.Getenv("E2E_USE_EXISTING_CLUSTER"), managerImage)
 	}
 
 	setupCertManager()


### PR DESCRIPTION
## Summary

Lets `go test -tags=e2e ./test/e2e/` opt out of Kind and run against an
already-provisioned cluster (kubeadm, k3s, EKS, …). Useful for dev
boxes that intentionally don't run a docker daemon (containerd-only),
and for CI lanes that target a long-lived cluster.

Two new env knobs, both backward-compatible:

- `E2E_USE_EXISTING_CLUSTER=1` — skip `make docker-build` and
  `LoadImageToKindClusterWithName` in BeforeSuite. The image is
  expected to be built and pushed out-of-band.
- `MANAGER_IMAGE=<registry>/ntn-operators:<tag>` — override the
  deploy image reference. Default unchanged
  (`example.com/ntn-operators:v0.0.1`) so a forgotten override still
  fails fast.

CertManager and the celestrak-mock setup are untouched, so combining
this with the existing `CERT_MANAGER_INSTALL_SKIP=true` gives a full
zero-Kind path when the target cluster already has cert-manager.

## Why

The existing suite hard-couples the e2e flow to Kind:

1. `make docker-build` requires a docker daemon
2. `LoadImageToKindClusterWithName` requires Kind

Together these two block running the suite anywhere except a developer
laptop with both Docker Desktop and Kind installed. The TODO comment
above `LoadImageToKindClusterWithName` already anticipated this.

## Behaviour matrix

| `E2E_USE_EXISTING_CLUSTER` | `MANAGER_IMAGE` | Behaviour |
|---|---|---|
| unset | unset | original Kind flow, image `example.com/...:v0.0.1` |
| unset | set | original Kind flow, image from env |
| set | unset | skip Kind setup, deploy `example.com/...:v0.0.1` (will likely ImagePullBackOff — guards against forgotten override) |
| set | set | **new path**: skip Kind setup, deploy from your registry |

## Test plan

- [x] `go test -tags=e2e ./test/e2e/` against a Kind-less kubeadm
  v1.36 single-node cluster:
  ```
  E2E_USE_EXISTING_CLUSTER=1 \
    MANAGER_IMAGE=localhost:30500/ntn-operators:v0.0.1 \
    CERT_MANAGER_INSTALL_SKIP=true \
    go test -tags=e2e ./test/e2e/ -timeout=20m
  ```
  → `ok ... 51.946s`, 5/5 specs pass
- [x] `go vet -tags=e2e ./test/e2e/...` clean
- [x] Default env (no new vars) still compiles + produces same call
  pattern as before (no behavioural diff in `BeforeSuite` when
  `E2E_USE_EXISTING_CLUSTER` is unset)