### PR TITLE
fix(ephemeris): trim pass windows to the minElevation mask [I-22]

### DIFF
--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -218,20 +218,135 @@ func predictSingle(
 		return nil, nil
 	}
 
+	observer := &sgp4.Location{Latitude: gs.Latitude, Longitude: gs.Longitude, Altitude: gs.Altitude}
+	elevFn := func(t time.Time) (float64, error) { return elevationAt(tle, observer, t) }
+
 	var results []PassResult
 	for _, p := range passes {
 		if p.MaxElevation < minElevation {
 			continue
 		}
+		// The library defines AOS/LOS at the 0° geometric horizon, but a link is
+		// only usable at/above minElevation. Trim each window to the interval where
+		// elevation >= minElevation (I-22) so availability consumers (e.g. NTNSlice
+		// failover) never treat a below-mask, unusable link as available.
+		aos, los := trimPassToMask(elevFn, p, minElevation)
+		if !los.After(aos) {
+			// Grazing pass whose usable window collapsed to (near) zero once the
+			// mask is applied — the satellite only brushes the mask, so drop it.
+			continue
+		}
 		results = append(results, PassResult{
 			Satellite:     omm.ObjectName,
 			GroundStation: gs.Name,
-			AOS:           p.AOS,
-			LOS:           p.LOS,
+			AOS:           aos,
+			LOS:           los,
 			MaxElevation:  p.MaxElevation,
 		})
 	}
 	return results, nil
+}
+
+const (
+	// maskCrossingIterations bounds the mask-crossing bisection. A LEO half-pass
+	// arc is at most a few hundred seconds, so this many halvings resolve the
+	// crossing far below one second; the loop also stops early once the bracket
+	// is under maskCrossingTol.
+	maskCrossingIterations = 40
+	// maskCrossingTol is the bracket width at which the bisection is considered
+	// converged (sub-second, as libpredict-style AOS/LOS refinement targets).
+	maskCrossingTol = 200 * time.Millisecond
+)
+
+// elevationAt returns the topocentric elevation (degrees) of the satellite as
+// seen from observer at time t. It mirrors the private elevation helper inside
+// akhenakh/sgp4's GeneratePasses, which is what lets us re-derive the
+// minElevation crossings the library itself only computes at the 0° horizon.
+func elevationAt(tle *sgp4.TLE, observer *sgp4.Location, t time.Time) (float64, error) {
+	eci, err := tle.FindPositionAtTime(t)
+	if err != nil {
+		return 0, err
+	}
+	sv := &sgp4.StateVector{
+		X: eci.Position.X, Y: eci.Position.Y, Z: eci.Position.Z,
+		VX: eci.Velocity.X, VY: eci.Velocity.Y, VZ: eci.Velocity.Z,
+	}
+	obs, err := sv.GetLookAngle(observer, t)
+	if err != nil {
+		return 0, err
+	}
+	return obs.LookAngles.Elevation, nil
+}
+
+// trimPassToMask narrows a 0°-horizon pass to the sub-interval where elevation
+// is at or above mask. Elevation over a single pass is unimodal (it rises to one
+// peak at p.MaxElevationTime, then falls), so the mask is crossed at most once on
+// each side of the peak. Each crossing is refined by bisection. Endpoints are
+// only trimmed when the satellite actually starts/ends below the mask, so a pass
+// clipped by the prediction window boundary (already above the mask at start or
+// stop) is left untouched on that side. mask <= 0 is a no-op (the 0° horizon
+// already satisfies it).
+func trimPassToMask(elevFn func(time.Time) (float64, error), p sgp4.PassDetails, mask float64) (aos, los time.Time) {
+	aos, los = p.AOS, p.LOS
+	if mask <= 0 {
+		return aos, los
+	}
+	peak := p.MaxElevationTime
+
+	// AOS side: [aos, peak] straddles the rising crossing when the satellite
+	// starts below the mask. (peak must be strictly after aos to be a valid
+	// bracket; peak's elevation is >= mask because the pass survived the
+	// MaxElevation filter.)
+	if peak.After(aos) {
+		if elAOS, err := elevFn(aos); err == nil && elAOS < mask {
+			if t, err := refineMaskCrossing(elevFn, aos, peak, mask, true); err == nil {
+				aos = t
+			}
+		}
+	}
+	// LOS side: [peak, los] straddles the falling crossing when the satellite
+	// ends below the mask.
+	if los.After(peak) {
+		if elLOS, err := elevFn(los); err == nil && elLOS < mask {
+			if t, err := refineMaskCrossing(elevFn, peak, los, mask, false); err == nil {
+				los = t
+			}
+		}
+	}
+	return aos, los
+}
+
+// refineMaskCrossing bisects [lo, hi] for the instant elevation crosses mask,
+// given the endpoints straddle it: for a rising crossing elevation(lo) < mask <=
+// elevation(hi); for a falling crossing elevation(lo) >= mask > elevation(hi).
+// It returns the boundary on the USABLE side (elevation >= mask) — hi for a
+// rising crossing (AOS), lo for a falling one (LOS) — so the trimmed window is a
+// subset of {t : elevation(t) >= mask} and never over-claims below-mask time.
+func refineMaskCrossing(
+	elevFn func(time.Time) (float64, error),
+	lo, hi time.Time,
+	mask float64,
+	rising bool,
+) (time.Time, error) {
+	for i := 0; i < maskCrossingIterations && hi.Sub(lo) > maskCrossingTol; i++ {
+		mid := lo.Add(hi.Sub(lo) / 2)
+		el, err := elevFn(mid)
+		if err != nil {
+			return time.Time{}, err
+		}
+		above := el >= mask
+		// Keep the bracket invariant (lo below/hi above for rising; lo above/hi
+		// below for falling) so the returned usable-side boundary stays valid.
+		if above == rising {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	if rising {
+		return hi, nil
+	}
+	return lo, nil
 }
 
 // FilterOMMs returns OMMs matching the NORAD ID filter. If filter is empty, returns all.

--- a/pkg/ephemeris/pass_predictor_mask_test.go
+++ b/pkg/ephemeris/pass_predictor_mask_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ephemeris
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+)
+
+// TestRefineMaskCrossing pins the bisection root-finder in isolation on a
+// synthetic, strictly-monotonic elevation ramp so the crossing time is known
+// exactly — no orbital dependency. It checks both sub-second precision and that
+// the returned boundary is on the usable (elevation >= mask) side.
+func TestRefineMaskCrossing(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	span := 300 * time.Second
+	const mask = 30.0
+
+	// Rising ramp 0°→90° over 300s → crosses 30° at t=100s.
+	rising := func(at time.Time) (float64, error) {
+		return at.Sub(base).Seconds() / span.Seconds() * 90.0, nil
+	}
+	got, err := refineMaskCrossing(rising, base, base.Add(span), mask, true)
+	if err != nil {
+		t.Fatalf("rising: unexpected error: %v", err)
+	}
+	if d := got.Sub(base) - 100*time.Second; d < -maskCrossingTol || d > maskCrossingTol {
+		t.Errorf("rising crossing = %v, want 100s (±%v)", got.Sub(base), maskCrossingTol)
+	}
+	if el, _ := rising(got); el < mask {
+		t.Errorf("rising boundary elevation %.4f must be on the usable side (>= %.0f)", el, mask)
+	}
+
+	// Falling ramp 90°→0° over 300s → crosses 30° at t=200s.
+	falling := func(at time.Time) (float64, error) {
+		return 90.0 - at.Sub(base).Seconds()/span.Seconds()*90.0, nil
+	}
+	got, err = refineMaskCrossing(falling, base, base.Add(span), mask, false)
+	if err != nil {
+		t.Fatalf("falling: unexpected error: %v", err)
+	}
+	if d := got.Sub(base) - 200*time.Second; d < -maskCrossingTol || d > maskCrossingTol {
+		t.Errorf("falling crossing = %v, want 200s (±%v)", got.Sub(base), maskCrossingTol)
+	}
+	if el, _ := falling(got); el < mask {
+		t.Errorf("falling boundary elevation %.4f must be on the usable side (>= %.0f)", el, mask)
+	}
+}
+
+// TestTrimPassToMask_Guards pins the non-orbital edge cases of the trimmer:
+// mask <= 0 is a no-op, and a propagation error leaves that side untrimmed
+// (degrade to the 0°-horizon window rather than dropping a real pass).
+func TestTrimPassToMask_Guards(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	p := sgp4.PassDetails{
+		AOS:              base,
+		LOS:              base.Add(600 * time.Second),
+		MaxElevationTime: base.Add(300 * time.Second),
+		MaxElevation:     70,
+	}
+
+	// mask <= 0: the 0° horizon already satisfies it → return the window verbatim,
+	// without ever calling the elevation function.
+	called := false
+	noop := func(time.Time) (float64, error) { called = true; return 0, nil }
+	aos, los := trimPassToMask(noop, p, 0)
+	if !aos.Equal(p.AOS) || !los.Equal(p.LOS) {
+		t.Errorf("mask=0 must be a no-op, got [%v,%v]", aos, los)
+	}
+	if called {
+		t.Error("mask=0 must not evaluate elevation")
+	}
+
+	// Propagation error on both endpoints → both sides left untrimmed.
+	boom := func(time.Time) (float64, error) { return 0, errors.New("propagation failed") }
+	aos, los = trimPassToMask(boom, p, 30)
+	if !aos.Equal(p.AOS) || !los.Equal(p.LOS) {
+		t.Errorf("elevation error must leave the window untrimmed, got [%v,%v]", aos, los)
+	}
+}
+
+// TestTrimPassToMask_Synthetic drives the full trimmer with a synthetic unimodal
+// elevation profile (a triangle peaking at the pass midpoint) so AOS/LOS mask
+// crossings are analytically known, independent of any orbital propagation.
+func TestTrimPassToMask_Synthetic(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	// Triangle: 0° at AOS, rises to 80° at the midpoint (300s), back to 0° at LOS
+	// (600s). Slope = 80°/300s. mask=40° ⇒ up-crossing at 150s, down-crossing at 450s.
+	peak := 80.0
+	half := 300 * time.Second
+	tri := func(at time.Time) (float64, error) {
+		d := at.Sub(base)
+		if d <= half {
+			return d.Seconds() / half.Seconds() * peak, nil
+		}
+		return peak - (d-half).Seconds()/half.Seconds()*peak, nil
+	}
+	p := sgp4.PassDetails{
+		AOS:              base,
+		LOS:              base.Add(2 * half),
+		MaxElevationTime: base.Add(half),
+		MaxElevation:     peak,
+	}
+	const mask = 40.0
+	aos, los := trimPassToMask(tri, p, mask)
+
+	if d := aos.Sub(base) - 150*time.Second; d < -maskCrossingTol || d > maskCrossingTol {
+		t.Errorf("AOS crossing = %v, want 150s (±%v)", aos.Sub(base), maskCrossingTol)
+	}
+	if d := los.Sub(base) - 450*time.Second; d < -maskCrossingTol || d > maskCrossingTol {
+		t.Errorf("LOS crossing = %v, want 450s (±%v)", los.Sub(base), maskCrossingTol)
+	}
+	// Endpoints must sit on the usable (>= mask) side, and the window must be a
+	// strict subset of the 0°-horizon span.
+	if el, _ := tri(aos); el < mask {
+		t.Errorf("trimmed AOS elevation %.4f below mask %.0f", el, mask)
+	}
+	if el, _ := tri(los); el < mask {
+		t.Errorf("trimmed LOS elevation %.4f below mask %.0f", el, mask)
+	}
+	if !aos.After(p.AOS) || !los.Before(p.LOS) {
+		t.Errorf("trimmed window [%v,%v] must be strictly inside [%v,%v]", aos, los, p.AOS, p.LOS)
+	}
+}
+
+// TestPredictPasses_MaskConformance is the I-22 acceptance invariant on real
+// orbital geometry: every reported pass window lies ENTIRELY at or above the
+// mask. Before the fix, AOS/LOS were the 0° horizon crossings, so the window
+// included unusable below-mask time near each end — this test fails on that code.
+func TestPredictPasses_MaskConformance(t *testing.T) {
+	const mask = 30.0
+	omm := issOMM()
+	gs := montrealStation
+	start := time.Now().UTC()
+	horizon := 72 * time.Hour
+
+	masked, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
+	if err != nil {
+		t.Fatalf("PredictPasses(mask=%.0f): %v", mask, err)
+	}
+	if len(masked) == 0 {
+		t.Skipf("no ISS pass >= %.0f° over %s in %v — geometry-dependent", mask, gs.Name, horizon)
+	}
+
+	tle, err := omm.ToTLE()
+	if err != nil {
+		t.Fatalf("ToTLE: %v", err)
+	}
+	observer := &sgp4.Location{Latitude: gs.Latitude, Longitude: gs.Longitude, Altitude: gs.Altitude}
+
+	// tol absorbs the sub-second bisection residual (elevation can move ~1°/s at
+	// low elevation for a LEO), not a below-mask window.
+	const tol = 1.0
+	for _, p := range masked {
+		window := p.LOS.Sub(p.AOS)
+		for _, frac := range []float64{0.0, 0.2, 0.5, 0.8, 1.0} {
+			at := p.AOS.Add(time.Duration(frac * float64(window)))
+			el, err := elevationAt(tle, observer, at)
+			if err != nil {
+				t.Fatalf("elevationAt: %v", err)
+			}
+			if el < mask-tol {
+				t.Errorf("pass [%v,%v]: elevation %.3f° at frac %.1f is below the %.0f° mask — window over-claims unusable time",
+					p.AOS.Format(time.RFC3339), p.LOS.Format(time.RFC3339), el, frac, mask)
+			}
+		}
+	}
+}
+
+// TestPredictPasses_MaskWindowSubset proves the trim is not a no-op: a masked
+// window is a subset of the 0°-horizon window for the same physical pass, and a
+// pass whose peak comfortably clears the mask is strictly shorter. The two runs
+// share one OMM + one start time, so geometry is identical and passes pair by
+// their (preserved, unmodified) MaxElevation.
+func TestPredictPasses_MaskWindowSubset(t *testing.T) {
+	const mask = 25.0
+	omm := issOMM()
+	gs := montrealStation
+	start := time.Now().UTC()
+	horizon := 72 * time.Hour
+
+	full, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, 0, horizon, nil, start)
+	if err != nil {
+		t.Fatalf("full: %v", err)
+	}
+	masked, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
+	if err != nil {
+		t.Fatalf("masked: %v", err)
+	}
+	if len(masked) == 0 {
+		t.Skipf("no ISS pass >= %.0f° over %s in %v — geometry-dependent", mask, gs.Name, horizon)
+	}
+	if len(masked) > len(full) {
+		t.Fatalf("masked passes (%d) cannot exceed 0°-horizon passes (%d)", len(masked), len(full))
+	}
+
+	byPeak := make(map[float64]PassResult, len(full))
+	for _, f := range full {
+		byPeak[f.MaxElevation] = f
+	}
+
+	trimmed := 0
+	for _, m := range masked {
+		f, ok := byPeak[m.MaxElevation]
+		if !ok {
+			t.Fatalf("masked pass (peak %.6f°) has no matching 0°-horizon pass", m.MaxElevation)
+		}
+		if m.AOS.Before(f.AOS) || m.LOS.After(f.LOS) {
+			t.Errorf("masked window [%v,%v] is not inside the 0° window [%v,%v]",
+				m.AOS, m.LOS, f.AOS, f.LOS)
+		}
+		if m.LOS.Sub(m.AOS) < f.LOS.Sub(f.AOS) {
+			trimmed++
+		}
+		// A pass peaking well above the mask must be shortened, unless its 0° window
+		// was clipped by the horizon boundary (started at the window start or ended
+		// at the window stop) so there was no sub-mask tail to trim on that side.
+		clippedAtStart := f.AOS.Equal(start)
+		clippedAtStop := f.LOS.Equal(start.Add(horizon))
+		if m.MaxElevation > mask+15 && !clippedAtStart && !clippedAtStop &&
+			m.LOS.Sub(m.AOS) >= f.LOS.Sub(f.AOS) {
+			t.Errorf("high pass (peak %.1f°) not shortened by the %.0f° mask: masked %v vs 0° %v",
+				m.MaxElevation, mask, m.LOS.Sub(m.AOS), f.LOS.Sub(f.AOS))
+		}
+	}
+	if trimmed == 0 {
+		t.Skip("no pass was trimmed (all clipped at the horizon boundary?) — geometry-dependent")
+	}
+}


### PR DESCRIPTION
`GeneratePasses` (akhenakh/sgp4) defines AOS/LOS at the 0° geometric horizon, and `predictSingle` only filtered a pass out when its *peak* fell below `minElevation` — the reported `[AOS, LOS]` window still spanned horizon-to-horizon, including the unusable below-mask time near each end. `NTNSlice.checkSatelliteAvailability` treats "now inside a pass window" as available, so a satellite sitting at a few degrees (below a 10° mask) was reported available and failover could hand traffic to an unusable link.

Trim each surviving pass to the sub-interval where elevation ≥ `minElevation` (the libpredict definition). Elevation over a single pass is unimodal, so the mask is crossed at most once each side of the peak; each crossing is refined by bisection to sub-second precision, returning the usable-side (≥ mask) boundary so the window never over-claims below-mask time. A window-boundary-clipped pass is left untouched on that side; a grazing pass whose usable window collapses is dropped. `MaxElevation` still reports the true peak; `mask ≤ 0` is a no-op.

**Verification:** the trimming and the usable-side boundary selection are both mutation-verified; the acceptance test asserts every reported window lies entirely at/above the mask on real ISS geometry (fails on the 0°-horizon code). `make lint` clean; ephemeris suite green under `-race`.
