### PR TITLE
chore(release): promote v0.5.0-rc.1 to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-27
+
+Promotion of `0.5.0-rc.1` after a short soak. No CRD, controller, or
+signing-format change vs rc.1; the rc validated the full publish + anonymous
+`cosign verify` / `verify-attestation` chain (Rekor logIndex 1635906087),
+multi-arch (amd64+arm64), and Helm OCI push. The OLM CSV now declares
+`replaces: ntn-operators.v0.4.0` (v0.4.0 is published on OperatorHub) in place
+of the rc's `skipRange`.
+
 ## [0.5.0-rc.1] - 2026-05-27
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.5.0-rc.1
+VERSION ?= 0.5.0
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Kubernetes-native management framework for Non-Terrestrial Networks (NTN). Declaratively manage satellite constellations, ground stations, NTN cell configurations, and terrestrial-satellite failover — all through standard Kubernetes CRDs.
 
-> **Latest release:** [v0.4.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.4.0) — Nephio R6 kpt package integration, Kptfile `@sha256:` digest pinning + T15 supply-chain validator, OWASP private-host allowlist for Prometheus endpoints, and reconciler 304 status fix. See [CHANGELOG.md](CHANGELOG.md) for the full v0.4.0-rc.1 → 0.4.0 delta.
+> **Latest release:** [v0.5.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.5.0) — NTNCellConfig `cellSpecificKoffset` aligned to OCUDU's accepted range (1-1023), k8s.io 0.36 + controller-runtime 0.24.1, Go 1.26.3 toolchain (HIGH stdlib CVE fixes), and an OLM bundle-CRD drift gate. See [CHANGELOG.md](CHANGELOG.md) for the full delta.
 
 ## Custom Resource Definitions
 

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
     # / clickhouse 0.26.3 all carry this annotation).
     certified: "false"
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.5.0-rc.1
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.5.0
     repository: https://github.com/thc1006/ntn-operators
     # description: short tile text shown on operatorhub.io marketplace cards.
     # Hard limit is 135 chars per k8s-operatorhub/community-operators
@@ -61,9 +61,9 @@ metadata:
     description: "Kubernetes-native NTN: satellite ephemeris, ground station lifecycle, NTN cell config, terrestrial-satellite slice failover."
     # createdAt: ISO-8601 timestamp of the bundle's published release.
     # Bump on every version cut (approximate; set at release-prep time).
-    createdAt: "2026-05-26T23:48:50Z"
+    createdAt: "2026-05-27T01:04:15Z"
     support: thc1006
-  name: ntn-operators.v0.5.0-rc.1
+  name: ntn-operators.v0.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -150,7 +150,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.5.0-rc.1
+                    image: ghcr.io/thc1006/ntn-operators:v0.5.0
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -220,11 +220,10 @@ spec:
   provider:
     name: ntn-operators
     url: https://github.com/thc1006/ntn-operators
-  # skipRange, not replaces: no v0.1.0 CSV was ever published to an
-  # OperatorHub catalog (the bundle infrastructure landed in PR #91,
-  # after the v0.1.0 tag). An explicit `replaces:` would therefore
-  # point OLM at a CSV it cannot find, failing the install. skipRange
-  # says "this CSV can take over from anything older than itself" and
-  # is safe whether or not an older CSV exists in the catalog.
-  skipRange: "<0.5.0-rc.1"
-  version: 0.5.0-rc.1
+  # replaces (not skipRange): v0.4.0 is published on OperatorHub
+  # (community-operators#8018, merged 2026-04-27), so this CSV declares an
+  # explicit upgrade edge from it. v0.4.0 itself used skipRange only because
+  # no v0.1.0 CSV was ever cataloged; that no longer applies now that a real
+  # predecessor CSV (ntn-operators.v0.4.0) exists in the catalog.
+  replaces: ntn-operators.v0.4.0
+  version: 0.5.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.5.0-rc.1
+  newTag: v0.5.0

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.5.0-rc.1
-appVersion: "0.5.0-rc.1"
+version: 0.5.0
+appVersion: "0.5.0"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.5.0-rc.1` | Image tag |
+| `manager.image.tag` | string | `v0.5.0` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.5.0-rc.1
+    tag: v0.5.0
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
Promotes **v0.5.0-rc.1 → v0.5.0** after a short soak (rc validated the full publish + anonymous cosign verify chain, Rekor logIndex 1635906087, multi-arch, Helm OCI). Bumps version strings 0.5.0-rc.1 → 0.5.0 across Makefile/chart/kustomization/CSV, adds CHANGELOG `[0.5.0]`, points README at v0.5.0.

⚠️ **One decision to review — OLM upgrade graph:** the CSV switches from `skipRange: "<0.5.0-rc.1"` to **`replaces: ntn-operators.v0.4.0`**. Rationale: v0.4.0 is now published on OperatorHub (community-operators#8018), so an explicit upgrade edge from it is the correct/standard pattern (the old skipRange-only rationale was "no cataloged predecessor", which no longer holds). This only affects the eventual OperatorHub submission, not the release tag itself.

After this merges I'll tag `v0.5.0` → release pipeline → verify (this run *does* move GHCR `latest` to the final).