### PR TITLE
fix(ci): bump Go toolchain 1.26.3 -> 1.26.4 to clear HIGH stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thc1006/ntn-operators
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/akhenakh/sgp4 v1.0.1


### PR DESCRIPTION
The **v0.6.0-rc.1 release dry-run's Trivy gate** flagged 2 HIGH stdlib CVEs in the ko-built image (built with Go 1.26.3 via `go.mod` + `setup-go`):
- **CVE-2026-27145** — crypto/x509 DoS
- **CVE-2026-42504** — mime DoS

Both fixed in **Go 1.26.4**. The Dockerfile was already on 1.26.4 (#155), but the release image is **ko-built from `go.mod`**, so the `go` directive is the effective toolchain pin (all workflows use `setup-go` with `go-version-file: go.mod`). Bump `go 1.26.3` → `1.26.4`.

Verified: build/vet clean, `golangci-lint` 0, full suite green (Go 1.26.4). The release dry-run will be re-run after merge to confirm the Trivy gate passes before tagging `v0.6.0-rc.1`.