### PR TITLE
fix(ephemeris): keep runtime-push epoch fresh off-cycle via cached-OMM re-propagation (#179)

### DIFF
--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +55,13 @@ type SatelliteEphemerisReconciler struct {
 	MaxConcurrentReconciles int
 	Fetcher                 ephemeris.GPFetcher          // CelesTrak fetcher
 	SpaceTrackFetcher       *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
+
+	// ommCache holds the last real GP-fetch result per SatelliteEphemeris so the
+	// orbit can be re-propagated on a short cadence WITHOUT re-contacting the GP
+	// source (rate-limit etiquette; #179). Keyed by client.ObjectKey, evicted on
+	// CR deletion. In-memory only — a cold cache (e.g. after a restart) just forces
+	// one fetch on the next reconcile.
+	ommCache sync.Map
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris,verbs=get;list;watch;create;update;patch;delete
@@ -77,8 +85,10 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, eph); err != nil {
 		if apierrors.IsNotFound(err) {
 			// CR deleted — release its per-CR metric series so /metrics does not
-			// accumulate dead series across create/delete churn.
+			// accumulate dead series across create/delete churn, and drop its
+			// cached OMMs so the in-memory cache does not leak (#179).
 			ntnmetrics.GPSatelliteCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			r.ommCache.Delete(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -110,18 +120,37 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// Step 4b: Fetch GP data (with duration metric).
-	fetchStart := time.Now()
-	result, fetchErr := fetcher.Fetch(ctx, eph.Spec.Source.URL)
-	fetchStatus := "success"
-	if fetchErr != nil {
-		fetchStatus = "error"
-	}
-	ntnmetrics.GPFetchDuration.With(prometheus.Labels{"source_type": eph.Spec.Source.Type, "status": fetchStatus}).Observe(time.Since(fetchStart).Seconds())
+	// Step 4b: Obtain OMM data. Within the GP-refresh window, re-propagate from the
+	// cached OMMs of the last real fetch WITHOUT contacting the GP source — this is
+	// what keeps the runtime-push epoch fresh on a short cadence without re-hitting
+	// CelesTrak/SpaceTrack (their rate-limit etiquette is why the fetch is floored
+	// to effectiveInterval). Only fetch when the window has elapsed or the cache is
+	// cold (e.g. the first reconcile after a restart). (#179)
+	now := time.Now()
+	var result ephemeris.GPFetchResult
+	reusedCache := false
+	if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
+		c.generation == eph.Generation && c.uid == eph.UID &&
+		now.Sub(c.result.FetchedAt) < effectiveInterval {
+		result = c.result
+		reusedCache = true
+		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
+			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
+	} else {
+		fetchStart := time.Now()
+		var fetchErr error
+		result, fetchErr = fetcher.Fetch(ctx, eph.Spec.Source.URL)
+		fetchStatus := "success"
+		if fetchErr != nil {
+			fetchStatus = "error"
+		}
+		ntnmetrics.GPFetchDuration.With(prometheus.Labels{"source_type": eph.Spec.Source.Type, "status": fetchStatus}).Observe(time.Since(fetchStart).Seconds())
 
-	// Step 5: Handle fetch errors.
-	if fetchErr != nil {
-		return r.handleFetchError(ctx, eph, fetchErr, effectiveInterval)
+		// Step 5: Handle fetch errors.
+		if fetchErr != nil {
+			return r.handleFetchError(ctx, eph, fetchErr, effectiveInterval)
+		}
+		r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, generation: eph.Generation, uid: eph.UID})
 	}
 
 	// Step 6: Update status with new data.
@@ -140,7 +169,24 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	eph.Status.LastUpdated = &metav1.Time{Time: result.FetchedAt}
 	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
 
-	if result.NotModified {
+	switch {
+	case reusedCache:
+		log.V(1).Info("GP data re-propagated from cache (no fetch)", "satelliteCount", result.SatelliteCount)
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionGPDataFetched,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CachedRepropagation",
+			Message:            fmt.Sprintf("Re-propagated %d satellites from cached OMMs; GP source not contacted within the refresh window", result.SatelliteCount),
+			ObservedGeneration: eph.Generation,
+		})
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionGPDataParsed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CachedOMMs",
+			Message:            "Using cached OMM data from previous fetch",
+			ObservedGeneration: eph.Generation,
+		})
+	case result.NotModified:
 		log.Info("GP data unchanged (304 Not Modified)", "satelliteCount", result.SatelliteCount)
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionGPDataFetched,
@@ -156,7 +202,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			Message:            "Using cached OMM data from previous fetch",
 			ObservedGeneration: eph.Generation,
 		})
-	} else {
+	default:
 		log.Info("Fetched GP data successfully", "satelliteCount", result.SatelliteCount)
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionGPDataFetched,
@@ -206,17 +252,22 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// an earlier version did) made OCUDU back-propagate hours from a position that
 	// was itself SGP4-propagated hours forward, compounding LEO error; a near-now
 	// epoch keeps OCUDU's internal propagation short and forward.
-	r.propagateStates(ctx, eph, result, time.Now().Add(propagationEpochLead))
+	r.propagateStates(ctx, eph, result, now.Add(propagationEpochLead))
 
 	if err := r.Status().Update(ctx, eph); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if r.Recorder != nil {
+	// Only emit the "fetched" event on a real fetch, not on the short-cadence
+	// cache re-propagations — otherwise they would flood the event stream (#179).
+	if r.Recorder != nil && !reusedCache {
 		r.Recorder.Eventf(eph, nil, "Normal", "GPDataFetched", "GPDataFetched", "Fetched %d satellites", result.SatelliteCount)
 	}
 
-	return ctrl.Result{RequeueAfter: effectiveInterval}, nil
+	// Requeue on the short propagation cadence (not the GP-refresh interval) so the
+	// runtime-push epoch stays fresh for off-cycle consumers; the fetch itself
+	// stays gated to effectiveInterval by the cache check above (#179).
+	return ctrl.Result{RequeueAfter: min(effectiveInterval, propagationRefreshInterval)}, nil
 }
 
 // maxPropagatedStates caps how many per-satellite propagated states are stored
@@ -230,6 +281,36 @@ const maxPropagatedStates = 128
 // LEO). The push happens on the watch-triggered reconcile right after this
 // propagation, so the epoch is fresh at push time.
 const propagationEpochLead = 5 * time.Minute
+
+// propagationRefreshInterval is how often the orbit is re-propagated (from cached
+// OMMs, WITHOUT a GP fetch) to keep the runtime-push epoch fresh between GP
+// refreshes (#179). It must be shorter than propagationEpochLead minus the
+// consumer's epochSkewMargin (10s) + delivery latency, so an off-cycle consumer
+// reconcile always finds a future epoch. The producer requeues at this cadence;
+// each re-propagation updates status.propagatedStates, which fans out (via the
+// NTNCellConfig watch) a fresh push to every referencing cell.
+const propagationRefreshInterval = 3 * time.Minute
+
+// cachedFetch is a per-CR OMM cache entry. generation+uid pin it to the exact
+// spec revision of the exact object: a spec/source edit (generation bump) or a
+// delete-recreate reusing the same name (uid change) invalidates the entry and
+// forces a fresh fetch, so an edited source.URL/type/credentials takes effect
+// immediately rather than after the refresh window (#179 regression guard).
+type cachedFetch struct {
+	result     ephemeris.GPFetchResult
+	generation int64
+	uid        types.UID
+}
+
+// cachedOMMResult returns the cached fetch for key, if any.
+func (r *SatelliteEphemerisReconciler) cachedOMMResult(key client.ObjectKey) (cachedFetch, bool) {
+	v, ok := r.ommCache.Load(key)
+	if !ok {
+		return cachedFetch{}, false
+	}
+	c, ok := v.(cachedFetch)
+	return c, ok
+}
 
 // maxSatelliteNameLen bounds the externally-sourced OMM ObjectName stored per
 // propagated state, so a malformed GP feed cannot bloat the status object.

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -52,6 +52,13 @@ func (m *mockGPFetcher) Fetch(_ context.Context, _ string) (ephemeris.GPFetchRes
 	return m.result, m.err
 }
 
+// callCount returns how many times Fetch was invoked (race-safe).
+func (m *mockGPFetcher) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
 // testISSOMM creates an ISS OMM with epoch set to now for deterministic tests.
 func testISSOMM() sgp4.OMM {
 	return sgp4.OMM{
@@ -195,7 +202,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(4 * time.Hour))
+			Expect(result.RequeueAfter).To(Equal(propagationRefreshInterval))
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
@@ -237,7 +244,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(4 * time.Hour))
+			Expect(result.RequeueAfter).To(Equal(propagationRefreshInterval))
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
@@ -263,6 +270,8 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
+			// Rate-limit backoff is unchanged by #179: error paths still requeue at
+			// the (clamped) GP-refresh interval, not the short propagation cadence.
 			Expect(result.RequeueAfter).To(Equal(4 * time.Hour))
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
@@ -358,7 +367,11 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 		})
 		AfterEach(func() { deleteResource() })
 
-		It("should clamp requeue interval to 2 hours", func() {
+		It("requeues on the short propagation cadence even when refreshInterval is below minimum", func() {
+			// The 2h clamp still gates the GP fetch (effectiveInterval), but since
+			// #179 the requeue is the short propagation cadence, not the fetch
+			// interval. The clamp's effect on fetch cadence is covered by the
+			// "re-propagating between GP refreshes" context below.
 			mock := &mockGPFetcher{
 				result: ephemeris.GPFetchResult{SatelliteCount: 100, FetchedAt: time.Now()},
 			}
@@ -368,7 +381,74 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(2 * time.Hour))
+			Expect(result.RequeueAfter).To(Equal(propagationRefreshInterval))
+		})
+	})
+
+	Context("When re-propagating between GP refreshes (#179)", func() {
+		BeforeEach(func() { createResource() })
+		AfterEach(func() { deleteResource() })
+
+		It("reuses cached OMMs without a second GP fetch within the refresh window", func() {
+			mock := &mockGPFetcher{result: ephemeris.GPFetchResult{
+				SatelliteCount: 1,
+				OMMs:           []sgp4.OMM{testISSOMM()},
+				FetchedAt:      time.Now(),
+			}}
+			// One reconciler instance so its ommCache persists across reconciles.
+			reconciler := newReconciler(mock)
+			req := reconcile.Request{NamespacedName: typeNamespacedName}
+
+			// 1st reconcile: cold cache → exactly one real GP fetch, short requeue.
+			r1, err := reconciler.Reconcile(context.Background(), req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mock.callCount()).To(Equal(1))
+			Expect(r1.RequeueAfter).To(Equal(propagationRefreshInterval))
+
+			// 2nd reconcile immediately (well within the 4h refresh window): it MUST
+			// re-propagate from cache with NO second GP-source request (#179 accept).
+			r2, err := reconciler.Reconcile(context.Background(), req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mock.callCount()).To(Equal(1)) // still 1 — the rate-limit guarantee
+			Expect(r2.RequeueAfter).To(Equal(propagationRefreshInterval))
+
+			// The runtime-push epoch is refreshed on the cached re-propagation and
+			// stays in the future, so an off-cycle consumer finds a fresh epoch.
+			updated := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
+			Expect(updated.Status.PropagatedStates).NotTo(BeEmpty())
+			Expect(updated.Status.PropagatedStates[0].EpochUnixMs).To(BeNumerically(">", time.Now().UnixMilli()))
+
+			// The cache-reuse path is reflected honestly in the condition reason.
+			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("CachedRepropagation"))
+		})
+
+		It("re-fetches after a spec change instead of serving stale cached OMMs", func() {
+			mock := &mockGPFetcher{result: ephemeris.GPFetchResult{
+				SatelliteCount: 1,
+				OMMs:           []sgp4.OMM{testISSOMM()},
+				FetchedAt:      time.Now(),
+			}}
+			reconciler := newReconciler(mock)
+			req := reconcile.Request{NamespacedName: typeNamespacedName}
+
+			_, err := reconciler.Reconcile(context.Background(), req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mock.callCount()).To(Equal(1))
+
+			// Edit the spec (bumps metadata.generation): change the source URL.
+			cur := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, cur)).To(Succeed())
+			cur.Spec.Source.URL = "https://celestrak.org/NORAD/elements/gp.php?GROUP=starlink&FORMAT=JSON"
+			Expect(k8sClient.Update(context.Background(), cur)).To(Succeed())
+
+			// The generation bump must invalidate the cache → a real fetch of the
+			// new source, not a stale reuse of the old one (#179 regression guard).
+			_, err = reconciler.Reconcile(context.Background(), req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mock.callCount()).To(Equal(2))
 		})
 	})
 
@@ -530,7 +610,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(4 * time.Hour))
+			Expect(result.RequeueAfter).To(Equal(propagationRefreshInterval))
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
@@ -574,7 +654,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(4 * time.Hour))
+			Expect(result.RequeueAfter).To(Equal(propagationRefreshInterval))
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())


### PR DESCRIPTION
Closes #179.

## Problem
The runtime NTN push (#177) stamps the ephemeris epoch near-now (`propagationEpochLead`=5m), but the producer only re-propagated on its GP-refresh reconcile (floored to 2h for rate-limit etiquette). A consumer reconcile landing >5m after the last propagation (controller restart, spec edit, cell created mid-interval) saw a **stale epoch**, classified it `EphemerisStale`, and **skipped the push** until the next refresh (up to 2h) — so the fleet fan-out (already wired via the NTNCellConfig→SatelliteEphemeris watch) only delivered fresh ephemeris every ~2h.

## Fix
Decouple the propagation cadence from the GP-fetch cadence. The reconciler caches the last real fetch's OMMs in memory (per CR, **pinned to `generation`+`uid`**, evicted on delete) and, within the GP-refresh window, **re-propagates from cached OMMs without contacting the GP source**, requeuing at `propagationRefreshInterval`=3m. A real fetch happens only when the window elapses, the cache is cold (restart), or **the spec changed** (so an edited `source.URL`/type/credentials takes effect immediately). **GP-source request rate is unchanged.**

Each re-propagation refreshes `status.propagatedStates` → the existing NTNCellConfig watch fans a fresh push to every referencing cell **that needs it** (the consumer's `ephemerisPushMarker` gates the actual WS push to real data changes, so healthy cells skip redundant pushes — no push amplification). An off-cycle consumer always finds a future epoch.

Honest status: reuse path uses reason `CachedRepropagation` and suppresses the "fetched" event; `status.LastUpdated` still reflects the last real fetch. Error-path backoff unchanged.

## Tests
- Acceptance: two reconciles within the window → **exactly one fetch**, short requeue, fresh future epoch, `CachedRepropagation` condition.
- Regression: spec edit → cache invalidated → re-fetch (guards the `generation`/`uid` pinning the adversarial review flagged).

## Review / verification
Two-pass adversarial review (mutation-verified guards; `-race` clean; the spec-change-invalidation regression the review found is **fixed** here). Build/vet clean · `golangci-lint` 0 · full `internal/controller`+`pkg/ephemeris`+`pkg/metrics` suite green.

Follow-up **#188**: gate the pass-prediction recompute/event on actual window change (currently recomputes identical windows each short-cadence reuse — churn, no correctness impact).