### PR TITLE
chore(release): prepare v0.6.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0-rc.1] - 2026-07-09
 
 Config-emitter correctness and runtime NTN push, verified end-to-end against a
 real OCUDU gNB (commit `0b229d35`).

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.5.0
+VERSION ?= 0.6.0-rc.1
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
     # / clickhouse 0.26.3 all carry this annotation).
     certified: "false"
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.5.0
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.6.0-rc.1
     repository: https://github.com/thc1006/ntn-operators
     # description: short tile text shown on operatorhub.io marketplace cards.
     # Hard limit is 135 chars per k8s-operatorhub/community-operators
@@ -61,9 +61,9 @@ metadata:
     description: "Kubernetes-native NTN: satellite ephemeris, ground station lifecycle, NTN cell config, terrestrial-satellite slice failover."
     # createdAt: ISO-8601 timestamp of the bundle's published release.
     # Bump on every version cut (approximate; set at release-prep time).
-    createdAt: "2026-05-27T01:04:15Z"
+    createdAt: "2026-07-09T00:00:00Z"
     support: thc1006
-  name: ntn-operators.v0.5.0
+  name: ntn-operators.v0.6.0-rc.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -150,7 +150,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.5.0
+                    image: ghcr.io/thc1006/ntn-operators:v0.6.0-rc.1
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -213,17 +213,15 @@ spec:
     - name: Documentation
       url: https://github.com/thc1006/ntn-operators/tree/main/docs
   maintainers:
-    - email: caake2025@gmail.com
+    - email: hctsai@linux.com
       name: thc1006
   maturity: alpha
   minKubeVersion: "1.29.0"
   provider:
     name: ntn-operators
     url: https://github.com/thc1006/ntn-operators
-  # replaces (not skipRange): v0.4.0 is published on OperatorHub
-  # (community-operators#8018, merged 2026-04-27), so this CSV declares an
-  # explicit upgrade edge from it. v0.4.0 itself used skipRange only because
-  # no v0.1.0 CSV was ever cataloged; that no longer applies now that a real
-  # predecessor CSV (ntn-operators.v0.4.0) exists in the catalog.
-  replaces: ntn-operators.v0.4.0
-  version: 0.5.0
+  # skipRange (not replaces): the OperatorHub community-operators semver-mode CI
+  # rejects `replaces`/`skips`, so declare the upgrade edge via skipRange. This
+  # range covers all prior published versions (v0.4.0 #8018, v0.5.0 #8299).
+  skipRange: "<0.6.0-rc.1"
+  version: 0.6.0-rc.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.5.0
+  newTag: v0.6.0-rc.1

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0-rc.1
+appVersion: "0.6.0-rc.1"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.5.0` | Image tag |
+| `manager.image.tag` | string | `v0.6.0-rc.1` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.5.0
+    tag: v0.6.0-rc.1
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
Version-bump prep to cut **v0.6.0-rc.1** (following the v0.5.0-rc.1 template, commit `a5b5b24`). On merge, the `v0.6.0-rc.1` tag triggers the release workflow (build → Trivy scan → cosign sign → ghcr image + Helm chart + GitHub Release).

**Contents of this rc** (accumulated v0.6 work already in main): OCUDU config-emitter correctness (config now parses on a real gNB), runtime NTN push (#176/#177) against OCUDU `!798`, SatelliteEphemeris→N-NTNCellConfig fan-out + off-cycle epoch freshness (#179), and the full metric-cleanup campaign (#178/#180/#181/#182/#183/#184/#185/#186/#187). ADR 0005 (cluster-scope orchestration) Accepted.

**Bumps:** Makefile, Chart.yaml, kustomization image tag, dist/chart README+values, bundle CSV (name/version/image/containerImage), CHANGELOG `[Unreleased]`→`[0.6.0-rc.1]`.

**Bundle CSV:** upgrade edge switched `replaces: v0.4.0` → `skipRange: "<0.6.0-rc.1"` (OperatorHub semver-mode CI rejects `replaces`/`skips`) + maintainer email → hctsai@linux.com (**closes #163**).

rc is pre-release: no OperatorHub catalog submission (final-only), README "Latest release" unchanged, signing unchanged (cosign v2.6.3 pin; #148 cosign-v3 deferred).