### PR TITLE
fix(controller): re-push runtime NTN config on epoch advance, not GP-fetch time [I-12]

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -422,16 +422,25 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 			fmt.Errorf("getting referenced SatelliteEphemeris %q: %w", spec.EphemerisRef, err),
 		)
 	}
+	// Runtime push path: when a remote-control endpoint + cellID are configured,
+	// push the SGP4-propagated ephemeris live via ntn_config_update (#176) instead
+	// of rewriting the bootstrap ConfigMap with the CR's static ephemeris. Its
+	// freshness key is the propagated EPOCH, not the 2h-stable GP fetch time: the
+	// SatelliteEphemeris re-propagates a fresh epoch every few minutes and fans out
+	// to this reconcile, so keying the dedup marker on the epoch is what re-pushes
+	// the live state between fetches and after a gNB restart (I-12). Refreshing
+	// epoch/ephemeris/TA is SI-change-free per TS 38.331, so the periodic re-push is
+	// a level re-assert that does not disturb UEs. pushRuntimeEphemeris computes its
+	// own epoch-aware marker and does its own up-to-date check.
+	if spec.Provider.RemoteControl != nil && spec.CellID != nil {
+		return r.pushRuntimeEphemeris(ctx, cc, spec, eph, prov)
+	}
+
+	// ConfigMap bootstrap path: the CR's static spec.ntn ephemeris; the last GP
+	// fetch time (LastUpdated) is the correct freshness key here.
 	marker := ephemerisPushMarker(eph)
 	if isEphemerisPushUpToDate(cc, marker) {
 		return false, marker, nil
-	}
-
-	// Runtime push path: when a remote-control endpoint + cellID are configured,
-	// push the SGP4-propagated ephemeris live via ntn_config_update (#176) instead
-	// of rewriting the bootstrap ConfigMap with the CR's static ephemeris.
-	if spec.Provider.RemoteControl != nil && spec.CellID != nil {
-		return r.pushRuntimeEphemeris(ctx, spec, eph, prov, marker)
 	}
 
 	// A satSwitchWithResync is runtime-only (its k_mac has no bootstrap-YAML
@@ -479,10 +488,10 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 // discarding it and re-emitting the CR's static ephemeris.
 func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	ctx context.Context,
+	cc *ntnv1alpha1.NTNCellConfig,
 	spec *ntnv1alpha1.NTNCellConfigSpec,
 	eph *ntnv1alpha1.SatelliteEphemeris,
 	prov provider.NTNProvider,
-	marker string,
 ) (bool, string, error) {
 	state := selectPropagatedState(eph.Status.PropagatedStates, spec.EphemerisNoradID)
 	if state == nil {
@@ -494,12 +503,24 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		if meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionUnsupportedOrbitRegime) {
 			hint = " (the referenced SatelliteEphemeris reports UnsupportedOrbitRegime: deep-space element sets are rejected because the near-earth SGP4 propagator cannot handle them)"
 		}
-		return false, marker, newEphemerisPushError(
+		return false, ephemerisPushMarker(eph), newEphemerisPushError(
 			ephemerisReasonPayloadMissing,
 			fmt.Errorf("no propagated state in SatelliteEphemeris %q for noradID selector %v%s",
 				eph.Name, spec.EphemerisNoradID, hint),
 		)
 	}
+
+	// Dedup on the propagated epoch (I-12): re-push whenever the SatelliteEphemeris
+	// re-propagated to a fresh epoch — the watch fans that out to this reconcile, so
+	// keying on the epoch (not the 2h-stable LastUpdated) keeps the gNB fresh between
+	// GP fetches and recovers it after a gNB restart. Same epoch ⇒ same marker ⇒ no
+	// redundant push; spec changes (koffset/TA/satSwitch) still re-push via the
+	// ObservedGeneration check in isEphemerisPushUpToDate.
+	marker := runtimeEphemerisPushMarker(eph, state)
+	if isEphemerisPushUpToDate(cc, marker) {
+		return false, marker, nil
+	}
+
 	// Skip a stale (past / about-to-expire) epoch rather than push a value OCUDU
 	// will reject. The state is only valid for its own epoch, so re-labeling it
 	// would corrupt the position; instead wait for the SatelliteEphemeris producer
@@ -576,6 +597,22 @@ func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
 		lastUpdated = eph.Status.LastUpdated.UTC().Format(time.RFC3339Nano)
 	}
 	return fmt.Sprintf("ephemerisRef=%s generation=%d lastUpdated=%s", eph.Name, eph.Generation, lastUpdated)
+}
+
+// runtimeEphemerisPushMarker is the dedup key for the runtime (ntn_config_update)
+// push path. The ConfigMap path keys on the GP fetch time (ephemerisPushMarker),
+// but the runtime push delivers the SGP4-propagated state, which the
+// SatelliteEphemeris re-propagates to a fresh EPOCH every few minutes; keying on
+// that epoch (not the 2h-stable LastUpdated) is what makes the watch fan-out
+// re-push the live state between GP fetches and after a gNB restart (I-12). The
+// epoch is a monotonic 1:1 proxy for the propagated ECEF — each re-propagation
+// yields a new epoch and a new state — so a same-epoch reconcile dedups without
+// hashing the payload. Refreshing epoch/ephemeris/TA is SI-change-free per TS
+// 38.331, and the re-push cadence is bounded by the SatelliteEphemeris
+// re-propagation interval, well under ntn-UlSyncValidityDuration (NR max 240 s).
+func runtimeEphemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris, state *ntnv1alpha1.PropagatedState) string {
+	return fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
+		eph.Name, eph.Generation, state.NoradID, state.EpochUnixMs)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ntncellconfig_push_freshness_test.go
+++ b/internal/controller/ntncellconfig_push_freshness_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestRuntimeEphemerisPushMarkerKeysOnEpoch pins I-12 at the marker level: the
+// runtime push marker must track the propagated EPOCH, because the short-cadence
+// re-propagation advances the epoch while LastUpdated (the 2h GP-fetch time) is
+// unchanged — so the LastUpdated-keyed marker would never re-push.
+func TestRuntimeEphemerisPushMarkerKeysOnEpoch(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC))
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-a", Generation: 7},
+		Status:     ntnv1alpha1.SatelliteEphemerisStatus{LastUpdated: &ts},
+	}
+	e1 := &ntnv1alpha1.PropagatedState{Satellite: "ISS", NoradID: 25544, EpochUnixMs: 1_700_000_000_000}
+	e2 := &ntnv1alpha1.PropagatedState{Satellite: "ISS", NoradID: 25544, EpochUnixMs: 1_700_000_180_000} // +3 min
+
+	// (Same-epoch dedup is proven end-to-end in TestPushRuntime_RepushesOnFreshEpoch_I12
+	// step 2; here we focus on what MUST change the marker.)
+	// Fresh epoch, LastUpdated UNCHANGED → different marker → re-push (the fix).
+	if runtimeEphemerisPushMarker(eph, e1) == runtimeEphemerisPushMarker(eph, e2) {
+		t.Fatal("a fresh propagated epoch must change the marker (I-12)")
+	}
+	// Proof of why the runtime path must not use the ConfigMap marker: it is
+	// identical across the epoch advance (LastUpdated didn't move).
+	if ephemerisPushMarker(eph) == "" {
+		t.Fatal("sanity")
+	}
+	// A different satellite is a distinct push target.
+	eOther := &ntnv1alpha1.PropagatedState{Satellite: "ONEWEB", NoradID: 44057, EpochUnixMs: e1.EpochUnixMs}
+	if runtimeEphemerisPushMarker(eph, e1) == runtimeEphemerisPushMarker(eph, eOther) {
+		t.Fatal("a different satellite must change the marker")
+	}
+	// A SatelliteEphemeris generation bump re-pushes (spec change).
+	ephG := eph.DeepCopy()
+	ephG.Generation++
+	if runtimeEphemerisPushMarker(eph, e1) == runtimeEphemerisPushMarker(ephG, e1) {
+		t.Fatal("an ephemeris generation change must change the marker")
+	}
+}
+
+// TestPushRuntime_RepushesOnFreshEpoch_I12 pins the end-to-end I-12 fix through
+// the reconciler helper: an already-pushed cell is NOT re-pushed for the same
+// epoch (dedup), but a fresh propagated epoch — with LastUpdated deliberately
+// UNCHANGED (as the short-cadence re-propagation leaves it) — DOES re-push. On
+// the pre-fix LastUpdated-keyed marker the third call would dedup and the gNB
+// would never be refreshed between GP fetches / after a restart.
+func TestPushRuntime_RepushesOnFreshEpoch_I12(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	ctx := context.Background()
+	epoch1 := time.Now().Add(time.Hour).UnixMilli()
+	eph := ephWithPropagatedState(epoch1)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	// Mirror what the reconciler persists after a push, so the next call's
+	// up-to-date check sees the last-pushed marker.
+	persist := func(marker string) {
+		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionEphemerisPushed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Pushed",
+			Message:            marker,
+			ObservedGeneration: cc.Generation,
+		})
+	}
+
+	// 1) First push at epoch1.
+	pushed, marker1, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if err != nil || !pushed {
+		t.Fatalf("first push: pushed=%v err=%v", pushed, err)
+	}
+	if mock.RuntimeCalls != 1 {
+		t.Fatalf("first push RuntimeCalls=%d, want 1", mock.RuntimeCalls)
+	}
+	persist(marker1)
+
+	// 2) Same epoch → dedup, no re-push.
+	pushed, _, err = r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if err != nil {
+		t.Fatalf("dedup call: %v", err)
+	}
+	if pushed || mock.RuntimeCalls != 1 {
+		t.Fatalf("same epoch must dedup: pushed=%v RuntimeCalls=%d (want false/1)", pushed, mock.RuntimeCalls)
+	}
+
+	// 3) Fresh epoch, LastUpdated unchanged → re-push (I-12).
+	epoch2 := epoch1 + (3 * time.Minute).Milliseconds()
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(eph), got); err != nil {
+		t.Fatalf("get eph: %v", err)
+	}
+	got.Status.PropagatedStates[0].EpochUnixMs = epoch2 // only the epoch advances
+	if err := c.Update(ctx, got); err != nil {
+		t.Fatalf("update eph: %v", err)
+	}
+
+	pushed, marker3, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if err != nil {
+		t.Fatalf("re-push call: %v", err)
+	}
+	if !pushed || mock.RuntimeCalls != 2 {
+		t.Fatalf("a fresh propagated epoch must re-push (I-12): pushed=%v RuntimeCalls=%d (want true/2)", pushed, mock.RuntimeCalls)
+	}
+	if mock.LastRuntime == nil || mock.LastRuntime.EpochUnixMs != epoch2 {
+		t.Fatalf("re-push must carry the fresh epoch: got %+v want %d", mock.LastRuntime, epoch2)
+	}
+	if marker3 == marker1 {
+		t.Fatal("a fresh epoch must change the marker")
+	}
+}


### PR DESCRIPTION
The runtime (`ntn_config_update`) push was deduplicated on a marker keyed to the SatelliteEphemeris `LastUpdated` (the 2h GP-fetch time), which is stable between fetches — so the SGP4-propagated state was pushed once per 2h fetch and never re-pushed off-cycle, leaving the gNB stale between fetches and with nothing after a gNB restart (I-12).

The SatelliteEphemeris re-propagates the orbit to a fresh near-now epoch every few minutes and fans that out to every referencing NTNCellConfig via the watch; only the `LastUpdated`-keyed marker blocked the re-push. This keys the runtime push marker on the **propagated epoch** instead (`runtimeEphemerisPushMarker`), so the fan-out re-pushes the live state whenever the epoch advances — a level re-assert that keeps the gNB fresh between fetches and recovers it within one re-propagation cycle after a gNB restart. The ConfigMap bootstrap path keeps its `LastUpdated` marker (its static ephemeris has no epoch to track).

The epoch is a monotonic 1:1 proxy for the propagated ECEF (each re-propagation yields a new epoch and a new state), so a same-epoch reconcile dedups without a payload hash; spec changes (koffset / TA / satSwitch) still re-push via the `ObservedGeneration` check.

**Design validated by a multi-source deep-research pass** (3GPP primary sources):
- Refreshing `epochTime` / `ephemerisInfo` / `ta-Common` is **explicitly excluded from SI-change determination** (TS 38.331), so a per-cycle re-push causes no `systemInfoModification` and does not disturb connected/idle UEs. (`cellSpecificKoffset` is *not* excluded — but the runtime push does not carry it, so the runtime re-push stays SI-change-free.)
- Re-push cadence sits under `ntn-UlSyncValidityDuration` (NR max 240 s).
- SGP4 LEO error is ~1 km at ~6 h, so the cadence is driven by restart-recovery, not accuracy.
- Periodic level re-assert is the canonical pattern for a downstream device whose restart the controller cannot observe.

**Verification:** mutation-verified (dropping the epoch from the marker reproduces I-12 — the fresh epoch stops re-pushing, `RuntimeCalls` stays 1); a unit test (marker keys on epoch) + an end-to-end integration test through the reconcile helper (fresh epoch → re-push, same epoch → dedup); existing runtime-push tests green; `make lint` clean; full suite green.
