### PR TITLE
docs: correct stale strings + koffset doc-comment [WO-15]

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ docs/                   # API reference (auto-generated)
 
 ## Grafana Dashboard
 
-Import `config/grafana/ntn-operators-dashboard.json` into your Grafana instance to visualize all 6 custom metrics (failover events, satellite pass availability, ground station health, fetch duration, satellite count, config errors).
+Import `config/grafana/ntn-operators-dashboard.json` into your Grafana instance to visualize 9 custom metrics (failover events, satellite pass availability, ground station health, GP fetch duration, satellite count, config-apply errors, reader errors, reader query duration, stale-read usage).
 
 ## API Reference
 

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -442,8 +442,9 @@ type SatSwitchNTNConfig struct {
 	// +optional
 	KMac *int `json:"kMac,omitempty"`
 
-	// cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-	// (1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.
+	// cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+	// same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+	// because OCUDU rejects 0. Omit the field to leave it unset.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=1023
 	// +optional

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -514,8 +514,9 @@ spec:
                         properties:
                           cellSpecificKoffset:
                             description: |-
-                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-                              (1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.
+                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+                              same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+                              because OCUDU rejects 0. Omit the field to leave it unset.
                             maximum: 1023
                             minimum: 1
                             type: integer

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -514,8 +514,9 @@ spec:
                         properties:
                           cellSpecificKoffset:
                             description: |-
-                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-                              (1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.
+                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+                              same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+                              because OCUDU rejects 0. Omit the field to leave it unset.
                             maximum: 1023
                             minimum: 1
                             type: integer

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -517,8 +517,9 @@ spec:
                         properties:
                           cellSpecificKoffset:
                             description: |-
-                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-                              (1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.
+                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+                              same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+                              because OCUDU rejects 0. Omit the field to leave it unset.
                             maximum: 1023
                             minimum: 1
                             type: integer

--- a/docs/runbooks/e2e-prometheus-metrics.md
+++ b/docs/runbooks/e2e-prometheus-metrics.md
@@ -11,7 +11,7 @@ SDR in the loop.
 
 - Kubernetes cluster where you can deploy to `ntn-e2e` namespace
 - `kubectl` and `docker` on the PATH
-- Go 1.25+ if you want to run the operator as a local process
+- Go 1.26+ if you want to run the operator as a local process
 - Open5GS running on the host (optional for §6)
 
 ## 1. Install CRDs

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -514,8 +514,9 @@ spec:
                         properties:
                           cellSpecificKoffset:
                             description: |-
-                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-                              (1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.
+                              cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+                              same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+                              because OCUDU rejects 0. Omit the field to leave it unset.
                             maximum: 1023
                             minimum: 1
                             type: integer


### PR DESCRIPTION
Audit hygiene sweep (WO-15). Each item was **verified still-open** before fixing — most of WO-15's original scope was already closed by earlier merges and is left untouched: the User-Agent `0.1`→`0.6` (N-7a, #200), the chart README OCI path (I-26, already correct), and the ±2^25 propagator test constants (N-11, #198).

**Fixed:**
- **N-7b** — the metrics runbook (`docs/runbooks/e2e-prometheus-metrics.md`) listed `Go 1.25+`; `go.mod` is `go 1.26.5` → `Go 1.26+`.
- **N-7c** — the README claimed the Grafana dashboard visualizes *"all 6 custom metrics"*; it actually panels **9** (of the operator's 12 custom metrics). Corrected the count and enumerated the nine (failover, pass availability, GS health, GP fetch duration, satellite count, config-apply errors, reader errors, reader query duration, stale-read usage).
- **N-4** — the NTNCellConfig SatSwitch `cellSpecificKoffset` comment said *"0 omits it"* next to a `Minimum=1` marker. For an `int`+`omitempty` field 0 is dropped, but the note didn't explain the Minimum, unlike the canonical `NTNParams.cellSpecificKoffset`. Reworded to match (Minimum 1 because OCUDU rejects 0; omit to leave unset), and **regenerated all four CRD copies** (config / bundle / chart / nephio) for the new description.

**Deferred:** N-7d (the dashboard lacks `controller_runtime_*` panels) is a dashboard-authoring task, not a string fix — better as a standalone dashboard PR.

**Verification:** no behavior change (doc strings + a comment/description only); `make manifests` idempotent; CRD 4-copy sync verified (bundle + nephio); full suite 9/9; lint 0.