### PR TITLE
chore(release): prepare v0.5.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0-rc.1] - 2026-05-27
 
 ### Changed
 
@@ -32,9 +32,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #52); no schema change for it here.
 
 **Dependencies / CI**
+- Bumped the k8s.io stack to **0.36.0** (api, apimachinery, client-go + indirect
+  apiextensions-apiserver / apiserver / component-base) with
+  `sigs.k8s.io/controller-runtime` **0.23.3 → 0.24.1** (#150). controller-runtime
+  0.24 deprecates `controller-runtime/pkg/scheme`, so the api package's scheme
+  registration was migrated to the `k8s.io/apimachinery/pkg/runtime.NewSchemeBuilder`
+  pattern (current kubebuilder v4 scaffold). No CRD/deepcopy or runtime behavior change.
+- Bumped `sigstore/cosign-installer` 3.8.2 → **4.1.2**, with the cosign **binary
+  pinned to `v2.6.3`** (#149). Installer v4 defaults to cosign v3.x, which would
+  change the published signature/attestation format (OCI 1.1 referrers + new
+  protobuf bundle) vs v0.4.0; pinning v2.x keeps the release format-consistent.
+  The deliberate cosign v3 migration is tracked in #148.
 - Bumped `onsi/ginkgo/v2` 2.28.1 → 2.28.2 (#133), `aquasecurity/trivy-action`
-  0.35.0 → 0.36.0 (#127), `docker/login-action` 4.1.0 → 4.2.0 (#145), and Nephio
-  KRM mutators `set-namespace` 0.4.5 / `set-labels` 0.2.4 (#118 / #134).
+  0.35.0 → 0.36.0 (#127), `docker/login-action` 4.1.0 → 4.2.0 (#145),
+  `anchore/sbom-action` 0.18.0 → 0.24.0 (#126, the syft used for the release
+  SBOM), and Nephio KRM mutators `set-namespace` 0.4.5 / `set-labels` 0.2.4
+  (#118 / #134).
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.4.0
+VERSION ?= 0.5.0-rc.1
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -53,18 +53,17 @@ metadata:
     # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
     # / clickhouse 0.26.3 all carry this annotation).
     certified: "false"
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.4.0
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.5.0-rc.1
     repository: https://github.com/thc1006/ntn-operators
     # description: short tile text shown on operatorhub.io marketplace cards.
     # Hard limit is 135 chars per k8s-operatorhub/community-operators
     # packaging-required-fields. Long-form prose lives in spec.description.
     description: "Kubernetes-native NTN: satellite ephemeris, ground station lifecycle, NTN cell config, terrestrial-satellite slice failover."
-    # createdAt: ISO-8601 timestamp of the bundle's published release. Tracks
-    # the v0.4.0 GitHub Release publish time (release.yml run 24963575814,
-    # 2026-04-26T18:12:49Z UTC). Bump on every version cut.
-    createdAt: "2026-04-26T18:12:49Z"
+    # createdAt: ISO-8601 timestamp of the bundle's published release.
+    # Bump on every version cut (approximate; set at release-prep time).
+    createdAt: "2026-05-26T23:48:50Z"
     support: thc1006
-  name: ntn-operators.v0.4.0
+  name: ntn-operators.v0.5.0-rc.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -151,7 +150,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.4.0
+                    image: ghcr.io/thc1006/ntn-operators:v0.5.0-rc.1
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -227,5 +226,5 @@ spec:
   # point OLM at a CSV it cannot find, failing the install. skipRange
   # says "this CSV can take over from anything older than itself" and
   # is safe whether or not an older CSV exists in the catalog.
-  skipRange: "<0.4.0"
-  version: 0.4.0
+  skipRange: "<0.5.0-rc.1"
+  version: 0.5.0-rc.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.4.0
+  newTag: v0.5.0-rc.1

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0-rc.1
+appVersion: "0.5.0-rc.1"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.4.0` | Image tag |
+| `manager.image.tag` | string | `v0.5.0-rc.1` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.4.0
+    tag: v0.5.0-rc.1
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
Release-prep for **v0.5.0-rc.1**. Bumps version strings to 0.5.0-rc.1 (Makefile, Helm chart version/appVersion + image tags, manager kustomization, OLM CSV name/version/containerImage/deployment-image/skipRange/createdAt) and finalizes the CHANGELOG section, which now covers the three substantive v0.5 changes: cellSpecificKoffset OCUDU alignment (#144), cosign-installer v4.1.2 + cosign v2.6.3 pin (#149), and k8s.io 0.36 + controller-runtime 0.24.1 (#150).

After this merges: dry-run `release.yml` (build-scan), then tag `v0.5.0-rc.1` to publish+sign the rc (validating the new cosign pipeline on a pre-release artifact). README "Latest release" stays at v0.4.0 until the final promote.