### PR TITLE
ci: add OLM bundle CRD drift gate + sync stale ntnslices CRD (#147)

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - 'dist/chart/**'
+      - 'bundle/**'
       - 'config/crd/**'
       - 'Makefile'
       - '.github/workflows/**'
   pull_request:
     paths:
       - 'dist/chart/**'
+      - 'bundle/**'
       - 'config/crd/**'
       - 'Makefile'
       - '.github/workflows/**'
@@ -26,6 +28,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Fail fast (before the heavy Go/Kind setup) if the OLM bundle CRDs
+      # have drifted from config/crd/bases/. Mirrors nephio-verify-sync;
+      # catches the gap that shipped a stale bundle CRD before #147.
+      - name: Verify OLM bundle CRDs are in sync (drift check)
+        run: make bundle-verify-sync
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,18 @@ bundle: manifests ## Sync CRDs into OLM bundle manifests.
 	done
 	cp config/crd/bases/*.yaml bundle/manifests/
 
+.PHONY: bundle-verify-sync
+bundle-verify-sync: ## Verify OLM bundle CRD copies match config/crd/bases/ (CI drift check).
+	@set -e; \
+	SRC=config/crd/bases; DST=bundle/manifests; drift=0; \
+	for src in $$SRC/ntn.operators.dev_*.yaml; do \
+	  base=$$(basename "$$src"); \
+	  if ! diff -q "$$src" "$$DST/$$base" >/dev/null 2>&1; then \
+	    echo "DRIFT: $$DST/$$base differs from $$src (run 'make bundle')"; drift=1; \
+	  fi; \
+	done; \
+	if [ $$drift -eq 0 ]; then echo "OLM bundle CRDs are in sync with config/crd/bases/"; else exit 1; fi
+
 .PHONY: bundle-build
 bundle-build: bundle ## Build the OLM bundle image.
 	$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -120,6 +120,69 @@ spec:
                 required:
                 - triggers
                 type: object
+              metricsSource:
+                description: |-
+                  metricsSource selects where the failover engine reads path quality
+                  metrics (RSRP, latency, packet loss) from. When omitted, the
+                  controller falls back to annotation-driven simulation for backward
+                  compatibility with existing development deployments.
+                properties:
+                  prometheus:
+                    description: |-
+                      prometheus configures the Prometheus HTTP API backend.
+                      Required when type is 'prometheus'.
+                    properties:
+                      endpoint:
+                        description: endpoint is the base URL of the Prometheus HTTP
+                          API.
+                        minLength: 1
+                        pattern: ^https?://
+                        type: string
+                      queries:
+                        description: queries holds the PromQL expressions for each
+                          observable metric.
+                        properties:
+                          latencyMs:
+                            description: latencyMs is a PromQL expression returning
+                              a scalar in milliseconds.
+                            type: string
+                          packetLossPercent:
+                            description: |-
+                              packetLossPercent is a PromQL expression returning a scalar in
+                              percent (0-100).
+                            type: string
+                          rsrpDbm:
+                            description: rsrpDbm is a PromQL expression returning
+                              a scalar in dBm.
+                            type: string
+                        type: object
+                      queryTimeout:
+                        description: |-
+                          queryTimeout limits the wall-clock time spent on each individual
+                          PromQL fetch; the controller issues up to three fetches per
+                          reconcile (one per metric), so the upper bound for a Read is
+                          roughly 3x this value. Defaults to 2s when unset.
+                        format: duration
+                        type: string
+                    required:
+                    - endpoint
+                    - queries
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one query must be non-empty
+                      rule: size(self.queries.rsrpDbm) > 0 || size(self.queries.latencyMs)
+                        > 0 || size(self.queries.packetLossPercent) > 0
+                  type:
+                    default: annotations
+                    description: type is the backend kind.
+                    enum:
+                    - annotations
+                    - prometheus
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: prometheus block is required when type is 'prometheus'
+                  rule: self.type != 'prometheus' || has(self.prometheus)
               qosMapping:
                 description: qosMapping defines QoS parameter mapping between paths.
                 properties:


### PR DESCRIPTION
Closes #147. Adds `make bundle-verify-sync` (mirrors `nephio-verify-sync`) and wires it as a fail-fast step in the Test Chart workflow (+ `bundle/**` triggers). Closes the gap that let a stale OLM bundle CRD slip past CI on #146 (caught only by Copilot).

The gate immediately surfaced **pre-existing drift**: the bundle `ntnslices` CRD was missing the `metricsSource` field (v0.4 #67) — the OLM bundle had been shipping a stale NTNSlice CRD. Re-synced from `config/crd/bases`.

Verified locally: gate exits 0 in-sync, exits non-zero on injected drift (mutation-tested).