### PR TITLE
fix(controller): count FailoverTotal only after the status write persists

### DIFF
--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -249,14 +249,19 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		ntnmetrics.SatellitePassAvailable.With(passLabels).Set(0)
 	}
 
+	// The FailoverTotal counter increment is deferred until after the status write
+	// (Step 8) persists, so a stale/conflicting reconcile that fails to record the
+	// failover cannot double-count it. Stays nil unless this reconcile fails over.
+	var failoverLabels prometheus.Labels
+
 	switch result.Decision {
 	case slice.DecisionFailover:
 		ns.Status.FailoverCount++
 		ns.Status.LastFailover = &metav1.Time{Time: now}
-		ntnmetrics.FailoverTotal.With(prometheus.Labels{
+		failoverLabels = prometheus.Labels{
 			"namespace": ns.Namespace, "slice": ns.Name,
 			"from_path": previousPath, "to_path": string(result.TargetPath),
-		}).Inc()
+		}
 		log.Info("Failover triggered", "from", previousPath, "to", result.TargetPath, "reason", result.Reason)
 		if r.Recorder != nil {
 			r.Recorder.Eventf(ns, nil, "Warning", "FailoverTriggered", "FailoverTriggered",
@@ -305,6 +310,14 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Step 8: Update status.
 	if err := r.Status().Update(ctx, ns); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Emit the failover counter only after the status write persisted, so a
+	// conflicting/stale reconcile (which discards its status update) never counts
+	// a failover it did not actually record — keeping FailoverTotal in step with
+	// status.FailoverCount.
+	if failoverLabels != nil {
+		ntnmetrics.FailoverTotal.With(failoverLabels).Inc()
 	}
 
 	return ctrl.Result{RequeueAfter: sliceRequeueInterval}, nil

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -198,6 +198,15 @@ var _ = Describe("NTNSlice Controller", func() {
 				_ = k8sClient.Delete(context.Background(), eph)
 			})
 
+			// Capture FailoverTotal before reconcile and assert a +1 delta,
+			// so the check is independent of any other spec that fails over
+			// on the same series under -ginkgo.randomize-all.
+			counterLabels := prometheus.Labels{
+				"namespace": namespace, "slice": sliceName,
+				"from_path": "terrestrial", "to_path": pathSatellite,
+			}
+			before := testutil.ToFloat64(ntnmetrics.FailoverTotal.With(counterLabels))
+
 			reconciler := newReconciler()
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -209,6 +218,10 @@ var _ = Describe("NTNSlice Controller", func() {
 			Expect(updated.Status.ActivePathType).To(Equal(pathSatellite))
 			Expect(updated.Status.FailoverCount).To(Equal(1))
 			Expect(updated.Status.LastFailover).NotTo(BeNil())
+			// The deferred FailoverTotal.Inc() must have fired, now that the
+			// status write persisted — guards the Inc ordering end-to-end.
+			Expect(testutil.ToFloat64(ntnmetrics.FailoverTotal.With(counterLabels))).
+				To(Equal(before + 1))
 		})
 	})
 

--- a/internal/controller/ntnslice_failover_metric_test.go
+++ b/internal/controller/ntnslice_failover_metric_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+)
+
+// TestReconcile_FailoverCounterNotIncrementedOnStatusConflict proves the
+// FailoverTotal counter is emitted ONLY after the status write persists.
+//
+// A stale reconcile (its cached copy behind a fresher one's status write) can
+// still re-decide DecisionFailover, but its own Status().Update then loses the
+// optimistic-concurrency race and is discarded. If the counter were bumped
+// inline in the switch, that discarded reconcile would count a failover it
+// never persisted, drifting FailoverTotal +1 above status.FailoverCount.
+//
+// We reproduce that exact interleaving by forcing Status().Update to return a
+// Conflict, and assert the counter does not move.
+func TestReconcile_FailoverCounterNotIncrementedOnStatusConflict(t *testing.T) {
+	const (
+		nsName    = "default"
+		sliceName = "failover-conflict"
+		ephName   = "oneweb-constellation"
+	)
+	// Fixed to sit inside the pass window below (AOS 11:00 <= now < LOS 13:00),
+	// so checkSatelliteAvailability reports the satellite path as available.
+	now := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+
+	slice := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sliceName,
+			Namespace: nsName,
+			Annotations: map[string]string{
+				// Degraded terrestrial signal → the "rsrp < -120" trigger fires.
+				"ntn.operators.dev/simulated-rsrp":        "-130",
+				"ntn.operators.dev/simulated-latency":     "20",
+				"ntn.operators.dev/simulated-packet-loss": "0.1",
+			},
+		},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant: "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{
+				Provider: "chunghwa-telecom", APN: "internet", Priority: "primary",
+			},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: ephName,
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers: []string{"rsrp < -120", "latency > 200", "packetLoss > 5"},
+			},
+		},
+	}
+	// Read-only for the reconciler, so it need not be a status subresource;
+	// its WithObjects status (the pass window) is preserved for Get.
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: ephName, Namespace: nsName},
+		Status: ntnv1alpha1.SatelliteEphemerisStatus{
+			SatelliteCount: 651,
+			NextPassWindows: []ntnv1alpha1.PassWindow{
+				{
+					Satellite:     "ONEWEB-0012",
+					GroundStation: "gs-taipei-01",
+					AOS:           metav1.Time{Time: time.Date(2026, 4, 17, 11, 0, 0, 0, time.UTC)},
+					LOS:           metav1.Time{Time: time.Date(2026, 4, 17, 13, 0, 0, 0, time.UTC)},
+					MaxElevation:  "45.0",
+				},
+			},
+		},
+	}
+
+	sch := makeScheme(t)
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(slice, eph).
+		WithStatusSubresource(slice).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Simulate the fresher reconcile having already advanced the
+			// resourceVersion: this stale reconcile's status write conflicts.
+			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: "ntn.operators.dev", Resource: "ntnslices"},
+					sliceName, errors.New("stale revision"))
+			},
+		}).
+		Build()
+
+	labels := prometheus.Labels{
+		"namespace": nsName, "slice": sliceName,
+		"from_path": "terrestrial", "to_path": "satellite",
+	}
+	before := testutil.ToFloat64(ntnmetrics.FailoverTotal.With(labels))
+
+	recorder := events.NewFakeRecorder(10)
+	r := &NTNSliceReconciler{
+		Client:   cli,
+		Scheme:   sch,
+		Recorder: recorder,
+		Now:      func() time.Time { return now },
+	}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: sliceName, Namespace: nsName},
+	})
+	// The conflict on the status write must surface so controller-runtime
+	// re-reconciles from a fresh cache; it must not be swallowed.
+	if err == nil {
+		t.Fatal("expected the status-update conflict to surface as a reconcile error")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected a Conflict error, got: %v", err)
+	}
+	// Positive control: FailoverTriggered is emitted in the DecisionFailover
+	// branch, before the (discarded) status write. Its presence proves the
+	// reconcile actually decided to fail over — otherwise "counter unchanged"
+	// would pass vacuously even if the setup never reached a failover.
+	select {
+	case ev := <-recorder.Events:
+		if !strings.Contains(ev, "FailoverTriggered") {
+			t.Fatalf("expected a FailoverTriggered event, got: %q", ev)
+		}
+	default:
+		t.Fatal("no event emitted: the reconcile never reached the failover decision, so the counter assertion would be vacuous")
+	}
+	// The failover was never persisted, so the counter must not have moved.
+	if got := testutil.ToFloat64(ntnmetrics.FailoverTotal.With(labels)); got != before {
+		t.Errorf("FailoverTotal moved on a discarded failover: before=%v after=%v (want unchanged)", before, got)
+	}
+}


### PR DESCRIPTION
## Problem
`FailoverTotal` (a `CounterVec`) was `Inc()`'d **inline** in the `DecisionFailover` switch case — *before* Step 8's `Status().Update`. A stale reconcile racing a fresher one can re-decide `DecisionFailover` off a behind-cache copy, `Inc` the counter, then lose the optimistic-concurrency race at `Status().Update` and discard its whole status update. Result: `FailoverTotal` drifts **+1** above the `status.FailoverCount` it is meant to mirror.

Surfaced by the **PR #181 post-merge audit** — pre-existing, low-severity, but a genuine counter/state divergence.

## Fix
Defer the `Inc`: capture the label set in the switch, emit it **only after** `Status().Update` returns `nil`. A discarded reconcile therefore never counts a failover it did not persist.

- `status.FailoverCount++` stays in the switch — persisted-or-discarded **atomically** with the counter (both now gated on the same single `Status().Update`).
- `SatellitePassAvailable` (a `Gauge`) stays **inline** on purpose — a `Set` is idempotent and self-heals on the next reconcile, unlike an accumulating counter.

## Tests
- **Happy path:** the envtest failover spec now asserts `FailoverTotal` increments — **delta-based** (`before+1`), so it's order-independent under `-ginkgo.randomize-all`. Nothing previously guarded this `Inc`.
- **Failure path (the actual point of the fix):** a fake-client unit test forces a `Status().Update` conflict and asserts the counter does **not** move. A `FailoverTriggered`-event positive control proves the reconcile genuinely reached the failover decision, so the "unchanged" assertion can't pass vacuously.

## Verification
`go build` / `go vet` clean · full controller + `pkg/metrics` suite green · `golangci-lint` v2.11.4 → 0 issues.