### PR TITLE
chore(tools): refresh dev toolchain + resolve golangci-lint v2.12 goconst findings

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -50,7 +50,7 @@ echo "------------------------------------"
 # Install kind
 if ! command -v kind &> /dev/null; then
   echo "Installing kind..."
-  curl -fLo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${ARCH}"
+  curl -fLo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-${ARCH}"
   chmod +x /usr/local/bin/kind
   echo "kind installed successfully"
 fi
@@ -67,7 +67,7 @@ fi
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
   echo "Installing kubebuilder..."
-  curl -fLo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/v4.6.0/linux/${ARCH}"
+  curl -fLo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/v4.15.0/linux/${ARCH}"
   chmod +x /usr/local/bin/kubebuilder
   echo "kubebuilder installed successfully"
 fi
@@ -84,7 +84,7 @@ fi
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   echo "Installing kubectl..."
-  KUBECTL_VERSION="v1.32.3"
+  KUBECTL_VERSION="v1.36.2"
   curl -fLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
   chmod +x /usr/local/bin/kubectl
   echo "kubectl installed successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Install Helm
         env:
-          HELM_VERSION: v3.17.4
+          HELM_VERSION: v3.21.2
         run: |
           set -euo pipefail
           TMPDIR="$(mktemp -d)"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,21 @@ linters:
     modernize:
       disable:
         - omitzero
+    goconst:
+      # Test files use repeated literal strings as explicit fixture data
+      # (metric names, label values, sample inputs); inlining them is
+      # clearer than indirection through shared constants.
+      ignore-tests: true
+      # "namespace"/"ephemeris" are Prometheus metric label keys, written inline
+      # both at the metric declarations (pkg/metrics) and at every .With()/
+      # DeletePartialMatch call site (internal/controller). Extracting only the
+      # frequently-repeated keys would be inconsistent with the single-use
+      # sibling keys inline beside them (slice, station, config, provider,
+      # condition, from_path, to_path, name). goconst v2.12's composite-literal
+      # walking flags them; anchored regexes suppress only these exact values.
+      ignore-string-values:
+        - '^namespace$'
+        - '^ephemeris$'
   exclusions:
     generated: lax
     rules:

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 # kpt binary path — prefer PATH. `make nephio-install-tools` installs into
 # $(go env GOPATH)/bin; ensure that directory is on your PATH.
 KPT ?= kpt
-KPT_VERSION ?= v1.0.0-beta.62
+KPT_VERSION ?= v1.0.0-beta.65
 NEPHIO_PKGS := nephio/packages/ntn-operators-crds nephio/packages/ntn-workloads-sample
 
 .PHONY: nephio-install-tools
@@ -295,7 +295,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.1
-CONTROLLER_TOOLS_VERSION ?= v0.20.1
+CONTROLLER_TOOLS_VERSION ?= v0.21.0
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
@@ -307,7 +307,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -396,7 +396,7 @@ HELM_CHART_DIR ?= dist/chart
 ## Additional arguments to pass to helm commands
 HELM_EXTRA_ARGS ?=
 
-HELM_VERSION ?= v3.17.4
+HELM_VERSION ?= v3.21.2
 .PHONY: install-helm
 install-helm: $(LOCALBIN) ## Install Helm (pinned version).
 	@{ command -v "$(HELM)" > /dev/null 2>&1 && "$(HELM)" version --short 2>/dev/null | grep -q "$(HELM_VERSION)"; } || { \

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-cliVersion: 4.13.1
+cliVersion: 4.15.0
 domain: operators.dev
 layout:
 - go.kubebuilder.io/v4

--- a/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: groundstationlifecycles.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntncellconfigs.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntnslices.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: satelliteephemeris.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/cmd/test-metrics-exporter/Dockerfile
+++ b/cmd/test-metrics-exporter/Dockerfile
@@ -1,6 +1,6 @@
 # Synthetic Prometheus exporter for NTNSlice E2E tests.
 # Build locally with: docker build -t test-metrics-exporter:latest -f cmd/test-metrics-exporter/Dockerfile .
-FROM golang:1.26.3-alpine AS build
+FROM golang:1.26.5-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: groundstationlifecycles.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntncellconfigs.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntnslices.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: satelliteephemeris.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{ end }}
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: groundstationlifecycles.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{ end }}
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntncellconfigs.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{ end }}
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntnslices.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{ end }}
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: satelliteephemeris.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -60,6 +60,10 @@ const (
 
 	// availableFirmwareAnnotation is the Node annotation for available firmware version.
 	availableFirmwareAnnotation = "ntn.operators.dev/available-firmware-version"
+
+	// reasonNodeNotFound is the condition Reason set on a GroundStationLifecycle's
+	// conditions when no Node matches its groundStationLabel selector.
+	reasonNodeNotFound = "NodeNotFound"
 )
 
 // ambiguousNodeError is returned when multiple Nodes match the same ground station label.
@@ -273,18 +277,18 @@ func (r *GroundStationLifecycleReconciler) reconcileHealth(
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionK8sNodeReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "NodeNotFound",
+			Reason:             reasonNodeNotFound,
 			Message:            fmt.Sprintf("No node with label %s=%s found", groundStationLabel, groundStationLabelValue(gs.Namespace, gs.Name)),
 			ObservedGeneration: gs.Generation,
 		})
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 			Type: ntnv1alpha1.ConditionAntennaReady, Status: metav1.ConditionUnknown,
-			Reason: "NodeNotFound", Message: "Node not found, antenna status unknown",
+			Reason: reasonNodeNotFound, Message: "Node not found, antenna status unknown",
 			ObservedGeneration: gs.Generation,
 		})
 		meta.SetStatusCondition(&gs.Status.Conditions, metav1.Condition{
 			Type: ntnv1alpha1.ConditionRFLinkHealthy, Status: metav1.ConditionUnknown,
-			Reason: "NodeNotFound", Message: "Node not found, RF link status unknown",
+			Reason: reasonNodeNotFound, Message: "Node not found, RF link status unknown",
 			ObservedGeneration: gs.Generation,
 		})
 		if gs.Status.Phase == "" || gs.Status.Phase == ntnv1alpha1.PhaseProvisioning {

--- a/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: groundstationlifecycles.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntncellconfigs.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: ntnslices.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: satelliteephemeris.ntn.operators.dev
 spec:
   group: ntn.operators.dev

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -36,6 +36,18 @@ const (
 	PathUnavailable PathType = "unavailable"
 )
 
+// Failover trigger metric names. Each satellite metric has a "terrestrial"
+// counterpart that resolves to the same Metrics field; both spellings are
+// accepted in trigger expressions (see ParseTrigger, Evaluate).
+const (
+	metricRSRP                  = "rsrp"
+	metricTerrestrialRSRP       = "terrestrialRSRP"
+	metricLatency               = "latency"
+	metricTerrestrialLatency    = "terrestrialLatency"
+	metricPacketLoss            = "packetLoss"
+	metricTerrestrialPacketLoss = "terrestrialPacketLoss"
+)
+
 // Decision represents the failover engine's recommendation.
 type Decision string
 
@@ -88,9 +100,9 @@ func ParseTrigger(s string) (Trigger, error) {
 				return Trigger{}, fmt.Errorf("empty metric in trigger %q", s)
 			}
 			validMetrics := map[string]bool{
-				"rsrp": true, "terrestrialRSRP": true,
-				"latency": true, "terrestrialLatency": true,
-				"packetLoss": true, "terrestrialPacketLoss": true,
+				metricRSRP: true, metricTerrestrialRSRP: true,
+				metricLatency: true, metricTerrestrialLatency: true,
+				metricPacketLoss: true, metricTerrestrialPacketLoss: true,
 			}
 			if !validMetrics[metric] {
 				return Trigger{}, fmt.Errorf("unknown metric %q in trigger %q", metric, s)
@@ -107,11 +119,11 @@ func ParseTrigger(s string) (Trigger, error) {
 func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 	var actual float64
 	switch t.Metric {
-	case "rsrp", "terrestrialRSRP":
+	case metricRSRP, metricTerrestrialRSRP:
 		actual = m.RSRP
-	case "latency", "terrestrialLatency":
+	case metricLatency, metricTerrestrialLatency:
 		actual = m.LatencyMs
-	case "packetLoss", "terrestrialPacketLoss":
+	case metricPacketLoss, metricTerrestrialPacketLoss:
 		actual = m.PacketLossPercent
 	default:
 		return false // unknown metric — fail-safe, assume NOT recovered
@@ -137,11 +149,11 @@ func (t Trigger) EvaluateRecovery(m Metrics, margin float64) bool {
 func (t Trigger) Evaluate(m Metrics) bool {
 	var actual float64
 	switch t.Metric {
-	case "rsrp", "terrestrialRSRP":
+	case metricRSRP, metricTerrestrialRSRP:
 		actual = m.RSRP
-	case "latency", "terrestrialLatency":
+	case metricLatency, metricTerrestrialLatency:
 		actual = m.LatencyMs
-	case "packetLoss", "terrestrialPacketLoss":
+	case metricPacketLoss, metricTerrestrialPacketLoss:
 		actual = m.PacketLossPercent
 	default:
 		return false


### PR DESCRIPTION
## Summary
Dev-toolchain + tooling refresh (part of the repo-wide staleness sweep after v0.6.0), plus resolution of the new goconst findings that golangci-lint v2.12 surfaces. Follows #195 (runtime deps + Go 1.26.5).

### Tool versions
- **golangci-lint** v2.11.4 → v2.12.2 (`Makefile`, `.custom-gcl.yml`)
- **controller-tools** v0.20.1 → v0.21.0 — re-stamps the CRD `controller-gen.kubebuilder.io/version` annotation only (no schema change)
- **Helm** v3.17.4 → v3.21.2 (`Makefile` **and** `release.yml` packaging step — the two had drifted apart)
- **kpt** v1.0.0-beta.62 → v1.0.0-beta.65
- **kubebuilder** cliVersion 4.13.1 → 4.15.0 (`PROJECT`); devcontainer dev CLIs: kind v0.32.0, kubebuilder v4.15.0, kubectl v1.36.2
- `cmd/test-metrics-exporter` builder golang 1.26.3 → 1.26.5-alpine

### CRDs
Re-stamped controller-gen v0.20.1 → v0.21.0 across all 4 copies (config/crd/bases, bundle, dist/chart, nephio). **Annotation-only diff**; drift gates pass.

### goconst (golangci-lint v2.12 composite-literal walking → 51 findings)
Resolved without masking real issues:
- `ignore-tests: true` — test-data literals are intentional fixtures
- Extracted genuine domain constants: `reasonNodeNotFound` (condition reason); the 6 failover-trigger metric names
- `ignore-string-values` for the `namespace`/`ephemeris` Prometheus label keys (inline is idiomatic; extracting only the repeated ones would be inconsistent with their single-use sibling keys)

## Verification
build/vet · golangci-lint 0 issues · full unit+envtest suite · `-race` · mutation tests on both extracted constants · kpt T1–T15 · helm lint · all CRD drift gates.