### PR TITLE
chore(ci): bump cosign-installer to v4.1.2, pin cosign binary to v2.6.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,15 @@ jobs:
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign BINARY to the latest v2.x. cosign-installer v4 defaults
+          # to cosign v3.x, which flips two defaults on (OCI 1.1 referring-artifact
+          # signatures + the new protobuf bundle format) and would change our
+          # published signature/attestation format vs v0.4.0 and the anonymous
+          # `cosign verify` chain we advertise. Staying on v2.x keeps the release
+          # format-consistent. The deliberate v3 migration is tracked in #148.
+          cosign-release: 'v2.6.3'
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0


### PR DESCRIPTION
Supersedes #136. Takes the dependabot `sigstore/cosign-installer` 3.8.2→4.1.2 action bump, but **pins the cosign binary to v2.6.3** because installer v4 defaults to cosign **v3.0.6**, which changes our published signature/attestation format (OCI 1.1 referring-artifact signatures + new protobuf bundle) vs v0.4.0 and could affect the anonymous `cosign verify` chain we advertise. `release.yml` signing isn't exercised by PR CI (tags/dispatch only), so this keeps v0.5.0 format-consistent with v0.4.0 (cosign v2.4.3→v2.6.3 = same legacy format, latest v2 patches).

The deliberate cosign v3 migration (dry-run sign + anonymous verify on GHCR + release-notes) is tracked in **#148**.

Validated: `hack/check-action-shas.sh` passes (v4.1.2 SHA resolved), release.yml is valid YAML.