### PR TITLE
fix(chart): NetworkPolicy egress for Prometheus/gNB; add ops docs [I-27/I-28/I-30/B-7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ clean). No CRD, controller, or config changes since the rc; same tree,
 re-tagged as the stable release. The full v0.5.0 → 0.6.0 delta is in the
 `[0.6.0-rc.1]` section below.
 
+### Upgrade notes
+
+- **CRDs upgrade separately on Option A (`--set crd.enable=false`).** `make
+  install` at the new tag **before** `helm upgrade`, or the new operator runs
+  against v0.5.0 CRDs and the runtime NTN push silently no-ops (the apiserver
+  drops the fields the old schema lacks). See the README "Upgrading (CRD skew)"
+  note. Rollback guidance: [RELEASING.md](RELEASING.md) § Rollback.
+- **Breaking: `siWindowPosition` minimum raised 0 → 2.** SIB19 must be scheduled
+  after the SIB2 the emitter always adds, so `spec.cellOverrides.sibSchedule.siWindowPosition`
+  now validates as `>= 2` (default 2). NTNCellConfigs authored under ≤ v0.5.0
+  with an **explicit** `siWindowPosition` of `0` or `1` are rejected by the
+  v0.6.0 CRD on their next apply/edit (objects left unset are unaffected — they
+  pick up the new default of 2). Migrate before upgrading the CRD:
+
+  ```bash
+  # List NTNCellConfigs pinned below the new minimum.
+  kubectl get ntncellconfig -A -o json \
+    | jq -r '.items[] | select(.spec.cellOverrides.sibSchedule.siWindowPosition != null and .spec.cellOverrides.sibSchedule.siWindowPosition < 2) | "\(.metadata.namespace)/\(.metadata.name)"'
+  # Patch each to a valid value (2 = the new default/minimum).
+  kubectl patch ntncellconfig <name> -n <ns> --type=merge \
+    -p '{"spec":{"cellOverrides":{"sibSchedule":{"siWindowPosition":2}}}}'
+  ```
+
 ## [0.6.0-rc.1] - 2026-07-09
 
 Config-emitter correctness and runtime NTN push, verified end-to-end against a

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ helm install ntn-operators dist/chart \
   --set crd.enable=false
 ```
 
+> **Upgrading (CRD skew).** With `--set crd.enable=false` the CRDs are managed
+> out-of-band by `make install`, so `helm upgrade` bumps the operator Deployment
+> but **not** the CRDs. Re-run `make install` at the new tag *before* the
+> `helm upgrade`:
+>
+> ```bash
+> git checkout vX.Y.Z && make install   # CRDs first, at the new tag
+> helm upgrade ntn-operators dist/chart --namespace ntn-operators-system --set crd.enable=false
+> ```
+>
+> Skipping this leaves a new operator running against last release's CRDs; the
+> apiserver silently drops fields the old schema doesn't know, so v0.6+ features
+> that depend on new spec fields (e.g. the runtime NTN push) go quietly inert.
+> To let Helm own the CRD lifecycle instead, install with `--set crd.enable=true`
+> (the default) and omit `make install` — then `helm upgrade` updates both
+> together.
+
 ### Option B: One-command Kind Demo
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,36 @@ does:
   migration pod) — conversion webhooks are deferred until 1.0.
 - Announce the break in the GitHub Release body prominently.
 
+## Rollback
+
+Rolling the operator back is safe; rolling the **CRD schema** back is the
+hazard. The chart renders CRDs as ordinary templates gated by `crd.enable`
+(there is no install-only `crds/` directory), so a `helm rollback` with
+`crd.enable=true` re-applies the *previous* release's CRD schema. If the
+release you are leaving added or tightened a field (e.g. raised a `Minimum`,
+narrowed an `Enum`), CRs already persisted under the newer schema can be
+rejected on their next write, and fields the old schema doesn't know are
+dropped — a silent data loss.
+
+Prefer an **operator-only rollback** that leaves the CRDs forward:
+
+```bash
+# CRDs stay at the newer (forward-compatible) schema; only the workload reverts.
+helm rollback ntn-operators <PREVIOUS_REVISION> \
+  --namespace ntn-operators-system --set crd.enable=false
+# (Option A / make-install users manage CRDs out-of-band, so their rollback
+#  never touches CRDs either — just roll the operator image.)
+```
+
+`crd.keep=true` (the chart default) means an uninstall never deletes CRDs or
+CRs, so your data survives an uninstall/reinstall — but it does **not** protect
+you from an incompatible schema being re-applied by a full `helm rollback`.
+
+If you genuinely must revert the CRD schema, migrate stored objects **first**:
+patch every CR back to values the old schema accepts, then apply the old CRDs.
+Verify after any rollback that the operator is `Available` and the CRs still
+report `Ready`/their expected conditions.
+
 ## Artifacts a release produces
 
 - Git tag, annotated

--- a/dist/chart/templates/manager/networkpolicy.yaml
+++ b/dist/chart/templates/manager/networkpolicy.yaml
@@ -36,4 +36,24 @@ spec:
           protocol: TCP
         - port: 53
           protocol: UDP
+    {{- with .Values.networkPolicy.prometheusPorts }}
+    # Allow querying the in-cluster Prometheus (NTNSlice metricsSource reader)
+    - ports:
+        {{- range . }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.gnbPorts }}
+    # Allow the runtime NTN push to the gNB remote_control WebSocket
+    - ports:
+        {{- range . }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    # Operator-supplied egress rules (e.g. namespace/CIDR-scoped Prometheus/gNB)
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -122,10 +122,39 @@ podDisruptionBudget:
   minAvailable: 1
 
 ## NetworkPolicy for zero-trust pod networking.
-## Restricts ingress to metrics (8443) and health probes (8081),
-## egress to HTTPS (443) and DNS (53).
+## Ingress: metrics (8443) and health probes (8081).
+## Egress: HTTPS 443 (Kubernetes API server, CelesTrak, Space-Track) and DNS 53.
+## The operator ALSO reaches two data-path targets whose addresses are set
+## per-CR, so they cannot be hardcoded here — leave them out and enabling this
+## policy silently blackholes them:
+##   - the in-cluster Prometheus that NTNSlice.spec.metricsSource.prometheus.endpoint
+##     queries (default port 9090), and
+##   - the gNB remote_control WebSocket that
+##     NTNCellConfig.spec.provider.remoteControl.endpoint targets (host:port).
+## List the ports you actually use below; use extraEgress to scope by
+## namespace/CIDR if the port-only default is too broad for your policy.
 ## Requires a CNI plugin that implements NetworkPolicy (e.g., Calico, Cilium).
 ##
 networkPolicy:
   enable: false
+  ## Egress ports for the in-cluster Prometheus queried by NTNSlice metricsSource.
+  ## Set to [] if no NTNSlice uses a prometheus metricsSource.
+  prometheusPorts:
+    - 9090
+  ## Egress ports for the gNB remote_control WebSocket targeted by the runtime
+  ## NTN push (NTNCellConfig.spec.provider.remoteControl.endpoint). Add every
+  ## distinct gNB port in use; set to [] if no NTNCellConfig configures a runtime push.
+  gnbPorts:
+    - 8001
+  ## Advanced: extra egress rules appended verbatim to spec.egress. Use to
+  ## restrict the Prometheus/gNB reachability to specific namespaces or CIDRs,
+  ## e.g. scope the gNB port to an external RAN subnet:
+  ##   extraEgress:
+  ##     - to:
+  ##         - ipBlock:
+  ##             cidr: 10.20.0.0/16
+  ##       ports:
+  ##         - port: 8001
+  ##           protocol: TCP
+  extraEgress: []
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,11 @@
+# Runbooks
+
+Operational procedures for running NTN Operators in production.
+
+| Runbook | Use when |
+|---|---|
+| [`alerts.md`](alerts.md) | An NTN Operators alert is firing — one response section per shipped `PrometheusRule` alert (ephemeris staleness, gNB push failure, failover flapping, and the rest). |
+| [`e2e-prometheus-metrics.md`](e2e-prometheus-metrics.md) | Wiring an NTNSlice to a live Prometheus metrics source and validating it end-to-end. |
+
+Release rollback and upgrade migrations live in [`../../RELEASING.md`](../../RELEASING.md)
+(§ Rollback) and the [CHANGELOG](../../CHANGELOG.md) Upgrade notes.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -1,0 +1,244 @@
+# NOC Runbook — NTN Operators alerts
+
+Operational response for the alerts shipped in the chart's `PrometheusRule`
+(`dist/chart/templates/monitoring/prometheusrule.yaml`, rendered when
+`--set prometheus.enable=true`). One section per alert:
+**Fires when → Impact → Diagnose → Mitigate → Escalate**.
+
+All alerts are `severity: warning` and namespaced — the alert labels
+(`namespace`, and one of `ephemeris` / `config` / `slice` / `controller`) point
+at the exact CR. Assume `NS=<namespace>` and the operator lives in
+`ntn-operators-system` unless you deploy it elsewhere.
+
+First moves for any alert:
+
+```bash
+# Which CR, and what does it say about itself?
+kubectl describe <kind> <name> -n "$NS"     # conditions + Events are the fastest signal
+kubectl logs deploy/ntn-operators-controller-manager -n ntn-operators-system --since=30m | grep -iE 'error|warn'
+```
+
+Metric → alert map:
+
+| Alert | Expr | For |
+|---|---|---|
+| `NTNEphemerisEpochStale` | `ntn_operators_ephemeris_epoch_stale_count > 0` | 15m |
+| `NTNEphemerisPushFailing` | `increase(ntn_operators_ephemeris_push_errors_total[15m]) > 0` | 15m |
+| `NTNSliceFailoverFlapping` | `increase(ntn_operators_failover_total[15m]) > 4` | 5m |
+| `NTNConfigApplyErrors` | `increase(ntn_operators_config_apply_errors_total[15m]) > 0` | 15m |
+| `NTNNoSatellitesTracked` | `ntn_operators_gp_satellite_count == 0` | 30m |
+| `NTNDeepSpaceElementsRejected` | `ntn_operators_gp_deep_space_rejected_count > 0` | 15m |
+| `NTNControllerReconcileErrors` | `sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m])) > 0.1` | 15m |
+
+---
+
+## NTNEphemerisEpochStale
+
+**Fires when** a tracked element set's epoch is older than the freshness bound
+while it is still being propagated. Labels: `namespace`, `ephemeris`.
+
+**Impact.** SGP4 propagation from a stale epoch drifts. The ECEF/orbital state
+this operator pushes into SIB19 (and to the gNB via the runtime push) is
+therefore increasingly wrong, so UE timing-advance and Doppler pre-compensation
+degrade — the practical symptom is falling NTN throughput and, eventually,
+dropped sync.
+
+**Diagnose.**
+
+```bash
+kubectl describe satelliteephemeris <ephemeris> -n "$NS"
+# Conditions to read:
+#   GPDataFetched=False  → the fetch itself is failing (reason: RateLimited / AuthFailed / FetchFailed)
+#   EphemerisEpochStale=True with the offending NORAD IDs in the message
+#   GPDataParsed / PassesPredicted → whether anything downstream still ran
+```
+
+```promql
+# Which ephemerides are stale, and how many element sets each.
+ntn_operators_ephemeris_epoch_stale_count > 0
+# Are fetches erroring (the usual upstream cause)?
+rate(ntn_operators_gp_fetch_duration_seconds_count{status="error"}[15m])
+```
+
+**Mitigate.**
+- `GPDataFetched=False, reason=RateLimited` — CelesTrak returns HTTP 403 when you
+  exceed its policy; the operator already backs off. Do **not** hand-retry;
+  confirm nothing else is fetching the same URL faster than the data updates
+  (~a few times/day).
+- `reason=AuthFailed` — Space-Track credentials are bad or the account is
+  throttled/suspended. Fix the secret; respect Space-Track's <30/min, <300/hr.
+- Source healthy but epoch still stale — `spec.source.refreshInterval` is longer
+  than the constellation's element cadence. Lower it.
+- If `networkPolicy.enable=true`, confirm egress `443/TCP` reaches
+  CelesTrak/Space-Track (it is allowed by default).
+
+**Escalate** to the constellation/ephemeris data owner; for Space-Track, the
+account owner (suspension risk).
+
+---
+
+## NTNEphemerisPushFailing
+
+**Fires when** the runtime NTN ephemeris push to the gNB fails. Labels:
+`namespace`, `config`, `reason`. This is the v0.6 WebSocket path
+(`ntn_config_update`); `NTNConfigApplyErrors` (static ConfigMap apply) does
+**not** cover it.
+
+**Impact.** The gNB's SIB19 stops being refreshed with live orbital state, so
+the RAN keeps broadcasting the last-good (aging) ephemeris. UEs lose NTN
+timing/Doppler sync → degraded throughput or failed attach.
+
+**Diagnose.** The `reason` label is the triage key:
+
+```promql
+sum by (namespace, config, reason) (increase(ntn_operators_ephemeris_push_errors_total[15m]))
+```
+
+| `reason` | Meaning | Class |
+|---|---|---|
+| `ProviderPushFailed` | dial/write/read to the gNB failed | transient (operator requeues) |
+| `ProviderPushRejected` | gNB replied `{"error":...}` — bad config | permanent, clears on spec/ephemeris change |
+| `EphemerisRefNotFound` / `EphemerisGetFailed` | the referenced SatelliteEphemeris is missing/unreadable | fix the ref, not the gNB |
+| `EphemerisPayloadMissing` | no propagated state to push yet | upstream ephemeris problem |
+| `EphemerisStale` | the propagated state is stale/expired | see **NTNEphemerisEpochStale** |
+
+```bash
+kubectl describe ntncellconfig <config> -n "$NS"
+#   Condition EphemerisPushed (Status/Reason/Message) + Event "EphemerisPushFailed"
+# For ProviderPushFailed, test gNB reachability from a debug pod:
+ENDPOINT=$(kubectl get ntncellconfig <config> -n "$NS" -o jsonpath='{.spec.provider.remoteControl.endpoint}')
+kubectl run netcheck --rm -it --image=nicolaka/netshoot -n "$NS" -- nc -vz ${ENDPOINT%:*} ${ENDPOINT##*:}
+```
+
+**Mitigate.**
+- `ProviderPushFailed` — restore the gNB `remote_control` server / fix the
+  `endpoint`. **If `networkPolicy.enable=true`, confirm the gNB port is in
+  `networkPolicy.gnbPorts`** — a missing port silently blackholes the push (this
+  is the exact failure the I-27 egress config prevents).
+- `ProviderPushRejected` — read the gNB log for the rejection; correct the
+  NTNCellConfig spec (commonly `siWindowPosition`, or an ephemeris field).
+- `EphemerisRefNotFound` / `PayloadMissing` — fix `spec.cellID` and the
+  referenced SatelliteEphemeris; then wait for a refresh to re-trigger.
+
+**Escalate** to the RAN/gNB operator (reachability/rejection); the ephemeris
+owner (stale/missing state).
+
+---
+
+## NTNSliceFailoverFlapping
+
+**Fires when** more than 4 path switches occur in 15m. Labels: `namespace`,
+`slice`, `from_path`, `to_path`.
+
+**Impact.** The slice is oscillating between terrestrial and satellite paths.
+Each switch disrupts in-flight sessions (reordering, loss, re-auth); sustained
+flapping degrades the very service the failover exists to protect.
+
+**Diagnose.**
+
+```promql
+sum by (namespace, slice, from_path, to_path) (increase(ntn_operators_failover_total[15m]))
+```
+
+```bash
+kubectl describe ntnslice <slice> -n "$NS"
+#   status.activePathType, status.lastFailover, status.failoverCount
+#   Conditions: PathActive, FailoverReady, MetricsStale
+```
+
+Flapping is almost always a metric hovering at the trigger threshold or a
+degraded metric source:
+
+```promql
+# Is the reader falling back to stale values / erroring for this slice?
+ntn_operators_reader_stale_value_used_total{namespace="<ns>", name="<slice>"}
+sum by (reason) (increase(ntn_operators_reader_errors_total[15m]))
+# Is the satellite pass itself marginal (1↔0 near a pass edge)?
+ntn_operators_satellite_pass_available{namespace="<ns>"}
+```
+
+**Mitigate.**
+- `MetricsStale=True` — the reader can't reach Prometheus. Fix
+  `spec.metricsSource.prometheus.endpoint`, the query, or — **if
+  `networkPolicy.enable=true` — add the Prometheus port to
+  `networkPolicy.prometheusPorts`** (I-27).
+- Genuine threshold-hugging — widen the recovery hysteresis / dwell in the
+  slice's `failoverPolicy` so a metric sitting on the boundary doesn't
+  retrigger. (Stronger N-of-M / dead-band / min-dwell anti-flap is tracked
+  separately; until then, a wider margin is the lever.)
+
+**Escalate** to network engineering (path policy) or the monitoring team (if the
+metric source is the culprit).
+
+---
+
+## NTNConfigApplyErrors
+
+**Fires when** `increase(ntn_operators_config_apply_errors_total[15m]) > 0`.
+Labels: `namespace`, `config`, `provider`. This is the **static** ConfigMap
+provider apply — distinct from the runtime push (`NTNEphemerisPushFailing`).
+
+**Impact.** The gNB's bootstrap ConfigMap is not being updated, so a config
+change (koffset, SIB schedule, ephemeris) never reaches the gNB's next boot.
+
+**Diagnose.** `kubectl describe ntncellconfig <config> -n "$NS"` — conditions
+`ConfigValid` (spec rejected at generation time) and `ConfigApplied`, plus the
+`ApplyFailed` / `StatusCheckFailed` Events. **Mitigate** by correcting the spec
+(a `ConfigValid=False` message names the field) or the provider target.
+**Escalate** to whoever owns the NTNCellConfig spec.
+
+---
+
+## NTNNoSatellitesTracked
+
+**Fires when** `ntn_operators_gp_satellite_count == 0` for 30m — the GP pipeline
+is dark. **Impact:** no passes are predicted, so every consuming NTNSlice sees
+its satellite path as unavailable. **Diagnose:** SatelliteEphemeris
+`GPDataFetched` / `GPDataParsed`, the source URL, and `spec.passPrediction`'s
+NORAD filter (a filter matching nothing yields zero). **Mitigate:** fix the
+source or widen the filter. **Escalate** to the ephemeris data owner.
+
+---
+
+## NTNDeepSpaceElementsRejected
+
+**Fires when** `ntn_operators_gp_deep_space_rejected_count > 0` — MEO/GEO element
+sets (period ≥ 225 min) are being dropped by the LEO-only guard. **Impact:** a
+fleet expecting MEO/GEO coverage silently loses it; for a LEO-only deployment
+this is informational. **Diagnose:** SatelliteEphemeris condition
+`UnsupportedOrbitRegime`. **Mitigate:** expected on v1.0 (LEO-only); if you need
+MEO/GEO, that is a roadmap gap, not a fault — filter those NORAD IDs out of the
+source to silence the alert. **Escalate** to product/roadmap if MEO/GEO is
+required.
+
+---
+
+## NTNControllerReconcileErrors
+
+**Fires when** any controller's reconcile error rate exceeds 0.1/s for 15m.
+Label: `controller`. **Impact:** that controller is not converging CRs to their
+desired state — changes stall. **Diagnose:**
+
+```bash
+kubectl logs deploy/ntn-operators-controller-manager -n ntn-operators-system --since=20m \
+  | grep -i 'error' | grep '<controller>'
+```
+
+```promql
+sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))
+```
+
+Common causes: RBAC gaps (a role missing a verb — check
+`kubectl auth can-i`), apiserver unreachable, or one poison CR erroring every
+reconcile. **Mitigate** per the logged error; if a single CR is the culprit,
+`kubectl describe` it and correct or quarantine it. **Escalate** to the platform
+owner for RBAC/apiserver issues.
+
+---
+
+## See also
+
+- [`e2e-prometheus-metrics.md`](e2e-prometheus-metrics.md) — wiring an NTNSlice
+  to a live Prometheus metrics source end-to-end.
+- Rollback and upgrade procedure: [`../../RELEASING.md`](../../RELEASING.md)
+  (§ Rollback) and the [CHANGELOG](../../CHANGELOG.md) Upgrade notes.


### PR DESCRIPTION
- **I-27 — NetworkPolicy egress.** The recommended-prod NetworkPolicy (`networkPolicy.enable=true`) allowed egress only on 443 + 53, which silently blackholes the two data paths whose addresses are set per-CR: the in-cluster Prometheus that `NTNSlice.spec.metricsSource.prometheus.endpoint` queries, and the gNB remote_control WebSocket that `NTNCellConfig.spec.provider.remoteControl.endpoint` targets. Adds configurable `networkPolicy.prometheusPorts` (default 9090), `gnbPorts` (default 8001), and a raw `extraEgress` passthrough for namespace/CIDR scoping. DNS already covered 53 TCP+UDP; the apiserver is reached via the `kubernetes` ClusterIP:443.
- **I-28 — README CRD skew.** With `--set crd.enable=false` the CRDs are managed out-of-band, so `helm upgrade` bumps the operator but not the CRDs; re-run `make install` at the new tag first, or v0.6+ runtime-push fields are silently dropped by the old schema.
- **I-30 — NOC runbooks.** `docs/runbooks/alerts.md` — one Fires / Impact / Diagnose / Mitigate / Escalate section per shipped `PrometheusRule` alert (ephemeris staleness, gNB push failure, failover flapping, and the rest) with the real metric/condition/reason names and kubectl + PromQL. Plus a `docs/runbooks` index.
- **B-7 — rollback + upgrade notes.** `RELEASING.md` gains a Rollback section (a full `helm rollback` re-applies the previous CRD schema — the hazard, since CRDs are ordinary templates), and the CHANGELOG v0.6.0 entry gains Upgrade notes (the `siWindowPosition` minimum rose 0→2; pre-0.6 configs pinned to 0/1 need a `kubectl patch` before the CRD upgrade).

**Verification:** `helm lint` clean; the policy renders the expected 443/53/9090/8001 egress and the chart parses as valid YAML; the CRD template location and the siWindowPosition v0.5→v0.6 schema change were verified against the code and git history. (`docs/**` and the chart docs are not CI-path-gated.)
