### PR TITLE
fix(metrics): namespace-key GroundStationHealth + ConfigApplyErrorsTotal, fix GS series leak (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,18 @@ real OCUDU gNB (commit `0b229d35`).
   CRs across namespaces and, on delete, the NotFound cleanup wiped the other
   namespace's series (self-healing only at the next ≥2 h GP refresh). The Grafana
   dashboard legend is now `{{namespace}}/{{ephemeris}}`.
+- `ntn_operators_ground_station_health` and `ntn_operators_config_apply_errors_total`
+  gain a `namespace` label (#183) — both CRDs are namespaced, so keying by
+  `station`/`config` (the CR name) alone conflated same-named CRs across
+  namespaces. **GroundStationHealth additionally leaked a series on every
+  GroundStation deletion**: the write used a composite `station="<ns>.<name>"`
+  whose bare-`name` delete never matched — now fixed (plain `station` + a real
+  `namespace` label, so the delete matches). Grafana legends/queries updated to
+  include `{{namespace}}`.
+- `ntn_operators_reader_stale_value_used_total` is now released on NTNSlice
+  deletion even when the reconciler falls back to the lazily-built default metrics
+  provider — the NotFound evict was previously guarded on the explicit
+  `ReaderProvider` field and leaked the series in that (non-production) config (#183).
 
 ### Notes
 
@@ -93,11 +105,6 @@ real OCUDU gNB (commit `0b229d35`).
 - The NTNSlice `metrics-cleanup` finalizer means `kubectl delete ntnslice` now
   completes only after the operator reconciles the deletion; a slice stays
   `Terminating` while the operator is down (standard finalizer behavior).
-- Known follow-up (tracked, #183): `ntn_operators_config_apply_errors_total`
-  (NTNCellConfig) and `ntn_operators_ground_station_health`
-  (GroundStationLifecycle) still key per-CR series by name only and have the same
-  cross-namespace conflation #180 fixed for `gp_satellite_count`; deferred as
-  separate controllers/scope.
 
 ## [0.5.0] - 2026-05-27
 

--- a/config/grafana/ntn-operators-dashboard.json
+++ b/config/grafana/ntn-operators-dashboard.json
@@ -86,7 +86,7 @@
       "targets": [
         {
           "expr": "ntn_operators_ground_station_health",
-          "legendFormat": "{{station}} / {{condition}}",
+          "legendFormat": "{{namespace}}/{{station}} / {{condition}}",
           "format": "table",
           "instant": true
         }
@@ -143,8 +143,8 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(ntn_operators_config_apply_errors_total[5m])) by (config, provider)",
-          "legendFormat": "{{config}} ({{provider}})"
+          "expr": "sum(rate(ntn_operators_config_apply_errors_total[5m])) by (namespace, config, provider)",
+          "legendFormat": "{{namespace}}/{{config}} ({{provider}})"
         }
       ]
     },

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -103,7 +103,7 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	if err := r.Get(ctx, req.NamespacedName, gs); err != nil {
 		if apierrors.IsNotFound(err) {
 			// CR deleted — release its per-CR metric series (all conditions).
-			ntnmetrics.GroundStationHealth.DeletePartialMatch(prometheus.Labels{"station": req.Name})
+			ntnmetrics.GroundStationHealth.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "station": req.Name})
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -138,8 +138,8 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}
 
-	// Step 6: Update health metrics.
-	stationKey := gs.Namespace + "." + gs.Name
+	// Step 6: Update health metrics (keyed by namespace+station — see #183; the
+	// old composite `station=namespace.name` value made the bare-name delete miss).
 	for _, condType := range []string{
 		ntnv1alpha1.ConditionK8sNodeReady,
 		ntnv1alpha1.ConditionAntennaReady,
@@ -156,7 +156,7 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 			}
 		}
 		ntnmetrics.GroundStationHealth.With(prometheus.Labels{
-			"station": stationKey, "condition": condType,
+			"namespace": gs.Namespace, "station": gs.Name, "condition": condType,
 		}).Set(val)
 	}
 

--- a/internal/controller/metric_cleanup_test.go
+++ b/internal/controller/metric_cleanup_test.go
@@ -19,9 +19,11 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -104,5 +106,155 @@ func TestSatelliteEphemerisReconcile_DeletedDoesNotWipeOtherNamespace(t *testing
 	// ...but team-b's same-named series in another namespace must survive.
 	if got := testutil.ToFloat64(ntnmetrics.GPSatelliteCount.With(survivor)); got != 648 {
 		t.Errorf("deleting team-a wiped team-b's series (cross-namespace conflation): got %v, want 648", got)
+	}
+}
+
+// TestGroundStationReconcile_DeletedReleasesAndIsolatesNamespace is the #183
+// regression guard for the GroundStationHealth DELETE key: two same-named
+// GroundStationLifecycle CRs in different namespaces own distinct series, and
+// deleting one must release only its own {namespace,station,condition} series and
+// leave the other namespace intact (a bare {station} delete would wipe both).
+// (Write/delete key CONSISTENCY — the actual leak root cause — is guarded
+// separately by TestGroundStationReconcile_WriteThenDeleteReleasesLiveSeries.)
+func TestGroundStationReconcile_DeletedReleasesAndIsolatesNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	const name = "gs-taipei-01"
+	deleted := prometheus.Labels{"namespace": "team-a", "station": name, "condition": ntnv1alpha1.ConditionRFLinkHealthy}
+	survivor := prometheus.Labels{"namespace": "team-b", "station": name, "condition": ntnv1alpha1.ConditionRFLinkHealthy}
+	ntnmetrics.GroundStationHealth.With(deleted).Set(1)
+	ntnmetrics.GroundStationHealth.With(survivor).Set(1)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &GroundStationLifecycleReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "team-a"},
+	}); err != nil {
+		t.Fatalf("reconcile of deleted CR should not error: %v", err)
+	}
+
+	// team-a released (pre-#183 the composite/bare-name mismatch leaked it forever)...
+	if got := testutil.ToFloat64(ntnmetrics.GroundStationHealth.With(deleted)); got != 0 {
+		t.Errorf("team-a series not released (composite/bare-name leak): got %v, want 0", got)
+	}
+	// ...team-b's same-named series in another namespace survives.
+	if got := testutil.ToFloat64(ntnmetrics.GroundStationHealth.With(survivor)); got != 1 {
+		t.Errorf("deleting team-a wiped team-b's series: got %v, want 1", got)
+	}
+}
+
+// TestGroundStationReconcile_WriteThenDeleteReleasesLiveSeries guards the #183
+// write/delete key CONSISTENCY end-to-end (the actual leak root cause): a series
+// written by a real reconcile MUST be released by a real NotFound reconcile.
+// The seed-and-delete test above cannot catch a write-side regression because it
+// never executes the Step-6 write path — reintroducing the old composite
+// station="<ns>.<name>" write (which the bare-name delete never matched) would
+// slip past it. This test drives BOTH keys through real code, so it fails if they
+// ever drift apart again.
+func TestGroundStationReconcile_WriteThenDeleteReleasesLiveSeries(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	const ns, name = "team-live", "gs-live-release-01"
+	gs := &ntnv1alpha1.GroundStationLifecycle{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gs).WithStatusSubresource(gs).Build()
+	r := &GroundStationLifecycleReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	base := testutil.CollectAndCount(ntnmetrics.GroundStationHealth)
+
+	// Live reconcile writes one GroundStationHealth series per condition (3).
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("live reconcile: %v", err)
+	}
+	if afterWrite := testutil.CollectAndCount(ntnmetrics.GroundStationHealth); afterWrite != base+3 {
+		t.Fatalf("live write did not emit 3 condition series: base=%d afterWrite=%d", base, afterWrite)
+	}
+
+	// Delete the CR, then a NotFound reconcile must release exactly those series.
+	if err := c.Delete(context.Background(), gs); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("notfound reconcile: %v", err)
+	}
+	if afterDelete := testutil.CollectAndCount(ntnmetrics.GroundStationHealth); afterDelete != base {
+		t.Errorf("live series leaked (write/delete key drift): base=%d afterDelete=%d", base, afterDelete)
+	}
+}
+
+// TestNTNCellConfigFinalizer_DeletedDoesNotWipeOtherNamespace is the #183
+// regression guard for ConfigApplyErrorsTotal (NTNCellConfig is namespaced). The
+// finalizer's DeletePartialMatch must release only the deleted CR's
+// {namespace,config} series and leave a same-named CR in another namespace intact.
+func TestNTNCellConfigFinalizer_DeletedDoesNotWipeOtherNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	const name = "cell-config-1"
+	deleted := prometheus.Labels{"namespace": "team-a", "config": name, "provider": "ocudu"}
+	survivor := prometheus.Labels{"namespace": "team-b", "config": name, "provider": "ocudu"}
+	ntnmetrics.ConfigApplyErrorsTotal.With(deleted).Add(3)
+	ntnmetrics.ConfigApplyErrorsTotal.With(survivor).Add(2)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &NTNCellConfigReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	// A deletion-timestamped CR with no finalizer: handleFinalizer fires the metric
+	// DeletePartialMatch first, then returns without touching the ConfigMap path.
+	cc := &ntnv1alpha1.NTNCellConfig{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: "team-a",
+		DeletionTimestamp: &metav1.Time{Time: time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)},
+	}}
+	if _, _, err := r.handleFinalizer(context.Background(), cc, nil); err != nil {
+		t.Fatalf("finalizer cleanup should not error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(ntnmetrics.ConfigApplyErrorsTotal.With(deleted)); got != 0 {
+		t.Errorf("team-a series not released: got %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(ntnmetrics.ConfigApplyErrorsTotal.With(survivor)); got != 2 {
+		t.Errorf("deleting team-a wiped team-b's series: got %v, want 2", got)
+	}
+}
+
+// TestNTNSliceReconcile_DeletedReleasesStaleSeriesWithNilProvider is the #183
+// regression guard for the ReaderStaleUsedTotal evict-guard asymmetry: reads go
+// through readerProvider() (a lazily-built default when ReaderProvider is nil),
+// but the NotFound evict was previously guarded on the raw r.ReaderProvider field,
+// so a stale series written via the lazy default was never released. The fix
+// evicts via the same accessor, releasing the series even with a nil provider.
+func TestNTNSliceReconcile_DeletedReleasesStaleSeriesWithNilProvider(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	labels := prometheus.Labels{"namespace": "team-a", "name": "slice-1"}
+	ntnmetrics.ReaderStaleUsedTotal.With(labels).Inc()
+	if before := testutil.ToFloat64(ntnmetrics.ReaderStaleUsedTotal.With(labels)); before < 1 {
+		t.Fatalf("seed failed: got %v", before)
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	// ReaderProvider intentionally nil — the exact config where the pre-#183 evict
+	// guard skipped release and leaked the stale series.
+	r := &NTNSliceReconciler{Client: c, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "slice-1", Namespace: "team-a"},
+	}); err != nil {
+		t.Fatalf("reconcile of deleted CR should not error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(ntnmetrics.ReaderStaleUsedTotal.With(labels)); got != 0 {
+		t.Errorf("stale series not released on delete with nil ReaderProvider: got %v, want 0", got)
 	}
 }

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -214,7 +214,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := prov.ApplyCellConfig(ctx, cc.Name, spec); err != nil {
 		log.Error(err, "Failed to apply cell config")
 		ntnmetrics.ConfigApplyErrorsTotal.With(prometheus.Labels{
-			"config": cc.Name, "provider": spec.Provider.Type,
+			"namespace": cc.Namespace, "config": cc.Name, "provider": spec.Provider.Type,
 		}).Inc()
 		cc.Status.AppliedKoffset = 0
 		// Preserve existing ConfigMapRef for best-effort finalizer cleanup.
@@ -334,7 +334,7 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 	if cc.DeletionTimestamp != nil {
 		// Release the CR's per-CR metric series on deletion so /metrics does not
 		// accumulate dead series across create/delete churn (idempotent).
-		ntnmetrics.ConfigApplyErrorsTotal.DeletePartialMatch(prometheus.Labels{"config": cc.Name})
+		ntnmetrics.ConfigApplyErrorsTotal.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		if controllerutil.ContainsFinalizer(cc, finalizerName) {
 			if prov == nil {
 				// Best-effort cleanup using Status.ConfigMapRef when provider is missing.

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -108,11 +108,14 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Step 1: Get the NTNSlice resource.
 	ns := &ntnv1alpha1.NTNSlice{}
 	if err := r.Get(ctx, req.NamespacedName, ns); err != nil {
-		if apierrors.IsNotFound(err) && r.ReaderProvider != nil {
-			// The CR is gone — drop any cached reader so the Provider
-			// does not leak staleCache state for slices that no longer
-			// exist. Safe to call even if no entry was present.
-			r.ReaderProvider.Evict(req.NamespacedName)
+		if apierrors.IsNotFound(err) {
+			// The CR is gone — drop any cached reader AND release the per-CR
+			// ReaderStaleUsedTotal series so a deleted NTNSlice leaves no state
+			// behind. Evict via readerProvider() (the same accessor reads use),
+			// NOT the raw r.ReaderProvider field: with a nil ReaderProvider the
+			// lazy default provider still holds the cache/series, so guarding on
+			// the raw field leaked the stale series (#183). No-op if no entry.
+			r.readerProvider().Evict(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,21 +48,28 @@ var (
 	)
 
 	// GroundStationHealth reports ground station condition status (1=True, 0=False, -1=Unknown).
+	// Keyed by namespace+station: GroundStationLifecycle is namespaced, so the same
+	// CR name in two namespaces is two distinct resources and must not share a
+	// series. (#183; supersedes the earlier namespace+"."+name composite `station`
+	// value, whose bare-name delete never matched → a permanent series leak.)
 	GroundStationHealth = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ntn_operators_ground_station_health",
 			Help: "Ground station condition status (1=True, 0=False, -1=Unknown).",
 		},
-		[]string{"station", "condition"},
+		[]string{"namespace", "station", "condition"},
 	)
 
 	// ConfigApplyErrorsTotal counts NTN cell config application failures.
+	// Keyed by namespace+config: NTNCellConfig is namespaced, so keying by config
+	// name alone conflated same-named CRs across namespaces (and wiped them on
+	// delete). Mirrors the #178/#184 namespace fix (#183).
 	ConfigApplyErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ntn_operators_config_apply_errors_total",
 			Help: "Total number of NTN cell config apply errors.",
 		},
-		[]string{"config", "provider"},
+		[]string{"namespace", "config", "provider"},
 	)
 
 	// GPFetchDuration tracks GP data fetch duration in seconds.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -28,8 +28,8 @@ func TestMetricsRegistered(t *testing.T) {
 	// Trigger all metrics with dummy values so Gather returns them.
 	FailoverTotal.With(prometheus.Labels{"namespace": "_", "slice": "_", "from_path": "_", "to_path": "_"}).Add(0)
 	SatellitePassAvailable.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
-	GroundStationHealth.With(prometheus.Labels{"station": "_", "condition": "_"}).Set(0)
-	ConfigApplyErrorsTotal.With(prometheus.Labels{"config": "_", "provider": "_"}).Add(0)
+	GroundStationHealth.With(prometheus.Labels{"namespace": "_", "station": "_", "condition": "_"}).Set(0)
+	ConfigApplyErrorsTotal.With(prometheus.Labels{"namespace": "_", "config": "_", "provider": "_"}).Add(0)
 	GPFetchDuration.With(prometheus.Labels{"source_type": "_", "status": "_"}).Observe(0)
 	GPSatelliteCount.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
 	ReaderQueryDuration.With(prometheus.Labels{"source": "_", "outcome": "_"}).Observe(0)


### PR DESCRIPTION
Closes #183.

## Problem
Two Prometheus metrics were keyed by CR **name only** on **namespaced** CRDs — the same conflation class #178/#180 fixed for the NTNSlice/SatelliteEphemeris metrics:
- `ntn_operators_ground_station_health` `{station,condition}` (GroundStationLifecycle)
- `ntn_operators_config_apply_errors_total` `{config,provider}` (NTNCellConfig)

Surfaced by a deep post-merge audit of #182/#184, which also found **two real leaks**:

1. **GroundStationHealth series leak (HIGH, prod):** the write built a composite `station="<ns>.<name>"` but the NotFound cleanup deleted bare `station="<name>"`, so `DeletePartialMatch` **never matched → one series set leaked on every GroundStation deletion**.
2. **ReaderStaleUsedTotal latent leak:** the NotFound evict was guarded on the raw `r.ReaderProvider` field, but reads use `readerProvider()` (a lazy default when `ReaderProvider==nil`), so a stale series written via the lazy default was never released (prod wires `ReaderProvider`, so prod is unaffected).

## Fix
- Re-key both metrics to include `namespace`; write with `<cr>.Namespace`, delete with `req.Namespace`.
- GroundStation: drop the composite `station` value → plain `station=name` + real `namespace` label, so write/delete keys agree and the delete releases.
- ReaderStale: evict via `readerProvider()` (same accessor reads use); `Evict`→`DeletePartialMatch` acts on the global series, so it releases regardless of provider wiring.
- Grafana legends/queries namespace-qualified; CHANGELOG updated.

## Tests
Per-metric guards in `metric_cleanup_test.go`: cross-namespace non-wipe for all three, **plus a live write→delete round-trip** for GroundStationHealth so the write/delete key consistency (the leak root cause) can't silently regress.

## Verification
Two independent adversarial review rounds (each mutation-tested every guard: reverting a fix makes its test fail; restoring passes). `go build`/`go vet` clean · `golangci-lint` 0 issues · full `internal/controller` + `pkg/metrics` + `pkg/slice/metrics` suite green · `-race -shuffle` clean. ConfigApply's write path is already exercised by the existing `ConfigApplied=False` envtest specs (a cardinality regression panics them).