### PR TITLE
fix(ntncellconfig): align cellSpecificKoffset to OCUDU range 1-1023 (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+**NTNCellConfig schema — OCUDU `ntn_config` alignment (#144)**
+- `spec.ntn.cellSpecificKoffset` minimum tightened from `0` to `1`. The 3GPP IE
+  `cellSpecificKoffset-r17` is `INTEGER(0..1023)` and permits `0`, but OCUDU
+  rejects `0` (its CLI and config validation enforce 1-1023), so the CRD mirrors
+  the backend rather than the spec. An explicit `cellSpecificKoffset: 0` is now
+  rejected at admission; omitting the field still defaults to `150` (the typed
+  zero value is dropped by `omitempty`, so only an explicit `0` reaches the
+  validation).
+- Field documentation now states the unit correctly: the value is in
+  **milliseconds** (TS 38.213 / TS 38.300 §16.14.2). OCUDU stores
+  `cell_specific_koffset` as `std::chrono::milliseconds` and converts it to
+  operating-SCS slots internally, so the integer passes through this operator
+  unchanged — no unit conversion. (3GPP expresses K_offset as a slot count
+  assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that is only how the
+  IE is defined, not a conversion applied here.)
+- This brings the CRD into alignment with 7 of the 8 fields in OCUDU's
+  `ntn_config` struct (`ntnUlSyncValidityDur`, `polarization`, `taReport`,
+  `taInfo.taCommonDrift*`, `epochTime`, `ephemeris*`, and `cellSpecificKoffset`
+  were verified present and correctly rendered). The 8th field, `k_mac`, stays
+  intentionally deferred pending upstream OCUDU MR!597 reassessment (tracked in
+  #52); no schema change for it here.
+
+**Dependencies / CI**
+- Bumped `onsi/ginkgo/v2` 2.28.1 → 2.28.2 (#133), `aquasecurity/trivy-action`
+  0.35.0 → 0.36.0 (#127), `docker/login-action` 4.1.0 → 4.2.0 (#145), and Nephio
+  KRM mutators `set-namespace` 0.4.5 / `set-labels` 0.2.4 (#118 / #134).
+
+### Added
+
+- E2E suite can run against an existing cluster instead of always provisioning a
+  Kind cluster (#135).
+- OLM ClusterServiceVersion description and `certified` annotation, with
+  `createdAt` aligned to the 2026-04 OperatorHub convention (#124).
+
 ## [0.4.0] - 2026-04-27
 
 Promotion of `0.4.0-rc.1` after a 6-day soak. No CRD or controller breaking

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -65,8 +65,17 @@ type ProviderRef struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.ephemerisECEF) && has(self.ephemerisOrbital))",message="ephemerisECEF and ephemerisOrbital are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="!has(self.ephemerisECEF) || self.ephemerisECEF.posX != 0 || self.ephemerisECEF.posY != 0 || self.ephemerisECEF.posZ != 0",message="ephemerisECEF position must not be all zeros"
 type NTNParams struct {
-	// cellSpecificKoffset sets the cell-specific k-offset for NTN (0-1023).
-	// +kubebuilder:validation:Minimum=0
+	// cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+	// (3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+	// cell_specific_koffset as std::chrono::milliseconds and converts it to
+	// operating-SCS slots internally, so the value passes through this operator
+	// unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+	// assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+	// how the IE is defined, not a conversion the user applies here.)
+	// The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+	// (its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+	// backend rather than the spec.
+	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=1023
 	// +kubebuilder:default=150
 	CellSpecificKoffset int `json:"cellSpecificKoffset,omitempty"`

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -134,10 +134,19 @@ spec:
                 properties:
                   cellSpecificKoffset:
                     default: 150
-                    description: cellSpecificKoffset sets the cell-specific k-offset
-                      for NTN (0-1023).
+                    description: |-
+                      cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+                      (3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+                      cell_specific_koffset as std::chrono::milliseconds and converts it to
+                      operating-SCS slots internally, so the value passes through this operator
+                      unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+                      assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+                      how the IE is defined, not a conversion the user applies here.)
+                      The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+                      (its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+                      backend rather than the spec.
                     maximum: 1023
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   distanceThreshold:
                     description: |-

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -134,10 +134,19 @@ spec:
                 properties:
                   cellSpecificKoffset:
                     default: 150
-                    description: cellSpecificKoffset sets the cell-specific k-offset
-                      for NTN (0-1023).
+                    description: |-
+                      cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+                      (3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+                      cell_specific_koffset as std::chrono::milliseconds and converts it to
+                      operating-SCS slots internally, so the value passes through this operator
+                      unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+                      assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+                      how the IE is defined, not a conversion the user applies here.)
+                      The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+                      (its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+                      backend rather than the spec.
                     maximum: 1023
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   distanceThreshold:
                     description: |-

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -137,10 +137,19 @@ spec:
                 properties:
                   cellSpecificKoffset:
                     default: 150
-                    description: cellSpecificKoffset sets the cell-specific k-offset
-                      for NTN (0-1023).
+                    description: |-
+                      cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+                      (3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+                      cell_specific_koffset as std::chrono::milliseconds and converts it to
+                      operating-SCS slots internally, so the value passes through this operator
+                      unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+                      assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+                      how the IE is defined, not a conversion the user applies here.)
+                      The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+                      (its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+                      backend rather than the spec.
                     maximum: 1023
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   distanceThreshold:
                     description: |-

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -613,10 +613,19 @@ ntn contains NTN-specific radio parameters per 3GPP TS 38.213 / OCUDU geo_ntn.ym
         <td><b>cellSpecificKoffset</b></td>
         <td>integer</td>
         <td>
-          cellSpecificKoffset sets the cell-specific k-offset for NTN (0-1023).<br/>
+          cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+(3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+cell_specific_koffset as std::chrono::milliseconds and converts it to
+operating-SCS slots internally, so the value passes through this operator
+unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+how the IE is defined, not a conversion the user applies here.)
+The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+(its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+backend rather than the spec.<br/>
           <br/>
             <i>Default</i>: 150<br/>
-            <i>Minimum</i>: 0<br/>
+            <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 1023<br/>
         </td>
         <td>false</td>

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -27,6 +27,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -699,6 +701,75 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			err := k8sClient.Create(context.Background(), cr)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("zeros"))
+		})
+	})
+
+	// --- cellSpecificKoffset range alignment with OCUDU (1-1023) ---
+	//
+	// OCUDU stores cell_specific_koffset as std::chrono::milliseconds with a
+	// config range of 1-1023; 0 is not accepted. The CRD's Minimum=1 mirrors
+	// that lower bound. Note the omitempty/default interaction: the typed Go
+	// client drops a zero int (omitempty) so an "unset" koffset defaults to
+	// 150 and never reaches the Minimum check — only an *explicit* 0 in the
+	// wire object exercises it, which is why this case uses unstructured.
+	Context("cellSpecificKoffset must be within OCUDU range 1-1023", func() {
+		newCellConfigUnstructured := func(name string, koffset int64) *unstructured.Unstructured {
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "ntn.operators.dev", Version: "v1alpha1", Kind: "NTNCellConfig",
+			})
+			u.SetName(name)
+			u.SetNamespace(namespace)
+			u.Object["spec"] = map[string]any{
+				"provider": map[string]any{"type": "ocudu", "namespace": namespace},
+				"ntn": map[string]any{
+					"cellSpecificKoffset": koffset,
+					"payloadType":         "transparent",
+					"ephemerisECEF": map[string]any{
+						"posX": int64(20922195), "posY": int64(1967783), "posZ": int64(19770302),
+					},
+				},
+			}
+			return u
+		}
+
+		It("should reject an explicit cellSpecificKoffset of 0 (below OCUDU min)", func() {
+			err := k8sClient.Create(context.Background(), newCellConfigUnstructured("koffset-zero", 0))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("greater than or equal to 1"))
+		})
+
+		It("should reject a cellSpecificKoffset above OCUDU max (1024)", func() {
+			err := k8sClient.Create(context.Background(), newCellConfigUnstructured("koffset-over-max", 1024))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("less than or equal to 1023"))
+		})
+
+		It("should accept the lower valid boundary cellSpecificKoffset=1", func() {
+			// The OCUDU/CRD lower bound is inclusive: 1 is the smallest accepted
+			// value. Guards against the Minimum being mis-set to 2 (off-by-one).
+			u := newCellConfigUnstructured("koffset-min-boundary", 1)
+			Expect(k8sClient.Create(context.Background(), u)).To(Succeed())
+			Expect(k8sClient.Delete(context.Background(), u)).To(Succeed())
+		})
+
+		It("should default an omitted (zero) cellSpecificKoffset to 150, not reject it", func() {
+			// Typed client: koffset==0 is the int zero value, omitempty drops it,
+			// the apiserver applies default=150. Documents why explicit-0 rejection
+			// above needs unstructured rather than the typed geoSpec().
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "koffset-defaulted", Namespace: namespace},
+				Spec:       geoSpec(),
+			}
+			cr.Spec.NTN.CellSpecificKoffset = 0
+			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+
+			fetched := &ntnv1alpha1.NTNCellConfig{}
+			Expect(k8sClient.Get(context.Background(),
+				types.NamespacedName{Name: "koffset-defaulted", Namespace: namespace}, fetched)).To(Succeed())
+			Expect(fetched.Spec.NTN.CellSpecificKoffset).To(Equal(150))
+
+			Expect(k8sClient.Delete(context.Background(), fetched)).To(Succeed())
 		})
 	})
 })

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -134,10 +134,19 @@ spec:
                 properties:
                   cellSpecificKoffset:
                     default: 150
-                    description: cellSpecificKoffset sets the cell-specific k-offset
-                      for NTN (0-1023).
+                    description: |-
+                      cellSpecificKoffset is the cell-specific K_offset for NTN scheduling timing
+                      (3GPP TS 38.213 / TS 38.300 §16.14.2). Its unit is milliseconds: OCUDU stores
+                      cell_specific_koffset as std::chrono::milliseconds and converts it to
+                      operating-SCS slots internally, so the value passes through this operator
+                      unchanged with no unit conversion. (3GPP expresses K_offset as a slot count
+                      assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that identity is only
+                      how the IE is defined, not a conversion the user applies here.)
+                      The 3GPP IE cellSpecificKoffset-r17 is INTEGER(0..1023), but OCUDU rejects 0
+                      (its CLI and config validation enforce 1-1023), so Minimum is 1 to mirror the
+                      backend rather than the spec.
                     maximum: 1023
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   distanceThreshold:
                     description: |-

--- a/pkg/provider/ocudu/config.go
+++ b/pkg/provider/ocudu/config.go
@@ -184,7 +184,12 @@ type ntnNeighborCellData struct {
 }
 
 type configData struct {
-	PayloadType               string
+	PayloadType string
+	// Koffset is the cell-specific K_offset in milliseconds. OCUDU stores
+	// cell_specific_koffset as std::chrono::milliseconds and converts to
+	// operating-SCS slots internally, so this value passes through unchanged
+	// (no unit conversion). OCUDU accepts 1-1023 and rejects 0; the 3GPP IE
+	// allows 0..1023, so the CRD's Minimum=1 mirrors OCUDU, not the spec.
 	Koffset                   int
 	TACommon                  int
 	TAInfoExtended            bool


### PR DESCRIPTION
## Summary

Closes #144 — closes the `cellSpecificKoffset` question in the OCUDU `ntn_config` alignment and verifies the rest of the struct.

**The "unit conversion" was a false alarm.** `cell_specific_koffset`'s unit is **milliseconds**. OCUDU stores it as `std::chrono::milliseconds` and converts it to operating-SCS slots *internally*, so the operator passes the integer through unchanged — no conversion. (3GPP expresses K_offset as a slot count assuming the 15 kHz reference SCS, where 1 slot = 1 ms; that is only how the IE is *defined*, not a conversion applied here.)

**The one real schema change is the lower bound.** The 3GPP IE `cellSpecificKoffset-r17` is `INTEGER(0..1023)` and *permits* 0, but OCUDU rejects 0 (its CLI11 schema and config validator both enforce `1..1023`). So `Minimum` is tightened `0 → 1` to mirror the **backend**, not the spec.

This brings the CRD into alignment with **7 of the 8** fields in OCUDU's `ntn_config` struct (`ntnUlSyncValidityDur`, `polarization`, `taReport`, `taInfo.taCommonDrift*`, `epochTime`, `ephemeris*`, `cellSpecificKoffset` — all verified present and correctly rendered by the OCUDU provider). The 8th, `k_mac`, stays intentionally deferred pending upstream OCUDU MR!597 reassessment (tracked in #52).

## Changes

- `Minimum: 0 → 1` on `spec.ntn.cellSpecificKoffset` (base + Helm chart CRD).
- Corrected the field doc to state the unit is milliseconds and that the `1` lower bound mirrors OCUDU, not 3GPP.
- 4 envtest boundary specs: explicit `0` and `1024` rejected, `1` (inclusive lower bound) accepted, omitted value defaults to `150` (documents the `omitempty`/default interaction — only an explicit `0` reaches the `Minimum` check, hence the unstructured object).
- Regenerated `docs/api-reference.md` from the CRD as a pure `crdoc` artifact (dropped a stale hand-added header block that `make docs` would have clobbered).
- `CHANGELOG.md` `[Unreleased]` entry.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- Full non-e2e suite green; controller envtest suite 92 specs pass (4 focused koffset specs: `4 Passed | 0 Failed`).
- The technical claim was cross-checked against the actual OCUDU upstream source (`ntn.h` type/comment, the CLI11 `Range(1U,1023U)` and `du_cell_config_validation.cpp` `1..1023` checks, and the internal `* get_nof_slots_per_subframe(scs)` conversion). The boundary tests were validated as non-false-positives via mutation testing (reverting `Minimum→0`, `Maximum→2000`, `default→99` each fails the corresponding spec).
