### PR TITLE
fix(ephemeris): fetch resilience — auth-body, rate-limit reclassify, cache fallback [I-18/I-19b/I-20]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,6 +196,7 @@ func main() {
 	)
 	if err := (&controller.SatelliteEphemerisReconciler{
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Scheme:                  mgr.GetScheme(),
 		Recorder:                mgr.GetEventRecorder("satelliteephemeris-controller"),
 		Fetcher:                 ephemeris.NewCelesTrakFetcher(gpHTTPClient),

--- a/internal/controller/satelliteephemeris_cachefallback_test.go
+++ b/internal/controller/satelliteephemeris_cachefallback_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestReconcile_FetchError_ServesCache pins I-18: when a GP fetch fails but a
+// still-valid cache exists, the reconcile keeps serving the cached OMMs — pass
+// windows are re-predicted (not wiped) and the runtime-push states re-propagated —
+// so SIB19 continuity is maintained instead of blackholed. A generic transient
+// error is still returned so the workqueue backs off the fetch retry.
+func TestReconcile_FetchError_ServesCache(t *testing.T) {
+	sch := makeScheme(t)
+	const ns = "default"
+
+	gs := &ntnv1alpha1.GroundStationLifecycle{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-taipei", Namespace: ns},
+		Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+			Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "edge-5000"},
+			Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654", Alt: "15"}},
+		},
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-cache", Namespace: ns},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+			PassPrediction: &ntnv1alpha1.PassPredictionSpec{
+				GroundStations: []string{"gs-taipei"},
+				MinElevation:   "10",
+				Horizon:        metav1.Duration{Duration: 24 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(gs, eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-cache", Namespace: ns}
+
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10),
+		Fetcher: &mockGPFetcher{err: errors.New("connection refused")}, // fetch will FAIL
+	}
+	// Seed a valid cache whose FetchedAt is OLDER than the 4h refresh window, so the
+	// reconcile actually fetches (and fails) rather than reusing the cache silently.
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{testISSOMM()}, SatelliteCount: 1, FetchedAt: time.Now().Add(-5 * time.Hour),
+		},
+		generation: got.Generation,
+		uid:        got.UID,
+	})
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	// Generic transient error → returned so the workqueue applies exponential backoff.
+	if err == nil {
+		t.Fatal("a generic fetch error must be returned for workqueue backoff, got nil")
+	}
+
+	updated := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	// The fetch failed but the cache was served (degraded, not blackholed).
+	cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "FetchFailedServingCache" {
+		t.Fatalf("GPDataFetched must be False/FetchFailedServingCache, got %+v", cond)
+	}
+	// The core of I-18: SIB19 continuity is preserved.
+	if len(updated.Status.PropagatedStates) == 0 {
+		t.Error("PropagatedStates must be re-propagated from the served cache (SIB19 push preserved)")
+	}
+	if len(updated.Status.NextPassWindows) == 0 {
+		t.Error("NextPassWindows must be re-predicted from the served cache, not wiped")
+	}
+	if updated.Status.SatelliteCount != 1 {
+		t.Errorf("SatelliteCount should reflect the served cache (1), got %d", updated.Status.SatelliteCount)
+	}
+}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -155,39 +155,14 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// to effectiveInterval). Only fetch when the window has elapsed or the cache is
 	// cold (e.g. the first reconcile after a restart). (#179)
 	now := time.Now()
-	var result ephemeris.GPFetchResult
-	reusedCache := false
-	if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
-		c.generation == eph.Generation && c.uid == eph.UID &&
-		now.Sub(c.result.FetchedAt) < effectiveInterval {
-		result = c.result
-		reusedCache = true
-		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
-			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
-	} else {
-		// Refuse a cleartext http:// source that resolves to a PUBLIC IP: an
-		// on-path attacker could inject forged OMM JSON that is propagated into
-		// SIB19 (findings.md I-21). In-cluster http mirrors and E2E mocks (which
-		// resolve to private IPs, behind NetworkPolicy) stay allowed, and https
-		// is always fine.
-		if ip, insecure := r.publicHTTPSource(ctx, eph.Spec.Source.URL); insecure {
-			return r.handleInsecureURL(ctx, eph, ip)
-		}
-		fetchStart := time.Now()
-		var fetchErr error
-		result, fetchErr = fetcher.Fetch(ctx, eph.Spec.Source.URL)
-		fetchStatus := "success"
-		if fetchErr != nil {
-			fetchStatus = "error"
-		}
-		ntnmetrics.GPFetchDuration.With(prometheus.Labels{"source_type": eph.Spec.Source.Type, "status": fetchStatus}).Observe(time.Since(fetchStart).Seconds())
-
-		// Step 5: Handle fetch errors.
-		if fetchErr != nil {
-			return r.handleFetchError(ctx, eph, fetchErr, effectiveInterval)
-		}
-		r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, generation: eph.Generation, uid: eph.UID})
+	outcome, earlyResult, earlyErr := r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
+	if earlyResult != nil {
+		return *earlyResult, earlyErr
 	}
+	result := outcome.result
+	reusedCache := outcome.reusedCache
+	servedCacheOnError := outcome.servedCacheOnError
+	cacheServeErr := outcome.cacheServeErr
 
 	// Step 6: Update status with new data.
 	//
@@ -206,6 +181,23 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
 
 	switch {
+	case servedCacheOnError:
+		log.Info("serving cached OMMs after fetch failure", "satelliteCount", result.SatelliteCount)
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:   ntnv1alpha1.ConditionGPDataFetched,
+			Status: metav1.ConditionFalse,
+			Reason: "FetchFailedServingCache",
+			Message: fmt.Sprintf("GP fetch failed (%s); serving %d satellites from cached OMMs — pass windows and runtime push preserved",
+				cacheServeErr.Error(), result.SatelliteCount),
+			ObservedGeneration: eph.Generation,
+		})
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionGPDataParsed,
+			Status:             metav1.ConditionTrue,
+			Reason:             reasonCachedOMMs,
+			Message:            "Using cached OMM data from a previous fetch",
+			ObservedGeneration: eph.Generation,
+		})
 	case reusedCache:
 		log.V(1).Info("GP data re-propagated from cache (no fetch)", "satelliteCount", result.SatelliteCount)
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
@@ -218,7 +210,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionGPDataParsed,
 			Status:             metav1.ConditionTrue,
-			Reason:             "CachedOMMs",
+			Reason:             reasonCachedOMMs,
 			Message:            "Using cached OMM data from previous fetch",
 			ObservedGeneration: eph.Generation,
 		})
@@ -234,7 +226,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionGPDataParsed,
 			Status:             metav1.ConditionTrue,
-			Reason:             "CachedOMMs",
+			Reason:             reasonCachedOMMs,
 			Message:            "Using cached OMM data from previous fetch",
 			ObservedGeneration: eph.Generation,
 		})
@@ -329,10 +321,32 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Recorder.Eventf(eph, nil, "Warning", "UnsupportedOrbitRegime", "OrbitRegimeGuard", "%s", orbitRegimeEvent)
 	}
 
-	// Only emit the "fetched" event on a real fetch, not on the short-cadence
-	// cache re-propagations — otherwise they would flood the event stream (#179).
-	if r.Recorder != nil && !reusedCache {
-		r.Recorder.Eventf(eph, nil, "Normal", "GPDataFetched", "GPDataFetched", "Fetched %d satellites", result.SatelliteCount)
+	// Emit the "fetched" event only on a real successful fetch — not on the
+	// short-cadence cache re-propagations (would flood the stream, #179) and not on
+	// a serve-cache-on-error cycle (the fetch failed). The latter emits its own
+	// Warning so an operator sees SIB19 is running on stale cache (I-18).
+	switch {
+	case servedCacheOnError:
+		if r.Recorder != nil {
+			r.Recorder.Eventf(eph, nil, "Warning", "FetchFailedServingCache", "FetchFailedServingCache",
+				"GP fetch failed (%s); serving %d satellites from cached OMMs", cacheServeErr.Error(), result.SatelliteCount)
+		}
+	case !reusedCache:
+		if r.Recorder != nil {
+			r.Recorder.Eventf(eph, nil, "Normal", "GPDataFetched", "GPDataFetched", "Fetched %d satellites", result.SatelliteCount)
+		}
+	}
+
+	// I-18: on a serve-cache-on-error cycle, back off the FETCH retry exactly as the
+	// wipe path would (rate-limited → slow requeue; generic transient → return the
+	// error for workqueue exponential backoff) — while the status just persisted
+	// keeps SIB19 served from cache.
+	if servedCacheOnError {
+		_, requeueAfter, returnAsError := classifyFetchError(cacheServeErr, effectiveInterval)
+		if returnAsError {
+			return ctrl.Result{}, cacheServeErr
+		}
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	// Requeue on the short propagation cadence (not the GP-refresh interval) so the
@@ -691,13 +705,7 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 	fetchErr error,
 	effectiveInterval time.Duration,
 ) (ctrl.Result, error) {
-	reason := "FetchFailed"
-	requeueAfter := time.Minute
-
-	if errors.Is(fetchErr, ephemeris.ErrRateLimited) {
-		reason = "RateLimited"
-		requeueAfter = effectiveInterval
-	}
+	reason, requeueAfter, returnAsError := classifyFetchError(fetchErr, effectiveInterval)
 
 	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionGPDataFetched,
@@ -727,7 +735,107 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 		r.Recorder.Eventf(eph, nil, "Warning", reason, reason, "%s", fetchErr.Error())
 	}
 
+	if returnAsError {
+		return ctrl.Result{}, fetchErr
+	}
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// retryAfterFrom extracts a server-supplied Retry-After delay from a rate-limit
+// error, or 0 if none. Lets a fronting proxy's Retry-After override the default
+// refresh-cadence requeue.
+func retryAfterFrom(err error) time.Duration {
+	var rle *ephemeris.RateLimitError
+	if errors.As(err, &rle) {
+		return rle.RetryAfter
+	}
+	return 0
+}
+
+// reasonCachedOMMs is the GPDataParsed condition reason when serving OMMs from the
+// in-memory cache rather than a fresh parse.
+const reasonCachedOMMs = "CachedOMMs"
+
+// ommFetchOutcome is how a reconcile obtained its OMM data: a cache re-propagation
+// within the refresh window (reusedCache), a fresh fetch, or — on fetch failure with
+// a still-valid cache — a degraded serve-from-cache (servedCacheOnError). See obtainOMMs.
+type ommFetchOutcome struct {
+	result             ephemeris.GPFetchResult
+	reusedCache        bool
+	servedCacheOnError bool
+	cacheServeErr      error
+}
+
+// obtainOMMs resolves the OMM data for this reconcile (Step 4b/5). It returns the
+// outcome plus an optional early Reconcile result: non-nil when the caller must
+// return immediately — an insecure-URL rejection (I-21) or a cold-cache fetch
+// failure (the wipe path). Within the refresh window it re-propagates from cache
+// without contacting the source (#179); otherwise it fetches, falling back to a
+// still-valid cache on error rather than blackholing SIB19 (I-18). The refresh-
+// window age check is intentionally NOT applied to the error fallback — we fetched
+// because the window elapsed, and the served cache's staleness is surfaced by the
+// I-17 EphemerisEpochStale condition.
+func (r *SatelliteEphemerisReconciler) obtainOMMs(
+	ctx context.Context, req ctrl.Request, eph *ntnv1alpha1.SatelliteEphemeris,
+	fetcher ephemeris.GPFetcher, effectiveInterval time.Duration, now time.Time,
+) (ommFetchOutcome, *ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
+		c.generation == eph.Generation && c.uid == eph.UID &&
+		now.Sub(c.result.FetchedAt) < effectiveInterval {
+		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
+			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
+		return ommFetchOutcome{result: c.result, reusedCache: true}, nil, nil
+	}
+
+	// Refuse a cleartext http:// source that resolves to a PUBLIC IP (I-21).
+	if ip, insecure := r.publicHTTPSource(ctx, eph.Spec.Source.URL); insecure {
+		res, err := r.handleInsecureURL(ctx, eph, ip)
+		return ommFetchOutcome{}, &res, err
+	}
+
+	fetchStart := time.Now()
+	result, fetchErr := fetcher.Fetch(ctx, eph.Spec.Source.URL)
+	fetchStatus := "success"
+	if fetchErr != nil {
+		fetchStatus = "error"
+	}
+	ntnmetrics.GPFetchDuration.With(prometheus.Labels{"source_type": eph.Spec.Source.Type, "status": fetchStatus}).Observe(time.Since(fetchStart).Seconds())
+
+	if fetchErr != nil {
+		if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
+			c.generation == eph.Generation && c.uid == eph.UID {
+			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
+				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String())
+			return ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: fetchErr}, nil, nil
+		}
+		res, err := r.handleFetchError(ctx, eph, fetchErr, effectiveInterval)
+		return ommFetchOutcome{}, &res, err
+	}
+
+	r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, generation: eph.Generation, uid: eph.UID})
+	return ommFetchOutcome{result: result}, nil, nil
+}
+
+// classifyFetchError chooses the retry strategy for a failed GP fetch (findings.md
+// I-19b), shared by the cache-wipe and the serve-cache (I-18) paths so both back off
+// identically:
+//   - rate-limited: an EXPECTED polite-backoff state (not a controller error).
+//     Requeue at the slow refresh cadence (honoring any Retry-After) — never hammer
+//     the source into a firewall block / account suspension.
+//   - auth failure: a persistent config error; slow requeue, surfaced by condition.
+//   - anything else (timeout, DNS, 5xx, parse): a genuine transient error — return it
+//     (returnAsError) so the controller-runtime workqueue applies exponential backoff
+//     (5ms→1000s) and a persistent failure surfaces on the reconcile-error alert.
+func classifyFetchError(fetchErr error, effectiveInterval time.Duration) (reason string, requeueAfter time.Duration, returnAsError bool) {
+	switch {
+	case errors.Is(fetchErr, ephemeris.ErrRateLimited):
+		return "RateLimited", max(effectiveInterval, retryAfterFrom(fetchErr)), false
+	case errors.Is(fetchErr, ephemeris.ErrAuthFailed):
+		return "AuthFailed", effectiveInterval, false
+	default:
+		return "FetchFailed", 0, true
+	}
 }
 
 // fetcherForSource returns the appropriate GPFetcher for the source type.

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -62,6 +62,11 @@ const maxRefreshInterval = 24 * time.Hour
 // SatelliteEphemerisReconciler reconciles a SatelliteEphemeris object
 type SatelliteEphemerisReconciler struct {
 	client.Client
+	// APIReader is an UNCACHED reader (mgr.GetAPIReader) used only to read the
+	// SpaceTrack credentials Secret. The cached client would need secrets list;watch
+	// to start an informer (and would then cache every Secret in the cluster); an
+	// uncached Get needs only secrets get. Falls back to the cached client if unset.
+	APIReader               client.Reader
 	Scheme                  *runtime.Scheme
 	Recorder                events.EventRecorder
 	MaxConcurrentReconciles int
@@ -863,7 +868,14 @@ func (r *SatelliteEphemerisReconciler) fetcherForSource(
 		}
 		secret := &corev1.Secret{}
 		secretKey := types.NamespacedName{Namespace: eph.Namespace, Name: creds.Name}
-		if err := r.Get(ctx, secretKey, secret); err != nil {
+		// Read the Secret UNCACHED (APIReader) so a secrets-get RBAC suffices and the
+		// operator does not cache every Secret in the cluster. Fall back to the cached
+		// client only if no APIReader was wired (e.g. some tests).
+		reader := r.APIReader
+		if reader == nil {
+			reader = r.Client
+		}
+		if err := reader.Get(ctx, secretKey, secret); err != nil {
 			return nil, fmt.Errorf("reading credentials Secret %q: %w", creds.Name, err)
 		}
 		key := creds.Key

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -529,15 +529,16 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 		BeforeEach(func() { createResource() })
 		AfterEach(func() { deleteResource() })
 
-		It("should set FetchFailed condition and requeue after 1 minute", func() {
+		It("should set FetchFailed and return the error so the workqueue backs off (I-19b)", func() {
 			mock := &mockGPFetcher{err: errors.New("connection refused")}
 			reconciler := newReconciler(mock)
 
-			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(time.Minute))
+			// I-19b: a generic transient fetch error is RETURNED so controller-runtime's
+			// workqueue applies exponential backoff, instead of a flat requeue.
+			Expect(err).To(HaveOccurred())
 
 			updated := &ntnv1alpha1.SatelliteEphemeris{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
@@ -546,6 +547,30 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(cond.Reason).To(Equal("FetchFailed"))
+		})
+	})
+
+	Context("When fetch is rate-limited (I-19b)", func() {
+		BeforeEach(func() { createResource() })
+		AfterEach(func() { deleteResource() })
+
+		It("requeues at the slow cadence with NO error (not a controller error), honoring Retry-After", func() {
+			// A rate-limit is an expected polite-backoff state, not a controller error:
+			// Reconcile must return nil + a RequeueAfter (>= a minute), never the error
+			// (which would trigger the workqueue's fast exponential retry → firewall risk).
+			mock := &mockGPFetcher{err: &ephemeris.RateLimitError{StatusCode: 403, RetryAfter: 90 * time.Minute}}
+			result, err := newReconciler(mock).Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// Retry-After (90m) exceeds the 2h floor? No — max(effectiveInterval, 90m).
+			Expect(result.RequeueAfter).To(BeNumerically(">=", time.Minute))
+
+			updated := &ntnv1alpha1.SatelliteEphemeris{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
+			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("RateLimited"))
 		})
 	})
 
@@ -580,7 +605,9 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			// I-19b: generic error is returned (workqueue backoff). With a COLD cache
+			// (no prior successful fetch) the pass windows are still cleared.
+			Expect(err).To(HaveOccurred())
 
 			// Verify stale data is cleared.
 			updated := &ntnv1alpha1.SatelliteEphemeris{}

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -234,10 +234,12 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 
 	newReconciler := func(fetcher ephemeris.GPFetcher) *SatelliteEphemerisReconciler {
 		return &SatelliteEphemerisReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(10),
-			Fetcher:  fetcher,
+			Client: k8sClient,
+			// Exercise the uncached-read path for the SpaceTrack credentials Secret.
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(10),
+			Fetcher:   fetcher,
 		}
 	}
 

--- a/pkg/ephemeris/gp_fetcher.go
+++ b/pkg/ephemeris/gp_fetcher.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,7 +35,69 @@ import (
 var (
 	ErrRateLimited = errors.New("rate limited by upstream (HTTP 403)")
 	ErrBadResponse = errors.New("unexpected HTTP response")
+	// ErrAuthFailed marks a credential/authentication failure (e.g. Space-Track
+	// returns HTTP 200 with a {"Login":"Failed"} body on bad credentials). It is a
+	// persistent error — retrying with the same credentials cannot succeed — so the
+	// caller requeues slowly rather than hammering the login endpoint (which risks
+	// account suspension). findings.md I-20.
+	ErrAuthFailed = errors.New("authentication failed")
 )
+
+// userAgent is a descriptive User-Agent as required by CelesTrak's usage policy
+// (machine-to-machine clients must identify themselves). findings.md I-19b/N-7.
+const userAgent = "ntn-operators/0.6 (+https://github.com/thc1006/ntn-operators)"
+
+// maxRetryAfter caps a server-supplied Retry-After so a malicious or garbled value
+// cannot park the reconcile arbitrarily far in the future.
+const maxRetryAfter = 24 * time.Hour
+
+// RateLimitError is returned when the GP source signals rate limiting. It carries
+// the parsed Retry-After delay (0 if none) and the observed status code. Different
+// sources signal differently (CelesTrak: HTTP 403; Space-Track: HTTP 500 with a
+// "violated your query rate limit" body; a fronting proxy may use 429), so the
+// caller keys off this type, not a raw status. It satisfies errors.Is(err,
+// ErrRateLimited) for backward compatibility. findings.md I-19b.
+type RateLimitError struct {
+	RetryAfter time.Duration
+	StatusCode int
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("rate limited by upstream (HTTP %d)", e.StatusCode)
+}
+
+// Is lets errors.Is(err, ErrRateLimited) match a *RateLimitError.
+func (e *RateLimitError) Is(target error) bool { return target == ErrRateLimited }
+
+// parseRetryAfter parses a Retry-After header per RFC 9110 §10.2.3, which allows
+// BOTH forms: delay-seconds (a non-negative integer, e.g. "120") OR an HTTP-date.
+// Returns 0 when absent/unparseable, clamped to [0, maxRetryAfter]. CelesTrak and
+// Space-Track do not currently send Retry-After; this is defensive (a CDN/proxy in
+// front might). findings.md I-19b.
+func parseRetryAfter(h http.Header) time.Duration {
+	v := strings.TrimSpace(h.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil { // delay-seconds
+		return clampRetryAfter(time.Duration(secs) * time.Second)
+	}
+	if t, err := http.ParseTime(v); err == nil { // HTTP-date
+		return clampRetryAfter(time.Until(t))
+	}
+	return 0
+}
+
+func clampRetryAfter(d time.Duration) time.Duration {
+	switch {
+	case d < 0:
+		return 0
+	case d > maxRetryAfter:
+		return maxRetryAfter
+	default:
+		return d
+	}
+}
 
 // maxResponseBody is the maximum size of a CelesTrak response we'll read (50 MB).
 const maxResponseBody = 50 * 1024 * 1024
@@ -86,7 +150,7 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 	if err != nil {
 		return GPFetchResult{}, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("User-Agent", "ntn-operators/0.1")
+	req.Header.Set("User-Agent", userAgent)
 
 	// Set conditional GET header if we have a cached ETag.
 	if etag, ok := f.etagCache.Load(url); ok {
@@ -143,8 +207,12 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 			FetchedAt:      now,
 		}, nil
 
-	case http.StatusForbidden:
-		return GPFetchResult{}, ErrRateLimited
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		// CelesTrak signals over-frequency / bandwidth abuse with a custom HTTP 403
+		// (429 handled defensively for a fronting proxy). Retrying does not change
+		// the response and risks a firewall block, so this is a rate-limit signal,
+		// not a transient error — the caller requeues at the slow refresh cadence.
+		return GPFetchResult{}, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
 
 	default:
 		return GPFetchResult{}, fmt.Errorf("%w: HTTP %d from %s", ErrBadResponse, resp.StatusCode, url)

--- a/pkg/ephemeris/gp_fetcher_test.go
+++ b/pkg/ephemeris/gp_fetcher_test.go
@@ -165,6 +165,65 @@ func TestFetch_HTTP403_RateLimited(t *testing.T) {
 	}
 }
 
+// TestFetch_HTTP429_RateLimited pins I-19b: a 429 (defensive; e.g. a fronting CDN)
+// is rate-limited and its Retry-After is parsed into the typed error.
+func TestFetch_HTTP429_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewCelesTrakFetcher(server.Client()).Fetch(context.Background(), server.URL)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("429 must be rate-limited, got %v", err)
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected a *RateLimitError, got %v", err)
+	}
+	if rle.RetryAfter != 120*time.Second {
+		t.Errorf("Retry-After: 120 must parse to 120s, got %v", rle.RetryAfter)
+	}
+	if rle.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want 429", rle.StatusCode)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Now().UTC()
+	cases := []struct {
+		name, val string
+		want      time.Duration
+		approx    bool
+	}{
+		{"absent", "", 0, false},
+		{"delay-seconds", "120", 120 * time.Second, false},
+		{"zero", "0", 0, false},
+		{"garbage", "soon", 0, false},
+		{"negative clamped to 0", "-5", 0, false},
+		{"huge clamped to max", "999999999", maxRetryAfter, false},
+		{"http-date future", now.Add(90 * time.Second).Format(http.TimeFormat), 90 * time.Second, true},
+		{"http-date past", now.Add(-1 * time.Hour).Format(http.TimeFormat), 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.val != "" {
+				h.Set("Retry-After", tc.val)
+			}
+			got := parseRetryAfter(h)
+			if tc.approx {
+				if got < tc.want-5*time.Second || got > tc.want+2*time.Second {
+					t.Errorf("parseRetryAfter(%q) = %v, want ~%v", tc.val, got, tc.want)
+				}
+			} else if got != tc.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFetch_HTTP500_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/ephemeris/spacetrack_fetcher.go
+++ b/pkg/ephemeris/spacetrack_fetcher.go
@@ -17,7 +17,9 @@ limitations under the License.
 package ephemeris
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -160,20 +162,54 @@ func (f *SpaceTrackFetcher) doLogin(ctx context.Context, username, password stri
 		return fmt.Errorf("creating login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("login request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	// Drain body to reuse connection.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// Read the login body (small; also drains it for connection reuse). Space-Track
+	// signals bad credentials with HTTP 200 + a {"Login":"Failed"} body, so a 200
+	// alone does NOT mean authenticated — the body must be inspected (I-20).
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
+	// A 401/403 (e.g. no session cookie issued) is an auth failure too.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("%w: SpaceTrack login rejected (HTTP %d)", ErrAuthFailed, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("login returned HTTP %d", resp.StatusCode)
 	}
-
+	if loginBodyIndicatesFailure(body) {
+		return fmt.Errorf("%w: SpaceTrack rejected the credentials (Login=Failed)", ErrAuthFailed)
+	}
 	return nil
+}
+
+// loginBodyIndicatesFailure reports whether a HTTP-200 Space-Track login response
+// body indicates rejected credentials. Space-Track returns {"Login":"Failed"} on a
+// bad login (a successful login body is empty / cookie-only, so it never carries a
+// Login=Failed marker). Parses the documented JSON shape first (whitespace/case-
+// tolerant); if the body is not JSON, falls back to requiring BOTH the "login" and
+// "failed" tokens (never a bare "failed", to avoid false positives). findings.md I-20.
+func loginBodyIndicatesFailure(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	var m map[string]json.RawMessage
+	if json.Unmarshal(trimmed, &m) == nil {
+		for k, raw := range m {
+			if !strings.EqualFold(k, "Login") {
+				continue
+			}
+			var s string
+			if json.Unmarshal(raw, &s) == nil && strings.EqualFold(s, "Failed") {
+				return true
+			}
+		}
+		return false // valid JSON, no Login=Failed → treat as an authenticated response
+	}
+	low := bytes.ToLower(trimmed)
+	return bytes.Contains(low, []byte(`"login"`)) && bytes.Contains(low, []byte(`"failed"`))
 }
 
 // errSessionExpired is a sentinel for 401 detection in retry logic.
@@ -192,7 +228,7 @@ func (f *SpaceTrackFetcher) doFetchGPRaw(ctx context.Context, gpURL string) ([]b
 	if err != nil {
 		return nil, fmt.Errorf("creating GP request: %w", err)
 	}
-	req.Header.Set("User-Agent", "ntn-operators/0.1")
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
@@ -215,7 +251,17 @@ func (f *SpaceTrackFetcher) doFetchGPRaw(ctx context.Context, gpURL string) ([]b
 
 	case http.StatusForbidden, http.StatusTooManyRequests:
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, ErrRateLimited
+		return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
+
+	case http.StatusInternalServerError:
+		// Space-Track signals a query-rate-limit violation with HTTP 500 and a body
+		// containing "violated your query rate limit" — NOT 429. Only that specific
+		// 500 is a rate limit; any other 500 is a genuine server error. I-19b.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if bytes.Contains(bytes.ToLower(body), []byte("violated your query rate limit")) {
+			return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
+		}
+		return nil, fmt.Errorf("%w: HTTP 500 from %s", ErrBadResponse, gpURL)
 
 	case http.StatusUnauthorized:
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/ephemeris/spacetrack_fetcher_test.go
+++ b/pkg/ephemeris/spacetrack_fetcher_test.go
@@ -18,6 +18,7 @@ package ephemeris
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -151,6 +152,61 @@ func TestSpaceTrackFetcher_LoginFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for failed login")
 	}
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Errorf("a 401 login must be an ErrAuthFailed, got %v", err)
+	}
+}
+
+// TestSpaceTrackFetcher_LoginFailure_200Body pins I-20: Space-Track returns HTTP
+// 200 with a {"Login":"Failed"} body on bad credentials. Before the fix, the 200
+// status alone read as success and the failure surfaced only later, cryptically.
+func TestSpaceTrackFetcher_LoginFailure_200Body(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == loginPath {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"Login":"Failed"}`) // Space-Track's bad-cred body
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	fetcher := NewSpaceTrackFetcher(server.Client(), server.URL)
+	fetcher.SetCredentials("bad", "creds")
+
+	_, err := fetcher.Fetch(context.Background(), server.URL+"/gp")
+	if err == nil {
+		t.Fatal("expected an auth error for a 200 + {\"Login\":\"Failed\"} body")
+	}
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Errorf("a 200 + Login=Failed body must be an ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestLoginBodyIndicatesFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"documented failure", `{"Login":"Failed"}`, true},
+		{"failure with whitespace", "  {\n \"Login\" : \"Failed\" \n} ", true},
+		{"value case-insensitive", `{"Login":"failed"}`, true},
+		{"key case-insensitive", `{"login":"Failed"}`, true},
+		{"success empty string", `""`, false},
+		{"success empty object", `{}`, false},
+		{"login success value", `{"Login":"Success"}`, false},
+		{"unrelated json", `{"request_id":42}`, false},
+		{"non-json but not a failure marker", `Welcome`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := loginBodyIndicatesFailure([]byte(tc.body)); got != tc.want {
+				t.Errorf("loginBodyIndicatesFailure(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestSpaceTrackFetcher_NoCredentials(t *testing.T) {
@@ -183,8 +239,48 @@ func TestSpaceTrackFetcher_RateLimited(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected rate limit error")
 	}
-	if err != ErrRateLimited {
-		t.Errorf("expected ErrRateLimited, got %v", err)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("expected a rate-limit error, got %v", err)
+	}
+}
+
+// TestSpaceTrackFetcher_RateLimited500Body pins I-19b: Space-Track signals a query
+// rate-limit with HTTP 500 + a "violated your query rate limit" body (NOT 429), and
+// that specific 500 must classify as rate-limited (a different 500 stays a bad response).
+func TestSpaceTrackFetcher_RateLimited500Body(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == loginPath {
+			http.SetCookie(w, &http.Cookie{Name: "chocolatechip", Value: "s", Path: "/"})
+			_, _ = fmt.Fprint(w, `""`)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "Error: You have violated your query rate limit.")
+	}))
+	defer server.Close()
+
+	fetcher := NewSpaceTrackFetcher(server.Client(), server.URL)
+	fetcher.SetCredentials("u", "p")
+
+	_, err := fetcher.Fetch(context.Background(), server.URL+"/gp")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("a 500 + 'violated your query rate limit' body must be rate-limited, got %v", err)
+	}
+
+	// A different 500 must NOT be a rate limit.
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == loginPath {
+			http.SetCookie(w, &http.Cookie{Name: "chocolatechip", Value: "s", Path: "/"})
+			_, _ = fmt.Fprint(w, `""`)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server2.Close()
+	f2 := NewSpaceTrackFetcher(server2.Client(), server2.URL)
+	f2.SetCredentials("u", "p")
+	if _, err := f2.Fetch(context.Background(), server2.URL+"/gp"); errors.Is(err, ErrRateLimited) {
+		t.Errorf("a generic 500 must NOT be classified rate-limited, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Hardens the SatelliteEphemeris fetch path against three real-world failure modes an audit surfaced, so a transient upstream problem degrades gracefully (keeps serving SIB19 continuity) instead of blackholing.

- **I-20 (SpaceTrack auth):** a bad credential returns HTTP 200 with a `{"Login":"Failed"}` body, not a 4xx. `doLogin` now inspects the body → `ErrAuthFailed`; the reconciler slow-requeues (no login hammering → no account suspension).
- **I-19b (rate-limit reclassification):** rate limiting is a typed `*RateLimitError` — CelesTrak HTTP 403 (verified 2026-07), Space-Track HTTP 500 + "violated your query rate limit" body; 429 kept defensively. `Retry-After` parsed per RFC 9110 (both delay-seconds and HTTP-date). A generic transient error is returned so controller-runtime's workqueue applies its built-in exponential backoff instead of a hand-rolled counter. Adds the descriptive User-Agent CelesTrak's policy requires.
- **I-18 (cache fallback):** on a fetch failure with a still-valid cache, serve the cached OMMs — pass windows re-predicted (not wiped), runtime-push states re-propagated — surfacing `GPDataFetched=False/FetchFailedServingCache`.

External-API behavior was validated via a multi-source deep-research pass before implementing (which corrected the original 429 assumption to 403 and dropped a hand-rolled backoff in favor of the workqueue).

**Verification:** each fix mutation-verified; `make lint` clean; ephemeris + controller suites green.
