### PR TITLE
fix(metrics): namespace-key ntn_operators_gp_satellite_count (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ real OCUDU gNB (commit `0b229d35`).
   same-named CRs/refs across namespaces (and, for the counter, wiped them on
   delete). PromQL that groups by the existing labels still works; add `namespace`
   to dashboards for per-CR accuracy.
+- `ntn_operators_gp_satellite_count` gains a `namespace` label (#180), mirroring
+  the #178 fix for the SatelliteEphemeris controller. SatelliteEphemeris is
+  namespaced, so keying by `ephemeris` (the CR name) alone conflated same-named
+  CRs across namespaces and, on delete, the NotFound cleanup wiped the other
+  namespace's series (self-healing only at the next ≥2 h GP refresh). The Grafana
+  dashboard legend is now `{{namespace}}/{{ephemeris}}`.
 
 ### Notes
 
@@ -87,9 +93,11 @@ real OCUDU gNB (commit `0b229d35`).
 - The NTNSlice `metrics-cleanup` finalizer means `kubectl delete ntnslice` now
   completes only after the operator reconciles the deletion; a slice stays
   `Terminating` while the operator is down (standard finalizer behavior).
-- Known follow-up (tracked, #180): `ntn_operators_gp_satellite_count`
-  (SatelliteEphemeris controller) has the same cross-namespace conflation #178
-  fixed for the NTNSlice metrics; deferred as a separate controller/scope.
+- Known follow-up (tracked, #183): `ntn_operators_config_apply_errors_total`
+  (NTNCellConfig) and `ntn_operators_ground_station_health`
+  (GroundStationLifecycle) still key per-CR series by name only and have the same
+  cross-namespace conflation #180 fixed for `gp_satellite_count`; deferred as
+  separate controllers/scope.
 
 ## [0.5.0] - 2026-05-27
 

--- a/config/grafana/ntn-operators-dashboard.json
+++ b/config/grafana/ntn-operators-dashboard.json
@@ -128,7 +128,7 @@
       "targets": [
         {
           "expr": "ntn_operators_gp_satellite_count",
-          "legendFormat": "{{ephemeris}}"
+          "legendFormat": "{{namespace}}/{{ephemeris}}"
         }
       ]
     },

--- a/internal/controller/metric_cleanup_test.go
+++ b/internal/controller/metric_cleanup_test.go
@@ -42,8 +42,8 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 		t.Fatalf("AddToScheme: %v", err)
 	}
 
-	// Seed a per-CR series, as a live reconcile would.
-	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"ephemeris": "deleted-eph"}).Set(7)
+	// Seed a per-CR series, as a live reconcile would (keyed by namespace+name).
+	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph"}).Set(7)
 	before := testutil.CollectAndCount(ntnmetrics.GPSatelliteCount)
 
 	// Empty client → Get returns NotFound (the CR is "deleted").
@@ -63,5 +63,46 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 	if after != before-1 {
 		t.Errorf("deleted CR's metric series was not released: series count before=%d after=%d (want after=before-1)",
 			before, after)
+	}
+}
+
+// TestSatelliteEphemerisReconcile_DeletedDoesNotWipeOtherNamespace is the #180
+// regression guard: SatelliteEphemeris is namespaced, so two CRs with the SAME
+// name in DIFFERENT namespaces own distinct GPSatelliteCount series. Deleting
+// one must release only its own {namespace,ephemeris} series and leave the
+// other intact. Before the namespace label, the {ephemeris}-only
+// DeletePartialMatch wiped both (self-healing only at the next ≥2h refresh).
+func TestSatelliteEphemerisReconcile_DeletedDoesNotWipeOtherNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	const name = "oneweb-constellation"
+	deleted := prometheus.Labels{"namespace": "team-a", "ephemeris": name}
+	survivor := prometheus.Labels{"namespace": "team-b", "ephemeris": name}
+	ntnmetrics.GPSatelliteCount.With(deleted).Set(651)
+	ntnmetrics.GPSatelliteCount.With(survivor).Set(648)
+
+	// Reconcile a NotFound for team-a's CR (it was deleted).
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SatelliteEphemerisReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: events.NewFakeRecorder(10),
+	}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "team-a"},
+	}); err != nil {
+		t.Fatalf("reconcile of deleted CR should not error: %v", err)
+	}
+
+	// team-a's series must be released (a fresh read re-creates it at 0)...
+	if got := testutil.ToFloat64(ntnmetrics.GPSatelliteCount.With(deleted)); got != 0 {
+		t.Errorf("team-a series not released: got %v, want 0", got)
+	}
+	// ...but team-b's same-named series in another namespace must survive.
+	if got := testutil.ToFloat64(ntnmetrics.GPSatelliteCount.With(survivor)); got != 648 {
+		t.Errorf("deleting team-a wiped team-b's series (cross-namespace conflation): got %v, want 648", got)
 	}
 }

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -78,7 +78,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if apierrors.IsNotFound(err) {
 			// CR deleted — release its per-CR metric series so /metrics does not
 			// accumulate dead series across create/delete churn.
-			ntnmetrics.GPSatelliteCount.DeletePartialMatch(prometheus.Labels{"ephemeris": req.Name})
+			ntnmetrics.GPSatelliteCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -138,7 +138,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// second reconcile.
 	eph.Status.SatelliteCount = result.SatelliteCount
 	eph.Status.LastUpdated = &metav1.Time{Time: result.FetchedAt}
-	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
+	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
 
 	if result.NotModified {
 		log.Info("GP data unchanged (304 Not Modified)", "satelliteCount", result.SatelliteCount)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -76,12 +76,15 @@ var (
 	)
 
 	// GPSatelliteCount reports the number of satellites in the latest GP fetch.
+	// Keyed by namespace+ephemeris: SatelliteEphemeris is namespaced, so the same
+	// CR name in two namespaces is two distinct resources and must not share a
+	// series (nor wipe each other's on delete). Mirrors the #178 namespace fix.
 	GPSatelliteCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ntn_operators_gp_satellite_count",
 			Help: "Number of satellites from the latest GP fetch.",
 		},
-		[]string{"ephemeris"},
+		[]string{"namespace", "ephemeris"},
 	)
 
 	// ReaderQueryDuration measures how long a single PromQL fetch made

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -31,7 +31,7 @@ func TestMetricsRegistered(t *testing.T) {
 	GroundStationHealth.With(prometheus.Labels{"station": "_", "condition": "_"}).Set(0)
 	ConfigApplyErrorsTotal.With(prometheus.Labels{"config": "_", "provider": "_"}).Add(0)
 	GPFetchDuration.With(prometheus.Labels{"source_type": "_", "status": "_"}).Observe(0)
-	GPSatelliteCount.With(prometheus.Labels{"ephemeris": "_"}).Set(0)
+	GPSatelliteCount.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
 	ReaderQueryDuration.With(prometheus.Labels{"source": "_", "outcome": "_"}).Observe(0)
 	ReaderErrorsTotal.With(prometheus.Labels{"source": "_", "reason": "_"}).Add(0)
 	ReaderStaleUsedTotal.With(prometheus.Labels{"namespace": "_", "name": "_"}).Add(0)
@@ -80,10 +80,11 @@ func TestFailoverTotalIncrement(t *testing.T) {
 }
 
 func TestGPSatelliteCountGauge(t *testing.T) {
-	GPSatelliteCount.With(prometheus.Labels{"ephemeris": "oneweb"}).Set(651)
+	labels := prometheus.Labels{"namespace": "test-ns", "ephemeris": "oneweb"}
+	GPSatelliteCount.With(labels).Set(651)
 
 	m := &dto.Metric{}
-	if err := GPSatelliteCount.With(prometheus.Labels{"ephemeris": "oneweb"}).Write(m); err != nil {
+	if err := GPSatelliteCount.With(labels).Write(m); err != nil {
 		t.Fatal(err)
 	}
 	if m.GetGauge().GetValue() != 651 {


### PR DESCRIPTION
Closes #180.

## Problem
`ntn_operators_gp_satellite_count` (`GPSatelliteCount`, a `GaugeVec`) was keyed `{ephemeris}` only, using the SatelliteEphemeris CR's **name**. SatelliteEphemeris is **namespaced**, so two same-named CRs in different namespaces:
- **conflated** into one series (last-writer-wins), and
- on deletion of one, the NotFound cleanup `DeletePartialMatch{ephemeris: req.Name}` **wiped the other namespace's series** too (self-heals only at the next ≥2h GP refresh).

Exactly the class #178/#181 fixed for the two NTNSlice metrics; #180 was tracked as the deferred SatelliteEphemeris sibling.

## Fix
Re-key to `{namespace, ephemeris}`:
- `Set` uses `eph.Namespace` (`satelliteephemeris_controller.go:141`)
- NotFound cleanup uses `req.Namespace` (`:81`)

This is **per-CR** — each SatelliteEphemeris owns its `{namespace,name}` series, so a direct `DeletePartialMatch` with **no refcount** is correct (mirrors the `FailoverTotal` half of #181, not the shared `SatellitePassAvailable` half). Grafana dashboard legend → `{{namespace}}/{{ephemeris}}`.

## Tests
- `TestMetricsRegistered` + `TestGPSatelliteCountGauge` updated for the new label.
- **New** `TestSatelliteEphemerisReconcile_DeletedDoesNotWipeOtherNamespace`: seeds two same-named CRs in `team-a`/`team-b`, reconciles a NotFound for `team-a`, asserts `team-a` released **and `team-b` survives**. Fails without the fix (the `{ephemeris}`-only delete wiped both).

## Scope / follow-up
Adversarial review (GO) flagged two sibling metrics with the identical name-only conflation on namespaced CRDs — `ConfigApplyErrorsTotal` (NTNCellConfig) and `GroundStationHealth` (GroundStationLifecycle). Out of #180's scope; filed as **#183**.

## Verification
`go build`/`go vet` clean · `golangci-lint` v2.11.4 → 0 issues · full controller + `pkg/metrics` suite green · dashboard JSON valid.