### PR TITLE
fix(ci): bump Go toolchain 1.26.2 → 1.26.3 to clear HIGH stdlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/test-metrics-exporter/Dockerfile
+++ b/cmd/test-metrics-exporter/Dockerfile
@@ -1,6 +1,6 @@
 # Synthetic Prometheus exporter for NTNSlice E2E tests.
 # Build locally with: docker build -t test-metrics-exporter:latest -f cmd/test-metrics-exporter/Dockerfile .
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26.3-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thc1006/ntn-operators
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/akhenakh/sgp4 v0.0.0-20260314155803-8ee03fc877eb


### PR DESCRIPTION
The **v0.5.0-rc.1 release dry-run** failed Trivy's HIGH gate: Go 1.26.2 stdlib has 5 HIGH CVEs (CVE-2026-33811/33814/39820/39836/42499), all **fixed in Go 1.26.3**. All workflows use `go-version-file: go.mod`, so bumping the go directive rebuilds the release binary on the patched stdlib. No source change; build/vet/full non-e2e suite pass on 1.26.3 locally. Required before tagging v0.5.0-rc.1.