### PR TITLE
chore(release): promote v0.6.0-rc.1 to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-09
+
+Promotion of `0.6.0-rc.1` after a short soak (the rc's release pipeline —
+build, Trivy scan, cosign signing, ghcr image + Helm chart + SBOM — published
+clean). No CRD, controller, or config changes since the rc; same tree,
+re-tagged as the stable release. The full v0.5.0 → 0.6.0 delta is in the
+`[0.6.0-rc.1]` section below.
+
 ## [0.6.0-rc.1] - 2026-07-09
 
 Config-emitter correctness and runtime NTN push, verified end-to-end against a

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.6.0-rc.1
+VERSION ?= 0.6.0
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Kubernetes-native management framework for Non-Terrestrial Networks (NTN). Declaratively manage satellite constellations, ground stations, NTN cell configurations, and terrestrial-satellite failover — all through standard Kubernetes CRDs.
 
-> **Latest release:** [v0.5.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.5.0) — NTNCellConfig `cellSpecificKoffset` aligned to OCUDU's accepted range (1-1023), k8s.io 0.36 + controller-runtime 0.24.1, Go 1.26.3 toolchain (HIGH stdlib CVE fixes), and an OLM bundle-CRD drift gate. See [CHANGELOG.md](CHANGELOG.md) for the full delta.
+> **Latest release:** [v0.6.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.6.0) — cluster-scope NTN orchestration foundation: gNB-parseable OCUDU config, runtime NTN push (OCUDU !798) with SGP4-propagated ECEF → SIB19, SatelliteEphemeris → multi-NTNCellConfig fan-out with off-cycle epoch freshness, namespace-consistent Prometheus metrics, and Go 1.26.4 (HIGH stdlib CVE fixes). See [CHANGELOG.md](CHANGELOG.md) for the full delta.
 
 ## Custom Resource Definitions
 

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
     # / clickhouse 0.26.3 all carry this annotation).
     certified: "false"
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.6.0-rc.1
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.6.0
     repository: https://github.com/thc1006/ntn-operators
     # description: short tile text shown on operatorhub.io marketplace cards.
     # Hard limit is 135 chars per k8s-operatorhub/community-operators
@@ -63,7 +63,7 @@ metadata:
     # Bump on every version cut (approximate; set at release-prep time).
     createdAt: "2026-07-09T00:00:00Z"
     support: thc1006
-  name: ntn-operators.v0.6.0-rc.1
+  name: ntn-operators.v0.6.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -150,7 +150,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.6.0-rc.1
+                    image: ghcr.io/thc1006/ntn-operators:v0.6.0
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -223,5 +223,5 @@ spec:
   # skipRange (not replaces): the OperatorHub community-operators semver-mode CI
   # rejects `replaces`/`skips`, so declare the upgrade edge via skipRange. This
   # range covers all prior published versions (v0.4.0 #8018, v0.5.0 #8299).
-  skipRange: "<0.6.0-rc.1"
-  version: 0.6.0-rc.1
+  skipRange: "<0.6.0"
+  version: 0.6.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.6.0-rc.1
+  newTag: v0.6.0

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.6.0-rc.1
-appVersion: "0.6.0-rc.1"
+version: 0.6.0
+appVersion: "0.6.0"
 
 keywords:
   - kubernetes

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.6.0-rc.1` | Image tag |
+| `manager.image.tag` | string | `v0.6.0` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -13,7 +13,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.6.0-rc.1
+    tag: v0.6.0
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
Promote **v0.6.0-rc.1 → v0.6.0** (following the v0.5.0 promote template, commit `8fd2684`). The rc's real release pipeline published clean (build, Trivy scan, cosign sign, ghcr image + Helm chart + SBOM), so this promotes the same tree to the stable release.

**No code changes** since the rc — pure version promotion: strip `-rc.1` (Makefile, Chart.yaml, kustomization image tag, dist/chart README+values, bundle CSV name/version/image, `skipRange "<0.6.0"`), add the CHANGELOG `[0.6.0]` section, and set README "Latest release" → v0.6.0.

On merge → dry-run → tag `v0.6.0` triggers the real release (ghcr image + Helm chart + SBOM + GitHub Release, cosign-signed, marked **Latest**).

Note: OperatorHub catalog submission for v0.6.0 is a separate follow-up; the CSV upgrade-edge (`skipRange` vs `replaces`) has conflicting signals (memory HARD-RULE says skipRange; v0.5.0 final used replaces + was accepted) and will be confirmed at catalog-submission time.