### PR TITLE
feat(api): ownership check, condition columns, IPv6 endpoints, string caps [WO-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **Breaking (alpha): `spec.satellites.constellation` removed from SatelliteEphemeris.**
+  The field was never read — it performed no filtering. Select a constellation
+  server-side in the source URL instead (CelesTrak `GROUP=oneweb`), and/or list
+  explicit `spec.satellites.noradIDs`. Per the Kubernetes deprecation policy an
+  alpha (`v1alpha1`) field may be removed without a deprecation period; a stored
+  CR's `constellation` value is pruned on next write. Find any manifest that sets
+  it and drop the field (ensuring the source URL carries `GROUP=<constellation>`):
+
+  ```bash
+  kubectl get satelliteephemeris -A -o json \
+    | jq -r '.items[] | select(.spec.satellites.constellation != null) | "\(.metadata.namespace)/\(.metadata.name)"'
+  ```
+
+### Added
+
+- SatelliteEphemeris `status.truncatedSatelliteCount` plus a `Warning`
+  `StatesTruncated` event when the selected set exceeds the 128 propagated-state
+  cap (previously only logged).
+- A condition-status printer column for `kubectl get`: SatelliteEphemeris
+  (Fetched), NTNCellConfig (Applied), NTNSlice (Ready).
+
+### Changed
+
+- `RemoteControlRef.endpoint` now accepts bracketed IPv6 literals (`[::1]:8001`)
+  for dual-stack clusters.
+- `MaxLength` bounds added to previously-unbounded spec strings across all four
+  CRDs (defensive; generous limits).
+- The OCUDU provider `Cleanup` deletes the ConfigMap only when it is
+  controller-owned by the CR (was: delete by name).
+
 ## [0.6.0] - 2026-07-09
 
 Promotion of `0.6.0-rc.1` after a short soak (the rc's release pipeline —

--- a/api/v1alpha1/groundstationlifecycle_types.go
+++ b/api/v1alpha1/groundstationlifecycle_types.go
@@ -25,14 +25,17 @@ import (
 type HardwareSpec struct {
 	// vendor is the hardware manufacturer (e.g., "ennoconn").
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Vendor string `json:"vendor"`
 
 	// model is the hardware model identifier.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Model string `json:"model"`
 
 	// antennaType is the antenna type (e.g., "flat-panel", "parabolic").
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	AntennaType string `json:"antennaType,omitempty"`
 
 	// bands lists the supported frequency bands (e.g., ["Ka", "Ku", "S"]).
@@ -48,14 +51,17 @@ type HardwareSpec struct {
 type GeoLocation struct {
 	// lat is the latitude in decimal degrees (string, e.g., "25.0330").
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	Lat string `json:"lat"`
 
 	// lon is the longitude in decimal degrees (string, e.g., "121.5654").
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	Lon string `json:"lon"`
 
 	// alt is the altitude in meters above sea level (string, e.g., "15").
 	// +optional
+	// +kubebuilder:validation:MaxLength=32
 	Alt string `json:"alt,omitempty"`
 }
 
@@ -72,6 +78,7 @@ type DeploymentSpec struct {
 
 	// gitopsRepo is the Git repository URL for GitOps-managed configuration.
 	// +optional
+	// +kubebuilder:validation:MaxLength=2048
 	GitopsRepo string `json:"gitopsRepo,omitempty"`
 }
 
@@ -83,6 +90,7 @@ type MonitoringSpec struct {
 
 	// endpoint is the monitoring endpoint of the ground station agent.
 	// +optional
+	// +kubebuilder:validation:MaxLength=261
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
@@ -94,6 +102,7 @@ type FirmwareSpec struct {
 
 	// channel is the firmware update channel (e.g., "stable", "beta").
 	// +kubebuilder:default="stable"
+	// +kubebuilder:validation:MaxLength=64
 	Channel string `json:"channel,omitempty"`
 
 	// maintenanceWindow is the time window for updates.

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -42,6 +42,7 @@ type NTNCellConfigSpec struct {
 	// on the provider reconcile path. The static ephemeris in spec.ntn
 	// (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`
 
@@ -83,7 +84,7 @@ type RemoteControlRef struct {
 	// tight-requeue on a mistyped endpoint).
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=261
-	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+:[0-9]{1,5}$`
+	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$`
 	Endpoint string `json:"endpoint"`
 
 	// tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -113,6 +114,7 @@ type RemoteControlTLS struct {
 	// "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
 	// replayable, so it is only ever sent over the wss:// (TLS) connection.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	SecretName string `json:"secretName"`
 
 	// serverName overrides the TLS ServerName (SNI) verified against the server
@@ -132,6 +134,7 @@ type ProviderRef struct {
 
 	// namespace where the provider resources (e.g., OCUDU gNB) are deployed.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace,omitempty"`
 
 	// remoteControl configures the gNB remote_control WebSocket for live NTN
@@ -142,6 +145,7 @@ type ProviderRef struct {
 
 	// endpoint is the provider-specific endpoint (e.g., O1 NETCONF address).
 	// +optional
+	// +kubebuilder:validation:MaxLength=261
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
@@ -665,6 +669,7 @@ const (
 // +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider.type`
 // +kubebuilder:printcolumn:name="Koffset",type=integer,JSONPath=`.spec.ntn.cellSpecificKoffset`
 // +kubebuilder:printcolumn:name="Payload",type=string,JSONPath=`.spec.ntn.payloadType`
+// +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=`.status.conditions[?(@.type=="ConfigApplied")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NTNCellConfig manages NTN-specific radio parameters for a gNB cell,

--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -28,6 +28,7 @@ import (
 type NTNSliceSpec struct {
 	// tenant is the organization or entity that owns this slice.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Tenant string `json:"tenant"`
 
 	// terrestrialPath defines the primary terrestrial connectivity.
@@ -101,6 +102,7 @@ type PrometheusMetricsSource struct {
 	// endpoint is the base URL of the Prometheus HTTP API.
 	// +kubebuilder:validation:Pattern=`^https?://`
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=2048
 	Endpoint string `json:"endpoint"`
 
 	// queryTimeout limits the wall-clock time spent on each individual
@@ -123,15 +125,18 @@ type PrometheusMetricsSource struct {
 type PrometheusQueries struct {
 	// rsrpDbm is a PromQL expression returning a scalar in dBm.
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	RsrpDbm string `json:"rsrpDbm,omitempty"`
 
 	// latencyMs is a PromQL expression returning a scalar in milliseconds.
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	LatencyMs string `json:"latencyMs,omitempty"`
 
 	// packetLossPercent is a PromQL expression returning a scalar in
 	// percent (0-100).
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	PacketLossPercent string `json:"packetLossPercent,omitempty"`
 }
 
@@ -139,10 +144,12 @@ type PrometheusQueries struct {
 type PathSpec struct {
 	// provider is the network operator name (e.g., "chunghwa-telecom").
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Provider string `json:"provider"`
 
 	// apn is the Access Point Name.
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
 	APN string `json:"apn,omitempty"`
 
 	// priority is the path priority.
@@ -157,6 +164,7 @@ type SatellitePathSpec struct {
 	// ephemerisRef is the name of the SatelliteEphemeris resource
 	// used to determine satellite pass availability.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	EphemerisRef string `json:"ephemerisRef"`
 }
 
@@ -199,6 +207,7 @@ type FailoverPolicy struct {
 	// failover fires at RSRP < -120, but switchback requires RSRP >= -110.
 	// +kubebuilder:validation:Pattern=`^[0-9]+\.?[0-9]*$`
 	// +optional
+	// +kubebuilder:validation:MaxLength=32
 	HysteresisMargin string `json:"hysteresisMargin,omitempty"`
 
 	// confirmationSamples is the number of CONSECUTIVE reconcile samples on which
@@ -339,6 +348,7 @@ const (
 // +kubebuilder:printcolumn:name="Tenant",type=string,JSONPath=`.spec.tenant`
 // +kubebuilder:printcolumn:name="Active Path",type=string,JSONPath=`.status.activePathType`
 // +kubebuilder:printcolumn:name="Failovers",type=integer,JSONPath=`.status.failoverCount`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="FailoverReady")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NTNSlice manages terrestrial-satellite network slice failover,

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -67,12 +67,11 @@ type SecretReference struct {
 	Key string `json:"key,omitempty"`
 }
 
-// SatelliteSelector defines which satellites to track.
+// SatelliteSelector defines which satellites to track. To fetch a single
+// constellation, select it SERVER-SIDE in the source URL — CelesTrak's GROUP=
+// query parameter (e.g. GROUP=oneweb) returns only that constellation's element
+// sets — and/or list explicit NORAD catalog IDs here.
 type SatelliteSelector struct {
-	// constellation filters by constellation name (e.g., "oneweb", "starlink").
-	// +optional
-	Constellation string `json:"constellation,omitempty"`
-
 	// noradIDs is an explicit list of NORAD catalog IDs to track.
 	// +optional
 	NoradIDs []int `json:"noradIDs,omitempty"`
@@ -157,6 +156,13 @@ type SatelliteEphemerisStatus struct {
 	// satelliteCount is the number of satellites currently tracked.
 	// +optional
 	SatelliteCount int `json:"satelliteCount,omitempty"`
+
+	// truncatedSatelliteCount is how many satellites were dropped because the
+	// selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+	// dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+	// eliminate it. A Warning "StatesTruncated" event is emitted alongside.
+	// +optional
+	TruncatedSatelliteCount int `json:"truncatedSatelliteCount,omitempty"`
 
 	// nextPassWindows contains upcoming contact opportunities.
 	// +optional

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -41,6 +41,7 @@ type EphemerisSource struct {
 	// For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^https?://`
+	// +kubebuilder:validation:MaxLength=2048
 	URL string `json:"url"`
 
 	// refreshInterval is how often to re-fetch GP data.
@@ -58,9 +59,11 @@ type EphemerisSource struct {
 // SecretReference points to a Kubernetes Secret.
 type SecretReference struct {
 	// name of the Secret.
+	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
 	// key within the Secret data.
 	// +kubebuilder:default="password"
+	// +kubebuilder:validation:MaxLength=253
 	Key string `json:"key,omitempty"`
 }
 
@@ -85,6 +88,7 @@ type PassPredictionSpec struct {
 	// minElevation is the minimum elevation angle in degrees (string, e.g., "10").
 	// +kubebuilder:default="10"
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	MinElevation string `json:"minElevation,omitempty"`
 
 	// horizon is how far into the future to predict passes.
@@ -196,6 +200,7 @@ const (
 // +kubebuilder:resource:shortName=sateph
 // +kubebuilder:printcolumn:name="Satellites",type=integer,JSONPath=`.status.satelliteCount`
 // +kubebuilder:printcolumn:name="Last Updated",type=date,JSONPath=`.status.lastUpdated`
+// +kubebuilder:printcolumn:name="Fetched",type=string,JSONPath=`.status.conditions[?(@.type=="GPDataFetched")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack),

--- a/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -808,10 +812,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -828,7 +834,7 @@ spec:
                           tight-requeue on a mistyped endpoint).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
                       tls:
                         description: |-
@@ -855,6 +861,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -92,10 +92,6 @@ spec:
                 description: satellites filters which satellites to track from the
                   source.
                 properties:
-                  constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
-                    type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs
                       to track.
@@ -356,6 +352,13 @@ spec:
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.
+                type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. A Warning "StatesTruncated" event is emitted alongside.
                 type: integer
             type: object
         required:

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -808,10 +812,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -828,7 +834,7 @@ spec:
                           tight-requeue on a mistyped endpoint).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
                       tls:
                         description: |-
@@ -855,6 +861,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -92,10 +92,6 @@ spec:
                 description: satellites filters which satellites to track from the
                   source.
                 properties:
-                  constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
-                    type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs
                       to track.
@@ -356,6 +352,13 @@ spec:
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.
+                type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. A Warning "StatesTruncated" event is emitted alongside.
                 type: integer
             type: object
         required:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/config/samples/ntn_v1alpha1_satelliteephemeris.yaml
+++ b/config/samples/ntn_v1alpha1_satelliteephemeris.yaml
@@ -8,10 +8,9 @@ metadata:
 spec:
   source:
     type: CelesTrak
+    # GROUP=oneweb selects the constellation server-side — no client-side filter.
     url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -69,6 +69,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -86,15 +87,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -120,6 +124,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -134,6 +139,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -143,10 +149,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -159,6 +167,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -157,6 +160,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -811,10 +815,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -831,7 +837,7 @@ spec:
                           tight-requeue on a mistyped endpoint).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
                       tls:
                         description: |-
@@ -858,6 +864,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -109,6 +112,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -173,6 +177,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -183,15 +188,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -253,11 +261,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -268,6 +278,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -298,6 +309,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -305,6 +317,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -314,6 +327,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -95,10 +95,6 @@ spec:
                 description: satellites filters which satellites to track from the
                   source.
                 properties:
-                  constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
-                    type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs
                       to track.
@@ -359,6 +355,13 @@ spec:
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.
+                type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. A Warning "StatesTruncated" event is emitted alongside.
                 type: integer
             type: object
         required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -82,6 +85,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -114,9 +118,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -144,6 +150,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1877,6 +1877,72 @@ enforces bare host:port (a permanent admission error beats a silent
 tight-requeue on a mistyped endpoint).<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b><a href="#ntncellconfigspecproviderremotecontroltls">tls</a></b></td>
+        <td>object</td>
+        <td>
+          tls, when set, secures the runtime push: the provider dials wss:// (TLS)
+instead of plaintext ws:// and authenticates with the material in the
+referenced Secret. Omit it to keep the plaintext ws:// behavior (N-12).<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### NTNCellConfig.spec.provider.remoteControl.tls
+<sup><sup>[↩ Parent](#ntncellconfigspecproviderremotecontrol)</sup></sup>
+
+
+
+tls, when set, secures the runtime push: the provider dials wss:// (TLS)
+instead of plaintext ws:// and authenticates with the material in the
+referenced Secret. Omit it to keep the plaintext ws:// behavior (N-12).
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>mode</b></td>
+        <td>enum</td>
+        <td>
+          mode selects the transport-security posture:
+  "tls"  — dial wss://, verify the server certificate, and (if the Secret
+           carries a token) send it as an Authorization: Bearer header.
+  "mtls" — additionally present a client certificate (mutual TLS); the
+           Secret MUST then carry tls.crt + tls.key.<br/>
+          <br/>
+            <i>Enum</i>: tls, mtls<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>secretName</b></td>
+        <td>string</td>
+        <td>
+          secretName is the Secret (in this NTNCellConfig's namespace) holding the TLS
+trust and auth material. Recognized keys: "ca.crt" (PEM CA to verify the
+gNB/proxy server certificate — omit to use the system roots), "token" (the
+shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
+"tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
+replayable, so it is only ever sent over the wss:// (TLS) connection.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>serverName</b></td>
+        <td>string</td>
+        <td>
+          serverName overrides the TLS ServerName (SNI) verified against the server
+certificate's SubjectAltNames. Defaults to the endpoint host. Set it when the
+gNB/proxy certificate's SAN does not match the dialed host (e.g. an IP
+endpoint fronted by a DNS-named certificate).<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -2232,6 +2298,8 @@ with terrestrial-satellite failover policy.
         <td>object</td>
         <td>
           failoverPolicy defines when and how to switch between paths.<br/>
+          <br/>
+            <i>Validations</i>:<li>self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)? *$')): each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite number (e.g. 'rsrp < -120')</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -2314,10 +2382,30 @@ failoverPolicy defines when and how to switch between paths.
         <td>
           triggers defines conditions that initiate failover (OR logic).
 Format: "metric operator value" (e.g., "rsrp < -120").
-Validated at runtime by the failover engine (pkg/slice.ParseTrigger).
+Validated at admission by the XValidation rule on this type and at runtime by
+the failover engine (pkg/slice.ParseTrigger).
 Order is intentionally not significant; set merge semantics are desired.<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>confirmationSamples</b></td>
+        <td>integer</td>
+        <td>
+          confirmationSamples is the number of CONSECUTIVE reconcile samples on which
+the terrestrial triggers must fire before a failover to satellite is taken
+(production load balancers such as AWS ALB / GCP count consecutive, not
+windowed, probe results). It absorbs a single-sample blip so one noisy
+reading does not trip a switch. 1 (the default when unset) preserves the
+prior immediate-failover behavior; a value of N delays failover by up to
+(N-1) reconcile intervals. The confirmation counter is kept in memory and
+resets on any healthy reliable sample; losing it on a controller restart or
+leader-election handoff only re-requires confirmation (a DELAY), never causes
+a spurious switch.<br/>
+          <br/>
+            <i>Minimum</i>: 1<br/>
+            <i>Maximum</i>: 10<br/>
+        </td>
+        <td>false</td>
       </tr><tr>
         <td><b>hysteresisMargin</b></td>
         <td>string</td>
@@ -2328,6 +2416,20 @@ oscillate near the threshold. The value uses the same unit as
 the trigger (dB for RSRP, ms for latency, percent for packetLoss).
 Example: with trigger "rsrp < -120" and hysteresisMargin "10",
 failover fires at RSRP < -120, but switchback requires RSRP >= -110.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minTerrestrialDwell</b></td>
+        <td>string</td>
+        <td>
+          minTerrestrialDwell is the minimum time the terrestrial path must be held
+after a switchback before another failover to satellite may be taken. It
+bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
+— a genuinely failing terrestrial still fails over once the dwell elapses,
+so it never indefinitely blocks a real failover. 0 (the default) disables
+it; 30s–120s is a sane range relative to a LEO pass.<br/>
+          <br/>
+            <i>Format</i>: duration<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2877,6 +2979,12 @@ SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack)
 orbital propagation (SGP4 via akhenakh/sgp4), and pass prediction for a set of
 satellites against ground stations.
 
+Orbit-regime support: v1.0 is LEO-only. The propagator is the near-earth SGP4
+model; element sets whose orbital period is >= 225 minutes (deep space —
+roughly MEO and above, e.g. O3b or GEO) are rejected rather than propagated
+into a wrong position, and surface as the UnsupportedOrbitRegime status
+condition. Multi-orbit (MEO/GEO) support is a v1.1 roadmap item.
+
 <table>
     <thead>
         <tr>
@@ -3004,7 +3112,11 @@ CelesTrak updates every 2 hours; setting this below 2h wastes bandwidth.<br/>
         <td><b>url</b></td>
         <td>string</td>
         <td>
-          url is the endpoint to fetch GP data from.
+          url is the endpoint to fetch GP data from. Use https for any public
+source: a cleartext http:// URL that resolves to a public IP is refused
+at runtime (InsecureURL condition) because an on-path attacker could
+inject forged OMM data that is propagated into SIB19. http:// is permitted
+only for a private/in-cluster mirror (NetworkPolicy-protected).
 For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
 For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...<br/>
         </td>
@@ -3121,13 +3233,6 @@ satellites filters which satellites to track from the source.
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>constellation</b></td>
-        <td>string</td>
-        <td>
-          constellation filters by constellation name (e.g., "oneweb", "starlink").<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>noradIDs</b></td>
         <td>[]integer</td>
         <td>
@@ -3192,6 +3297,16 @@ under the etcd object-size limit.<br/>
         <td>integer</td>
         <td>
           satelliteCount is the number of satellites currently tracked.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>truncatedSatelliteCount</b></td>
+        <td>integer</td>
+        <td>
+          truncatedSatelliteCount is how many satellites were dropped because the
+selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+eliminate it. A Warning "StatesTruncated" event is emitted alongside.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -19,12 +19,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/akhenakh/sgp4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
@@ -258,6 +260,57 @@ func TestPropagateStates_FillsStatus(t *testing.T) {
 	}
 	if s.ECEF.PosX == 0 && s.ECEF.PosY == 0 && s.ECEF.PosZ == 0 {
 		t.Fatalf("ECEF not populated by SGP4: %+v", s.ECEF)
+	}
+}
+
+// I-23: when the selected set exceeds the maxPropagatedStates cap, propagateStates
+// records the drop count in status AND emits a Warning StatesTruncated event —
+// instead of only logging (observability of dropped data).
+func TestPropagateStates_TruncationSurfacedInStatusAndEvent(t *testing.T) {
+	rec := events.NewFakeRecorder(10)
+	r := &SatelliteEphemerisReconciler{Recorder: rec}
+	const over = 5
+	omms := make([]sgp4.OMM, 0, maxPropagatedStates+over)
+	for i := range maxPropagatedStates + over {
+		o := issOMMForTest()
+		o.NoradCatID = 25544 + i // distinct satellites
+		omms = append(omms, o)
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	epoch := time.Now().Add(2 * time.Hour)
+	r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: omms}, epoch)
+
+	if eph.Status.TruncatedSatelliteCount != over {
+		t.Errorf("TruncatedSatelliteCount = %d, want %d", eph.Status.TruncatedSatelliteCount, over)
+	}
+	if len(eph.Status.PropagatedStates) != maxPropagatedStates {
+		t.Errorf("PropagatedStates = %d, want cap %d", len(eph.Status.PropagatedStates), maxPropagatedStates)
+	}
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, "Warning") || !strings.Contains(ev, "StatesTruncated") {
+			t.Errorf("want a Warning StatesTruncated event, got %q", ev)
+		}
+	default:
+		t.Error("expected a StatesTruncated event, got none")
+	}
+}
+
+// Below the cap: no truncation recorded, no event emitted.
+func TestPropagateStates_NoTruncation_NoEvent(t *testing.T) {
+	rec := events.NewFakeRecorder(10)
+	r := &SatelliteEphemerisReconciler{Recorder: rec}
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	epoch := time.Now().Add(2 * time.Hour)
+	r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMForTest()}}, epoch)
+
+	if eph.Status.TruncatedSatelliteCount != 0 {
+		t.Errorf("TruncatedSatelliteCount = %d, want 0", eph.Status.TruncatedSatelliteCount)
+	}
+	select {
+	case ev := <-rec.Events:
+		t.Errorf("expected no event below the cap, got %q", ev)
+	default:
 	}
 }
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -461,13 +461,21 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		norad = eph.Spec.Satellites.NoradIDs
 	}
 	omms := ephemeris.FilterOMMs(result.OMMs, norad)
+	truncated := 0
 	if len(omms) > maxPropagatedStates {
-		// No silent truncation: a satellite beyond the cap won't be pushable at
-		// runtime (its NoradID selector would miss). Tell the operator to narrow
-		// the set with spec.satellites.noradIDs.
+		truncated = len(omms) - maxPropagatedStates
+		// Not silent: a satellite beyond the cap won't be pushable at runtime (its
+		// NoradID selector would miss). Surface it as a status field + a Warning
+		// event, and tell the operator to narrow the selected set.
 		logf.FromContext(ctx).Info("propagated-state list capped; some satellites omitted from runtime-push status",
 			"tracked", len(omms), "cap", maxPropagatedStates,
 			"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
+		if r.Recorder != nil {
+			r.Recorder.Eventf(eph, nil, "Warning", "StatesTruncated", "StatesTruncated",
+				"selected %d satellites but the propagated-state cap is %d; %d omitted from "+
+					"runtime-push status — narrow spec.satellites.noradIDs or the source URL GROUP=",
+				len(omms), maxPropagatedStates, truncated)
+		}
 	}
 	epochMs := epoch.UnixMilli()
 
@@ -504,6 +512,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		})
 	}
 	eph.Status.PropagatedStates = states
+	eph.Status.TruncatedSatelliteCount = truncated
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
 }
 

--- a/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -808,10 +812,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -828,7 +834,7 @@ spec:
                           tight-requeue on a mistyped endpoint).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
                       tls:
                         description: |-
@@ -855,6 +861,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -92,10 +92,6 @@ spec:
                 description: satellites filters which satellites to track from the
                   source.
                 properties:
-                  constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
-                    type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs
                       to track.
@@ -356,6 +352,13 @@ spec:
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.
+                type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. A Warning "StatesTruncated" event is emitted alongside.
                 type: integer
             type: object
         required:

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
@@ -8,10 +8,9 @@ metadata:
 spec:
   source:
     type: CelesTrak
+    # GROUP=oneweb selects the constellation server-side — no client-side filter.
     url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -85,14 +86,34 @@ func (p *Provider) EnsureOwnership(
 	return nil
 }
 
-// Cleanup deletes the provider's ConfigMap for the given CR.
+// Cleanup deletes the provider's ConfigMap for the given CR, but only when that
+// ConfigMap is actually controller-owned by this CR — mirroring the reconciler's
+// own best-effort finalizer (ntncellconfig_controller.go). A same-named ConfigMap
+// the operator does not own (a user-created one, or a leftover from a different CR
+// that reused the name) is left untouched instead of deleted.
 func (p *Provider) Cleanup(ctx context.Context, crName, namespace string) error {
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
 	if err := p.client.Get(ctx, key, cm); err != nil {
 		return client.IgnoreNotFound(err)
 	}
+	if !isConfigMapOwnedByCR(cm, crName) {
+		return nil
+	}
 	return client.IgnoreNotFound(p.client.Delete(ctx, cm))
+}
+
+// isConfigMapOwnedByCR reports whether cm's controller owner reference is an
+// NTNCellConfig named crName in this operator's API group. Cleanup is given only
+// the CR name (not the live object with its UID), so this is a group+kind+name
+// check rather than the UID-based metav1.IsControlledBy the reconciler can use.
+func isConfigMapOwnedByCR(cm *corev1.ConfigMap, crName string) bool {
+	ctrl := metav1.GetControllerOf(cm)
+	if ctrl == nil || ctrl.Kind != "NTNCellConfig" || ctrl.Name != crName {
+		return false
+	}
+	gv, err := schema.ParseGroupVersion(ctrl.APIVersion)
+	return err == nil && gv.Group == ntnv1alpha1.GroupVersion.Group
 }
 
 // NewProvider creates an OCUDU Provider with the given K8s client.

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,6 +65,63 @@ func newTestProvider(t *testing.T) *Provider {
 
 // Compile-time check: Provider implements NTNProvider.
 var _ provider.NTNProvider = &Provider{}
+
+// TestCleanup_OwnershipCheck asserts Cleanup only deletes a ConfigMap that is
+// controller-owned by the named NTNCellConfig (N-3), mirroring the reconciler's
+// finalizer, and leaves a same-named but unowned/foreign ConfigMap alone.
+func TestCleanup_OwnershipCheck(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1): %v", err)
+	}
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ntnv1alpha1): %v", err)
+	}
+	const crName = "cell-a"
+	const ns = "ntn-system"
+	cmName := ConfigMapNameFor(crName)
+	isController := true
+
+	mkRef := func(apiVersion, kind, name string, controller bool) metav1.OwnerReference {
+		ref := metav1.OwnerReference{APIVersion: apiVersion, Kind: kind, Name: name, UID: "uid-owner"}
+		if controller {
+			ref.Controller = &isController
+		}
+		return ref
+	}
+	grp := ntnv1alpha1.GroupVersion.String()
+
+	tests := []struct {
+		name        string
+		refs        []metav1.OwnerReference
+		wantDeleted bool
+	}{
+		{"controller-owned by this CR", []metav1.OwnerReference{mkRef(grp, "NTNCellConfig", crName, true)}, true},
+		{"no owner references", nil, false},
+		{"owned by a different CR name", []metav1.OwnerReference{mkRef(grp, "NTNCellConfig", "cell-b", true)}, false},
+		{"owned by a different kind", []metav1.OwnerReference{mkRef(grp, "SomethingElse", crName, true)}, false},
+		{"owned by a different group", []metav1.OwnerReference{mkRef("other/v1", "NTNCellConfig", crName, true)}, false},
+		{"present but not the controller", []metav1.OwnerReference{mkRef(grp, "NTNCellConfig", crName, false)}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns, OwnerReferences: tc.refs},
+				Data:       map[string]string{"geo_ntn.yml": "x"},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+			p := NewProvider(c)
+			if err := p.Cleanup(context.Background(), crName, ns); err != nil {
+				t.Fatalf("Cleanup: %v", err)
+			}
+			err := c.Get(context.Background(), types.NamespacedName{Name: cmName, Namespace: ns}, &corev1.ConfigMap{})
+			deleted := apierrors.IsNotFound(err)
+			if deleted != tc.wantDeleted {
+				t.Errorf("deleted=%v, want %v (get err=%v)", deleted, tc.wantDeleted, err)
+			}
+		})
+	}
+}
 
 func TestApplyCellConfig_CreatesConfigMap(t *testing.T) {
 	p := newTestProvider(t)

--- a/test/e2e/fixtures/satelliteephemeris-e2e.yaml
+++ b/test/e2e/fixtures/satelliteephemeris-e2e.yaml
@@ -16,8 +16,6 @@ spec:
     type: CelesTrak
     url: http://celestrak-mock.default.svc.cluster.local/gp.json
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01


### PR DESCRIPTION
Audit ratchets & small correctness (**WO-16**, minus I-23 which lands in a follow-up commit). Each item verified still-open first.

- **N-3** — `ocudu.Provider.Cleanup` deleted the ConfigMap by name with **no ownership check**, so a same-named ConfigMap the operator doesn't own (user-created, or a leftover from a name-reused CR) could be deleted. It now deletes only when the ConfigMap's *controller* owner reference is an `NTNCellConfig` of this group+name — mirroring the reconciler's finalizer. **Unit-tested** (owned / no-owner / wrong-name / wrong-kind / wrong-group / non-controller) and **mutation-verified** (forcing "owned" fails the five keep cases).
- **N-8** — added a condition-status printer column so `kubectl get` shows health: SatelliteEphemeris **Fetched** (`GPDataFetched`), NTNCellConfig **Applied** (`ConfigApplied`), NTNSlice **Ready** (`FailoverReady`). GroundStation already prints Phase.
- **N-10** — `RemoteControlRef.endpoint` pattern rejected IPv6 literals; now accepts a bracketed IPv6 host (`[::1]:8001`, `[2001:db8::1]:443`) alongside host/IPv4 → runtime gNB push works on dual-stack clusters. Regex-verified.
- **MaxLength** — bounded **26** previously-unbounded spec strings (refs/secret-names 253, namespace 63, endpoints 261, URLs 2048, PromQL 1024, numeric strings 32). Enum / fixed-pattern / status fields left alone.

**Verification:** all four CRD copies regenerated + drift-checked (bundle + nephio in sync); full suite 9/9; lint 0; gofmt clean.

Follow-up in this branch: **I-23** (remove the dead `spec.satellites.constellation` field + surface the `maxPropagatedStates` truncation in status/events) — decided via deep-research (alpha removal permitted; constellation redundant with CelesTrak `GROUP=`).