### PR TITLE
feat(ha): active-passive high availability via leader election [N-9]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,8 +101,13 @@ func main() {
 			"Set this only to enable internal CelesTrak mirrors (e.g. air-gapped "+
 			"deployments) or E2E test mock servers. Production clusters with public "+
 			"CelesTrak access should leave this empty.")
+	// Default to the Zap PRODUCTION config (JSON encoder, info level, sampling,
+	// error-level stacktraces) rather than the kubebuilder scaffold's Development
+	// default (console, warning stacktraces, no sampling), so a deployed operator
+	// emits structured logs. Still flag-overridable: `--zap-devel` restores the
+	// development config for local `make run`.
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -169,17 +174,14 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b1076767.operators.dev",
-		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
-		// when the Manager ends. This requires the binary to immediately end when the
-		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
-		// LeaseDuration time first.
-		//
-		// In the default scaffold provided, the program ends immediately after
-		// the manager stops, so would be fine to enable this option. However,
-		// if you are doing or is intended to do any operation such as perform cleanups
-		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
+		// Release the lease on graceful shutdown so a standby replica takes over
+		// immediately instead of waiting out LeaseDuration (~15s) — the active-passive
+		// HA win, and it collapses the rollout dead window. This is SAFE here because
+		// main() exits as soon as mgr.Start returns (below) with NO post-Start work:
+		// controller-runtime warns (issue #1132) this is only unsafe when the binary
+		// keeps running — and performing lease-guarded work — after the Manager stops.
+		// Lease timing keeps the controller-runtime/client-go defaults (15s/10s/2s).
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")
@@ -262,6 +264,12 @@ func main() {
 		setupLog.Error(err, "Failed to set up health check")
 		os.Exit(1)
 	}
+	// readyz is intentionally leadership-agnostic (healthz.Ping): under active-passive
+	// HA a NON-leader standby must still report Ready, or the Deployment never counts
+	// it Available and a rolling update deadlocks (the new pod can only become leader
+	// after the old releases the lease, but the old is not torn down until the new is
+	// Ready). A cache-sync- or leadership-gated readyz would break HA the same way,
+	// because a non-leader's cache/controllers do not start until it acquires the lease.
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up ready check")
 		os.Exit(1)

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -9,7 +9,11 @@
 ## Configure the controller manager deployment
 ##
 manager:
-  replicas: 1
+  ## Active-passive HA: 2 replicas + leader election run one active reconciler and
+  ## one warm standby that takes over on failure or rollout (fast, because the
+  ## operator sets LeaderElectionReleaseOnCancel). Set to 1 for single-node / dev
+  ## clusters where a standby cannot be scheduled.
+  replicas: 2
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
@@ -68,9 +72,19 @@ manager:
       cpu: 10m
       memory: 64Mi
 
-  ## Manager pod's affinity
-  ##
-  affinity: {}
+  ## Manager pod's affinity. Defaults to a SOFT pod anti-affinity that spreads the
+  ## HA replicas onto different nodes when possible — "preferred", so the standby
+  ## still schedules on a single-node cluster instead of hanging Pending. Override
+  ## with your own affinity, or set to {} to disable spreading.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                control-plane: controller-manager
 
   ## Manager pod's node selector
   ##
@@ -115,10 +129,11 @@ prometheus:
   enable: false
 
 ## PodDisruptionBudget for high availability.
-## Requires replicas > 1 to be effective.
+## Keeps a manager pod up across voluntary disruptions (node drain, rollout).
+## Effective with replicas > 1 (the active-passive default).
 ##
 podDisruptionBudget:
-  enable: false
+  enable: true
   minAvailable: 1
 
 ## NetworkPolicy for zero-trust pod networking.


### PR DESCRIPTION
Hardens the operator for **active-passive HA**, grounded in a controller-runtime / client-go primary-source review (a deep-research pass whose synthesis failed but whose 70 verified claims were recovered from the run journal).

- **`LeaderElectionReleaseOnCancel: true`** — the leader releases its lease on graceful shutdown so a standby takes over immediately instead of waiting out `LeaseDuration` (~15 s), which also collapses the rolling-update dead window. Safe here because `main()` exits as soon as `mgr.Start` returns with **no post-Start work** (controller-runtime [#1132](https://github.com/kubernetes-sigs/controller-runtime/issues/1132) warns this is only unsafe when the binary keeps doing lease-guarded work after the Manager stops). Lease timing keeps the controller-runtime `15s/10s/2s` defaults.
- **zap → production config** — default `Development: false` (JSON encoder, info level, sampling, error-level stacktraces) instead of the kubebuilder scaffold's development default; `--zap-devel` still restores the console config for local runs.
- **readyz stays leadership-agnostic (`healthz.Ping`)** — under HA a non-leader standby **must** report Ready, or a rolling update deadlocks: a leadership- or cache-sync-gated readyz never goes Ready on the standby (whose cache/controllers do not start until it acquires the lease), so the Deployment never counts it Available and the old leader is never torn down. This is a case where the naive "make readiness real" change would *introduce* a bug; the code comment explains why.
- **Chart HA defaults** — 2 replicas, `podDisruptionBudget.enable: true` (`minAvailable: 1`, one voluntary drain at a time), and a **soft** pod anti-affinity that spreads replicas across nodes while still scheduling on a single-node cluster. The PDB template already existed (only the default flipped on); the leader-election lease RBAC already exists.

**Verification:** `helm lint` clean; `helm template` renders replicas 2 + soft anti-affinity + exactly one PDB (a duplicate PDB template I initially added was caught in review and removed) and the PDB disappears when disabled; `go build`, full test suite, `make lint`, `go vet` all clean. This WO is wiring/config (two `ctrl.Options` booleans + chart values), so there is no natural unit-test/mutation target — correctness rests on the build + helm render + the primary-source research.
