### PR TITLE
fix(dashboard): namespace-qualify Grafana legends for namespaced metrics

### DIFF
--- a/config/grafana/ntn-operators-dashboard.json
+++ b/config/grafana/ntn-operators-dashboard.json
@@ -19,8 +19,8 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(ntn_operators_failover_total[5m])) by (slice, to_path)",
-          "legendFormat": "{{slice}} -> {{to_path}}"
+          "expr": "sum(rate(ntn_operators_failover_total[5m])) by (namespace, slice, to_path)",
+          "legendFormat": "{{namespace}}/{{slice}} -> {{to_path}}"
         }
       ]
     },
@@ -36,7 +36,7 @@
       "targets": [
         {
           "expr": "ntn_operators_satellite_pass_available",
-          "legendFormat": "{{ephemeris}}"
+          "legendFormat": "{{namespace}}/{{ephemeris}}"
         }
       ],
       "fieldConfig": {


### PR DESCRIPTION
Post-merge consistency audit (after #178/#180/#184 added `namespace` labels) found two Grafana panels still keyed per-CR-name without namespace:

- **"Failover Events"** — `sum(rate(ntn_operators_failover_total[5m])) by (slice, to_path)` summed same-named slices **across namespaces** into one wrong series (a live query bug, not just cosmetics). Now `by (namespace, slice, to_path)`, legend `{{namespace}}/{{slice}} -> {{to_path}}`.
- **"Satellite Pass Availability"** — legend `{{ephemeris}}` → `{{namespace}}/{{ephemeris}}`; two same-named ephemerides in different namespaces are otherwise indistinguishable.

Both metrics already carry `namespace` (from #178); this just makes the dashboard reflect it — mirroring the legend fix #184 applied to `gp_satellite_count`. JSON validated (`jq`).

The two remaining name-only metrics (`config_apply_errors_total`, `ground_station_health`) plus their dashboard panels are tracked in **#183** (they need the code label first, else the legends render blank).