### PR TITLE
fix(provider): own the ConfigMap at create + UID-scoped cleanup [WO-16 PR A]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -219,7 +219,11 @@ func main() {
 		os.Exit(1)
 	}
 	providers := map[string]provider.NTNProvider{
-		"ocudu": ocudu.NewProvider(mgr.GetClient()),
+		// WithAPIReader wires the uncached reader so ownership checks and the status
+		// read-back see a just-created ConfigMap immediately, instead of racing the
+		// eventually-consistent informer cache (which would persist an empty
+		// configMapRef on the first reconcile and only self-heal on the 5m requeue).
+		"ocudu": ocudu.NewProvider(mgr.GetClient()).WithAPIReader(mgr.GetAPIReader()),
 	}
 	if err := (&controller.NTNCellConfigReconciler{
 		Client:                  mgr.GetClient(),

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -222,17 +222,23 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		"provider", spec.Provider.Type,
 		"koffset", spec.NTN.CellSpecificKoffset)
 
-	if err := prov.ApplyCellConfig(ctx, cc.Name, spec); err != nil {
+	if err := prov.ApplyCellConfig(ctx, cc, spec, r.Scheme); err != nil {
 		log.Error(err, "Failed to apply cell config")
 		ntnmetrics.ConfigApplyErrorsTotal.With(prometheus.Labels{
 			"namespace": cc.Namespace, "config": cc.Name, "provider": spec.Provider.Type,
 		}).Inc()
 		cc.Status.AppliedKoffset = 0
+		// A ConfigMap-ownership collision is distinct from a generic apply failure:
+		// the operator refuses to overwrite a ConfigMap it does not own.
+		reason := "ApplyFailed"
+		if errors.Is(err, provider.ErrConfigMapNotOwned) {
+			reason = "OwnershipConflict"
+		}
 		// Preserve existing ConfigMapRef for best-effort finalizer cleanup.
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
-			Reason:             "ApplyFailed",
+			Reason:             reason,
 			Message:            err.Error(),
 			ObservedGeneration: cc.Generation,
 		})
@@ -240,15 +246,12 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 		if r.Recorder != nil {
-			r.Recorder.Eventf(cc, nil, "Warning", "ApplyFailed", "ApplyFailed", "%s", err.Error())
+			r.Recorder.Eventf(cc, nil, "Warning", reason, reason, "%s", err.Error())
 		}
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
-
-	// Step 5b: Ensure ownership on provider artifact for garbage collection.
-	if err := prov.EnsureOwnership(ctx, cc.Name, cc, r.Scheme); err != nil {
-		log.Error(err, "failed to ensure ownership on provider artifact")
-	}
+	// The controller reference is set ATOMICALLY at ConfigMap creation inside
+	// ApplyCellConfig, so no separate best-effort ownership step is needed.
 
 	// Step 6: Get applied status from provider.
 	status, err := prov.GetCellStatus(ctx, cc.Name, spec.Provider.Namespace)
@@ -385,7 +388,7 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 				controllerutil.RemoveFinalizer(cc, finalizerName)
 				return true, ctrl.Result{}, r.Update(ctx, cc)
 			}
-			if err := prov.Cleanup(ctx, cc.Name, cc.Namespace); err != nil {
+			if err := prov.Cleanup(ctx, cc); err != nil {
 				log.Error(err, "Failed to cleanup provider artifact during finalization")
 				return true, ctrl.Result{}, err
 			}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -484,7 +484,7 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 		)
 	}
 
-	if err := prov.PushEphemerisUpdate(ctx, cc.Name, spec.Provider.Namespace, update); err != nil {
+	if err := prov.PushEphemerisUpdate(ctx, cc, update); err != nil {
 		return false, marker, newEphemerisPushError(
 			ephemerisReasonProviderPushFailed,
 			fmt.Errorf("provider PushEphemerisUpdate: %w", err),

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
@@ -116,15 +115,17 @@ type NTNProvider interface {
 	// with the CR). An existing artifact is overwritten only when it is already
 	// controller-owned by owner; otherwise ErrConfigMapNotOwned is returned.
 	ApplyCellConfig(
-		ctx context.Context, owner client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
+		ctx context.Context, owner *ntnv1alpha1.NTNCellConfig, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
 	) error
 
 	// GetCellStatus returns the current applied configuration status.
 	GetCellStatus(ctx context.Context, crName, namespace string) (*ntnv1alpha1.NTNCellConfigStatus, error)
 
 	// PushEphemerisUpdate pushes fresh ephemeris data to the backend by rewriting
-	// the bootstrap ConfigMap (the gNB must reload). Kept as the baseline path.
-	PushEphemerisUpdate(ctx context.Context, crName, namespace string, update EphemerisUpdate) error
+	// the bootstrap ConfigMap (the gNB must reload). Kept as the baseline path. It
+	// re-verifies the ConfigMap is controller-owned by owner before mutating it, so
+	// it never rewrites a foreign object (ErrConfigMapNotOwned if it is not).
+	PushEphemerisUpdate(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig, update EphemerisUpdate) error
 
 	// PushRuntimeUpdate pushes a runtime NTN config update to the gNB's
 	// remote-control WebSocket (OCUDU ntn_config_update, MR !798) — a live update
@@ -137,5 +138,5 @@ type NTNProvider interface {
 	// controller-owned by owner (UID match via metav1.IsControlledBy), so a
 	// same-named artifact the operator does not own is left untouched. Returns nil
 	// if there is nothing to clean up.
-	Cleanup(ctx context.Context, owner client.Object) error
+	Cleanup(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig) error
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
@@ -95,6 +95,13 @@ var ErrRuntimeUnsupported = errors.New("runtime NTN config push is not supported
 // (unlike a transient unreachable-endpoint error). Test with errors.Is.
 var ErrRuntimePushRejected = errors.New("runtime NTN config push permanently rejected")
 
+// ErrConfigMapNotOwned is returned by ApplyCellConfig when a ConfigMap with the
+// provider's deterministic name already exists but is NOT controller-owned by the
+// applying CR (a name collision with a foreign/user-created object, or a leftover
+// from a different CR that reused the name). The provider refuses to overwrite it;
+// the controller surfaces an OwnershipConflict condition + event. Test with errors.Is.
+var ErrConfigMapNotOwned = errors.New("existing ConfigMap is not owned by this NTNCellConfig")
+
 // NTNProvider abstracts NTN backend interactions for cell configuration
 // and ephemeris updates. Ground station lifecycle is handled directly
 // by its respective controller.
@@ -103,9 +110,14 @@ var ErrRuntimePushRejected = errors.New("runtime NTN config push permanently rej
 // ConfigMap. If a future provider uses a different artifact type,
 // the interface and controller should be generalized at that time.
 type NTNProvider interface {
-	// ApplyCellConfig applies NTN radio parameters to the backend.
-	// crName is the NTNCellConfig CR name (used to scope the provider artifact).
-	ApplyCellConfig(ctx context.Context, crName string, spec *ntnv1alpha1.NTNCellConfigSpec) error
+	// ApplyCellConfig applies NTN radio parameters to the backend. owner is the
+	// NTNCellConfig CR: its name scopes the artifact, and a controller reference to
+	// it is set ATOMICALLY when the artifact is created (so K8s garbage-collects it
+	// with the CR). An existing artifact is overwritten only when it is already
+	// controller-owned by owner; otherwise ErrConfigMapNotOwned is returned.
+	ApplyCellConfig(
+		ctx context.Context, owner client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
+	) error
 
 	// GetCellStatus returns the current applied configuration status.
 	GetCellStatus(ctx context.Context, crName, namespace string) (*ntnv1alpha1.NTNCellConfigStatus, error)
@@ -120,13 +132,10 @@ type NTNProvider interface {
 	// provider or target has no runtime transport configured.
 	PushRuntimeUpdate(ctx context.Context, target ResolvedRemoteControl, update RuntimeUpdate) error
 
-	// EnsureOwnership sets ownership metadata (e.g., OwnerReference) on
-	// the provider's managed artifact so it is garbage-collected when
-	// the parent NTNCellConfig CR is deleted.
-	EnsureOwnership(ctx context.Context, crName string, owner metav1.Object, scheme *runtime.Scheme) error
-
-	// Cleanup removes provider-managed artifacts for the given CR name
-	// and namespace. Called by the finalizer during CR deletion.
-	// Returns nil if there is nothing to clean up (artifact not found).
-	Cleanup(ctx context.Context, crName, namespace string) error
+	// Cleanup removes provider-managed artifacts owned by the given CR. Called by
+	// the finalizer during CR deletion. It deletes the artifact only when it is
+	// controller-owned by owner (UID match via metav1.IsControlledBy), so a
+	// same-named artifact the operator does not own is left untouched. Returns nil
+	// if there is nothing to clean up.
+	Cleanup(ctx context.Context, owner client.Object) error
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"sync"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
@@ -40,6 +40,8 @@ type MockProvider struct {
 	EphemerisCalls int
 	RuntimeErr     error
 	RuntimeCalls   int
+	CleanupErr     error
+	CleanupCalls   int
 	LastSpec       *ntnv1alpha1.NTNCellConfigSpec
 	LastEphemeris  *EphemerisUpdate
 	LastRuntime    *RuntimeUpdate
@@ -47,7 +49,9 @@ type MockProvider struct {
 	StatusValue    *ntnv1alpha1.NTNCellConfigStatus
 }
 
-func (m *MockProvider) ApplyCellConfig(_ context.Context, _ string, spec *ntnv1alpha1.NTNCellConfigSpec) error {
+func (m *MockProvider) ApplyCellConfig(
+	_ context.Context, _ client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, _ *runtime.Scheme,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ApplyCalls++
@@ -82,12 +86,9 @@ func (m *MockProvider) PushRuntimeUpdate(_ context.Context, target ResolvedRemot
 	return m.RuntimeErr
 }
 
-func (m *MockProvider) EnsureOwnership(
-	_ context.Context, _ string, _ metav1.Object, _ *runtime.Scheme,
-) error {
-	return nil
-}
-
-func (m *MockProvider) Cleanup(_ context.Context, _, _ string) error {
-	return nil
+func (m *MockProvider) Cleanup(_ context.Context, _ client.Object) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.CleanupCalls++
+	return m.CleanupErr
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
@@ -50,7 +49,7 @@ type MockProvider struct {
 }
 
 func (m *MockProvider) ApplyCellConfig(
-	_ context.Context, _ client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, _ *runtime.Scheme,
+	_ context.Context, _ *ntnv1alpha1.NTNCellConfig, spec *ntnv1alpha1.NTNCellConfigSpec, _ *runtime.Scheme,
 ) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -69,7 +68,9 @@ func (m *MockProvider) GetCellStatus(_ context.Context, _, _ string) (*ntnv1alph
 	return &ntnv1alpha1.NTNCellConfigStatus{}, m.StatusErr
 }
 
-func (m *MockProvider) PushEphemerisUpdate(_ context.Context, _, _ string, update EphemerisUpdate) error {
+func (m *MockProvider) PushEphemerisUpdate(
+	_ context.Context, _ *ntnv1alpha1.NTNCellConfig, update EphemerisUpdate,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.EphemerisCalls++
@@ -86,7 +87,7 @@ func (m *MockProvider) PushRuntimeUpdate(_ context.Context, target ResolvedRemot
 	return m.RuntimeErr
 }
 
-func (m *MockProvider) Cleanup(_ context.Context, _ client.Object) error {
+func (m *MockProvider) Cleanup(_ context.Context, _ *ntnv1alpha1.NTNCellConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.CleanupCalls++

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -64,33 +64,34 @@ type Provider struct {
 	client client.Client
 }
 
-// EnsureOwnership sets OwnerReference on the provider's ConfigMap.
-func (p *Provider) EnsureOwnership(
-	ctx context.Context, crName string, owner metav1.Object, scheme *runtime.Scheme,
-) error {
+// Management labels stamped on every ConfigMap this provider creates. They let the
+// provider recognize (and safely adopt) its own artifact even when a controller
+// owner reference is missing — e.g. a ConfigMap created by a pre-atomic-reference
+// operator version — while never touching an unlabeled foreign object.
+const (
+	managedByLabel = "app.kubernetes.io/managed-by"
+	managedByValue = "ntn-operators"
+	componentLabel = "app.kubernetes.io/component"
+	componentValue = "ocudu-ntn-config"
+)
+
+// isOperatorManaged reports whether cm carries this provider's management labels.
+func isOperatorManaged(cm *corev1.ConfigMap) bool {
+	return cm.Labels[managedByLabel] == managedByValue && cm.Labels[componentLabel] == componentValue
+}
+
+// Cleanup deletes the provider's ConfigMap for owner, but only when it is
+// controller-owned by owner (UID match via metav1.IsControlledBy) — a same-named
+// ConfigMap the operator does not own is left untouched. Called by the finalizer
+// during CR deletion.
+func (p *Provider) Cleanup(ctx context.Context, owner client.Object) error {
 	cm := &corev1.ConfigMap{}
-	key := types.NamespacedName{
-		Name:      ConfigMapNameFor(crName),
-		Namespace: owner.GetNamespace(),
-	}
+	key := types.NamespacedName{Name: ConfigMapNameFor(owner.GetName()), Namespace: owner.GetNamespace()}
 	if err := p.client.Get(ctx, key, cm); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(cm, owner) {
-		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
-			return err
-		}
-		return p.client.Update(ctx, cm)
-	}
-	return nil
-}
-
-// Cleanup deletes the provider's ConfigMap for the given CR.
-func (p *Provider) Cleanup(ctx context.Context, crName, namespace string) error {
-	cm := &corev1.ConfigMap{}
-	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
-	if err := p.client.Get(ctx, key, cm); err != nil {
-		return client.IgnoreNotFound(err)
+		return nil
 	}
 	return client.IgnoreNotFound(p.client.Delete(ctx, cm))
 }
@@ -100,9 +101,14 @@ func NewProvider(c client.Client) *Provider {
 	return &Provider{client: c}
 }
 
-// ApplyCellConfig generates OCUDU-compatible NTN config YAML and writes it
-// to a ConfigMap in the provider's target namespace.
-func (p *Provider) ApplyCellConfig(ctx context.Context, crName string, spec *ntnv1alpha1.NTNCellConfigSpec) error {
+// ApplyCellConfig generates OCUDU-compatible NTN config YAML and writes it to a
+// ConfigMap in the provider's target namespace. On create it sets a controller
+// reference to owner ATOMICALLY; on update it overwrites only a ConfigMap it owns
+// (or adopts an unowned but operator-labeled one from a pre-atomic-ref version),
+// returning ErrConfigMapNotOwned for a foreign object.
+func (p *Provider) ApplyCellConfig(
+	ctx context.Context, owner client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
+) error {
 	if spec == nil {
 		return fmt.Errorf("spec must not be nil")
 	}
@@ -115,6 +121,7 @@ func (p *Provider) ApplyCellConfig(ctx context.Context, crName string, spec *ntn
 		return fmt.Errorf("generating OCUDU config: %w", err)
 	}
 
+	crName := owner.GetName()
 	namespace := spec.Provider.Namespace
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
@@ -126,8 +133,8 @@ func (p *Provider) ApplyCellConfig(ctx context.Context, crName string, spec *ntn
 				Name:      ConfigMapNameFor(crName),
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "ntn-operators",
-					"app.kubernetes.io/component":  "ocudu-ntn-config",
+					managedByLabel: managedByValue,
+					componentLabel: componentValue,
 				},
 				Annotations: map[string]string{
 					"ntn.operators.dev/koffset": strconv.Itoa(spec.NTN.CellSpecificKoffset),
@@ -137,25 +144,43 @@ func (p *Provider) ApplyCellConfig(ctx context.Context, crName string, spec *ntn
 				"geo_ntn.yml": string(yamlData),
 			},
 		}
+		// Set the controller reference ATOMICALLY, before Create, so the ConfigMap
+		// is owned (and GC-cascaded with the CR) from the instant it exists — no
+		// best-effort second write that can fail and leave an unowned artifact.
+		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
+			return fmt.Errorf("setting controller reference: %w", err)
+		}
 		if err := p.client.Create(ctx, cm); err != nil {
 			return fmt.Errorf("creating ConfigMap: %w", err)
 		}
-	} else if err != nil {
+		return nil
+	}
+	if err != nil {
 		return fmt.Errorf("getting ConfigMap: %w", err)
-	} else {
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
-		}
-		cm.Data["geo_ntn.yml"] = string(yamlData)
-		if cm.Annotations == nil {
-			cm.Annotations = make(map[string]string)
-		}
-		cm.Annotations["ntn.operators.dev/koffset"] = strconv.Itoa(spec.NTN.CellSpecificKoffset)
-		if err := p.client.Update(ctx, cm); err != nil {
-			return fmt.Errorf("updating ConfigMap: %w", err)
-		}
 	}
 
+	// Existing ConfigMap: overwrite only if we own it, or adopt it if it is unowned
+	// but carries our management labels (a pre-atomic-ref leftover). A ConfigMap
+	// owned by a different controller, or an unlabeled foreign object, is refused.
+	if !metav1.IsControlledBy(cm, owner) {
+		if metav1.GetControllerOf(cm) != nil || !isOperatorManaged(cm) {
+			return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
+		}
+		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
+			return fmt.Errorf("adopting ConfigMap: %w", err)
+		}
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["geo_ntn.yml"] = string(yamlData)
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	cm.Annotations["ntn.operators.dev/koffset"] = strconv.Itoa(spec.NTN.CellSpecificKoffset)
+	if err := p.client.Update(ctx, cm); err != nil {
+		return fmt.Errorf("updating ConfigMap: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -84,7 +84,7 @@ func isOperatorManaged(cm *corev1.ConfigMap) bool {
 // controller-owned by owner (UID match via metav1.IsControlledBy) — a same-named
 // ConfigMap the operator does not own is left untouched. Called by the finalizer
 // during CR deletion.
-func (p *Provider) Cleanup(ctx context.Context, owner client.Object) error {
+func (p *Provider) Cleanup(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig) error {
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(owner.GetName()), Namespace: owner.GetNamespace()}
 	if err := p.client.Get(ctx, key, cm); err != nil {
@@ -107,13 +107,20 @@ func NewProvider(c client.Client) *Provider {
 // (or adopts an unowned but operator-labeled one from a pre-atomic-ref version),
 // returning ErrConfigMapNotOwned for a foreign object.
 func (p *Provider) ApplyCellConfig(
-	ctx context.Context, owner client.Object, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
+	ctx context.Context, owner *ntnv1alpha1.NTNCellConfig, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
 ) error {
 	if spec == nil {
 		return fmt.Errorf("spec must not be nil")
 	}
 	if spec.Provider.Namespace == "" {
 		return fmt.Errorf("provider namespace must be set")
+	}
+	// Defense-in-depth: the ConfigMap is created in spec.Provider.Namespace with a
+	// controller reference to owner, which Kubernetes forbids across namespaces — so
+	// require them equal here rather than trusting the caller to have aligned them.
+	if owner.GetNamespace() != spec.Provider.Namespace {
+		return fmt.Errorf("owner namespace %q must equal provider namespace %q",
+			owner.GetNamespace(), spec.Provider.Namespace)
 	}
 
 	yamlData, err := GenerateConfig(spec)
@@ -222,10 +229,10 @@ func (p *Provider) GetCellStatus(
 // Phase 1 implementation: reads the current config, replaces the ephemeris
 // data, and writes it back. Future Phase 2 will use OCUDU's WebSocket API.
 func (p *Provider) PushEphemerisUpdate(
-	ctx context.Context, crName, namespace string, update provider.EphemerisUpdate,
+	ctx context.Context, owner *ntnv1alpha1.NTNCellConfig, update provider.EphemerisUpdate,
 ) error {
-	if namespace == "" {
-		return fmt.Errorf("namespace must not be empty")
+	if owner.GetNamespace() == "" {
+		return fmt.Errorf("owner namespace must not be empty")
 	}
 	if update.ECEF == nil && update.Orbital == nil {
 		return fmt.Errorf("either ECEF or Orbital must be set")
@@ -234,6 +241,8 @@ func (p *Provider) PushEphemerisUpdate(
 		return fmt.Errorf("ECEF and Orbital are mutually exclusive")
 	}
 
+	crName := owner.GetName()
+	namespace := owner.GetNamespace()
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{
 		Name:      ConfigMapNameFor(crName),
@@ -242,6 +251,12 @@ func (p *Provider) PushEphemerisUpdate(
 	if err := p.client.Get(ctx, key, cm); err != nil {
 		return fmt.Errorf("reading ConfigMap %s/%s: %w",
 			namespace, ConfigMapNameFor(crName), err)
+	}
+	// Re-verify ownership before mutating: never rewrite a ConfigMap the operator
+	// does not control — e.g. a same-named foreign object created between the
+	// ApplyCellConfig that made this CM and this bootstrap ephemeris rewrite.
+	if !metav1.IsControlledBy(cm, owner) {
+		return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 	}
 
 	yamlContent, ok := cm.Data["geo_ntn.yml"]

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -40,6 +40,10 @@ import (
 // ConfigMapPrefix is the prefix for ConfigMap names. Final name = prefix + CR name.
 const ConfigMapPrefix = "ocudu-ntn-"
 
+// configDataKey is the ConfigMap data key holding the OCUDU NTN config document.
+// Its presence also marks a ConfigMap as a genuine operator artifact for adoption.
+const configDataKey = "geo_ntn.yml"
+
 // maxK8sNameLen is the maximum length for a Kubernetes object name.
 const maxK8sNameLen = 253
 
@@ -62,6 +66,28 @@ func ConfigMapNameFor(crName string) string {
 // It is stateless — status is derived from the ConfigMap.
 type Provider struct {
 	client client.Client
+	// apiReader performs uncached reads straight from the API server. The controller
+	// wires it to mgr.GetAPIReader() so ownership checks and the status read-back see a
+	// just-created ConfigMap immediately, instead of racing the informer cache — which
+	// is eventually consistent and can lag a Create by a cache-sync interval, making a
+	// same-reconcile read-back return NotFound and persist an empty configMapRef. Nil
+	// in unit tests, where reader() falls back to the (already-consistent) fake client.
+	apiReader client.Reader
+}
+
+// reader returns the uncached API reader when wired, else the cached client.
+func (p *Provider) reader() client.Reader {
+	if p.apiReader != nil {
+		return p.apiReader
+	}
+	return p.client
+}
+
+// WithAPIReader wires an uncached reader (mgr.GetAPIReader()) for read-back
+// consistency and returns the receiver for chaining.
+func (p *Provider) WithAPIReader(r client.Reader) *Provider {
+	p.apiReader = r
+	return p
 }
 
 // Management labels stamped on every ConfigMap this provider creates. They let the
@@ -87,7 +113,7 @@ func isOperatorManaged(cm *corev1.ConfigMap) bool {
 func (p *Provider) Cleanup(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig) error {
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(owner.GetName()), Namespace: owner.GetNamespace()}
-	if err := p.client.Get(ctx, key, cm); err != nil {
+	if err := p.reader().Get(ctx, key, cm); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(cm, owner) {
@@ -132,7 +158,7 @@ func (p *Provider) ApplyCellConfig(
 	namespace := spec.Provider.Namespace
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
-	err = p.client.Get(ctx, key, cm)
+	err = p.reader().Get(ctx, key, cm)
 
 	if apierrors.IsNotFound(err) {
 		cm = &corev1.ConfigMap{
@@ -148,7 +174,7 @@ func (p *Provider) ApplyCellConfig(
 				},
 			},
 			Data: map[string]string{
-				"geo_ntn.yml": string(yamlData),
+				configDataKey: string(yamlData),
 			},
 		}
 		// Set the controller reference ATOMICALLY, before Create, so the ConfigMap
@@ -167,10 +193,12 @@ func (p *Provider) ApplyCellConfig(
 	}
 
 	// Existing ConfigMap: overwrite only if we own it, or adopt it if it is unowned
-	// but carries our management labels (a pre-atomic-ref leftover). A ConfigMap
-	// owned by a different controller, or an unlabeled foreign object, is refused.
+	// but is a genuine operator artifact — carrying our management labels AND the
+	// geo_ntn.yml config key (a pre-atomic-ref leftover). A ConfigMap owned by a
+	// different controller, an unlabeled foreign object, or a labeled-but-empty
+	// impostor that never held our config is refused.
 	if !metav1.IsControlledBy(cm, owner) {
-		if metav1.GetControllerOf(cm) != nil || !isOperatorManaged(cm) {
+		if metav1.GetControllerOf(cm) != nil || !isOperatorManaged(cm) || cm.Data[configDataKey] == "" {
 			return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 		}
 		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
@@ -180,7 +208,7 @@ func (p *Provider) ApplyCellConfig(
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
-	cm.Data["geo_ntn.yml"] = string(yamlData)
+	cm.Data[configDataKey] = string(yamlData)
 	if cm.Annotations == nil {
 		cm.Annotations = make(map[string]string)
 	}
@@ -203,7 +231,7 @@ func (p *Provider) GetCellStatus(
 
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(crName), Namespace: namespace}
-	if err := p.client.Get(ctx, key, cm); err != nil {
+	if err := p.reader().Get(ctx, key, cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			return status, nil
 		}
@@ -218,8 +246,8 @@ func (p *Provider) GetCellStatus(
 		}
 	}
 
-	if _, ok := cm.Data["geo_ntn.yml"]; !ok {
-		return status, fmt.Errorf("ConfigMap %s/%s missing geo_ntn.yml key", namespace, ConfigMapNameFor(crName))
+	if _, ok := cm.Data[configDataKey]; !ok {
+		return status, fmt.Errorf("ConfigMap %s/%s missing %s key", namespace, ConfigMapNameFor(crName), configDataKey)
 	}
 
 	return status, nil
@@ -248,7 +276,7 @@ func (p *Provider) PushEphemerisUpdate(
 		Name:      ConfigMapNameFor(crName),
 		Namespace: namespace,
 	}
-	if err := p.client.Get(ctx, key, cm); err != nil {
+	if err := p.reader().Get(ctx, key, cm); err != nil {
 		return fmt.Errorf("reading ConfigMap %s/%s: %w",
 			namespace, ConfigMapNameFor(crName), err)
 	}
@@ -259,11 +287,11 @@ func (p *Provider) PushEphemerisUpdate(
 		return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 	}
 
-	yamlContent, ok := cm.Data["geo_ntn.yml"]
+	yamlContent, ok := cm.Data[configDataKey]
 	if !ok {
 		return fmt.Errorf(
-			"ConfigMap %s/%s missing geo_ntn.yml",
-			namespace, ConfigMapNameFor(crName))
+			"ConfigMap %s/%s missing %s",
+			namespace, ConfigMapNameFor(crName), configDataKey)
 	}
 
 	// Replace the ephemeris section in the existing YAML.
@@ -273,7 +301,7 @@ func (p *Provider) PushEphemerisUpdate(
 			"ConfigMap %s/%s has no ephemeris block to replace",
 			namespace, ConfigMapNameFor(crName))
 	}
-	cm.Data["geo_ntn.yml"] = updated
+	cm.Data[configDataKey] = updated
 
 	if err := p.client.Update(ctx, cm); err != nil {
 		return fmt.Errorf("updating ConfigMap: %w", err)

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -186,6 +186,27 @@ func TestApplyCellConfig_OwnershipCollision(t *testing.T) {
 			t.Error("operator-labeled leftover should be adopted (controller ref set)")
 		}
 	})
+
+	t.Run("labeled but no geo_ntn.yml -> refused (not adopted)", func(t *testing.T) {
+		// A labeled-but-empty impostor never held our config: adoption must require
+		// the geo_ntn.yml key, not the labels alone, so a squatter cannot get itself
+		// controller-owned (and GC-cascaded) by copying two well-known label values.
+		impostor := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: "ntn-system",
+				Labels:    map[string]string{managedByLabel: managedByValue, componentLabel: componentValue},
+			},
+		}
+		p := newTestProviderWith(t, impostor)
+		err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), geoSpec(), ownerScheme(t))
+		if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+			t.Fatalf("want ErrConfigMapNotOwned, got %v", err)
+		}
+		if metav1.GetControllerOf(get(p)) != nil {
+			t.Error("labeled-but-empty impostor must not be adopted")
+		}
+	})
 }
 
 // TestCleanup_OwnershipUID: Cleanup deletes only a ConfigMap controlled by owner

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -18,6 +18,7 @@ package ocudu
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -25,7 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/provider"
@@ -57,19 +60,186 @@ func newTestProvider(t *testing.T) *Provider {
 
 	// Pre-create the target namespace.
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"}}
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
 
-	return NewProvider(client)
+	return NewProvider(cl)
+}
+
+// ownerFor returns an NTNCellConfig usable as the ApplyCellConfig/Cleanup owner,
+// in the provider namespace with a stable UID derived from name (so a same-named
+// owner compares equal under metav1.IsControlledBy, and a different name → a
+// different UID).
+func ownerFor(name string) *ntnv1alpha1.NTNCellConfig {
+	return &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ntn-system", UID: types.UID("uid-" + name)},
+	}
+}
+
+// ownerScheme is a scheme with the types SetControllerReference needs to resolve
+// the owner's GroupVersionKind.
+func ownerScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(corev1): %v", err)
+	}
+	if err := ntnv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(ntnv1alpha1): %v", err)
+	}
+	return s
 }
 
 // Compile-time check: Provider implements NTNProvider.
 var _ provider.NTNProvider = &Provider{}
 
+// newTestProviderWith builds a Provider whose fake client is pre-seeded with the
+// target namespace plus the given objects.
+func newTestProviderWith(t *testing.T, objs ...client.Object) *Provider {
+	t.Helper()
+	scheme := ownerScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"}}
+	b := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns)
+	for _, o := range objs {
+		b = b.WithObjects(o)
+	}
+	return NewProvider(b.Build())
+}
+
+// seedConfigMap builds the ConfigMap for the "cell-a" test CR, optionally
+// operator-labeled and/or controller-owned by controllerRef.
+func seedConfigMap(t *testing.T, labeled bool, controllerRef *ntnv1alpha1.NTNCellConfig) *corev1.ConfigMap {
+	t.Helper()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system"},
+		Data:       map[string]string{"geo_ntn.yml": "seed"},
+	}
+	if labeled {
+		cm.Labels = map[string]string{managedByLabel: managedByValue, componentLabel: componentValue}
+	}
+	if controllerRef != nil {
+		if err := controllerutil.SetControllerReference(controllerRef, cm, ownerScheme(t)); err != nil {
+			t.Fatalf("SetControllerReference: %v", err)
+		}
+	}
+	return cm
+}
+
+// TestApplyCellConfig_SetsControllerReferenceAtomically: the ConfigMap is
+// controller-owned by the CR the instant it is created (so K8s GC removes it with
+// the CR), not via a separate best-effort step.
+func TestApplyCellConfig_SetsControllerReferenceAtomically(t *testing.T) {
+	p := newTestProvider(t)
+	owner := ownerFor("cell-a")
+	if err := p.ApplyCellConfig(context.Background(), owner, geoSpec(), ownerScheme(t)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system"}
+	if err := p.client.Get(context.Background(), key, cm); err != nil {
+		t.Fatal(err)
+	}
+	if !metav1.IsControlledBy(cm, owner) {
+		t.Fatalf("ConfigMap not controller-owned at create; ownerRefs=%v", cm.OwnerReferences)
+	}
+}
+
+// TestApplyCellConfig_OwnershipCollision: a same-named ConfigMap owned by another
+// CR (different UID) or an unlabeled foreign object is refused (ErrConfigMapNotOwned)
+// and left unchanged; an unowned but operator-labeled leftover is adopted.
+func TestApplyCellConfig_OwnershipCollision(t *testing.T) {
+	ctx := context.Background()
+	cmName := ConfigMapNameFor("cell-a")
+	get := func(p *Provider) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{}
+		_ = p.client.Get(ctx, types.NamespacedName{Name: cmName, Namespace: "ntn-system"}, cm)
+		return cm
+	}
+
+	t.Run("owned by a different-UID CR -> refused, unchanged", func(t *testing.T) {
+		other := ownerFor("cell-a")
+		other.UID = "different-uid"
+		p := newTestProviderWith(t, seedConfigMap(t, true, other))
+		err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), geoSpec(), ownerScheme(t))
+		if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+			t.Fatalf("want ErrConfigMapNotOwned, got %v", err)
+		}
+		if get(p).Data["geo_ntn.yml"] != "seed" {
+			t.Error("foreign ConfigMap must not be overwritten")
+		}
+	})
+
+	t.Run("unlabeled foreign object -> refused", func(t *testing.T) {
+		p := newTestProviderWith(t, seedConfigMap(t, false, nil))
+		err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), geoSpec(), ownerScheme(t))
+		if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+			t.Fatalf("want ErrConfigMapNotOwned, got %v", err)
+		}
+	})
+
+	t.Run("unowned but operator-labeled -> adopted", func(t *testing.T) {
+		p := newTestProviderWith(t, seedConfigMap(t, true, nil))
+		owner := ownerFor("cell-a")
+		if err := p.ApplyCellConfig(ctx, owner, geoSpec(), ownerScheme(t)); err != nil {
+			t.Fatalf("adopt should succeed: %v", err)
+		}
+		if !metav1.IsControlledBy(get(p), owner) {
+			t.Error("operator-labeled leftover should be adopted (controller ref set)")
+		}
+	})
+}
+
+// TestCleanup_OwnershipUID: Cleanup deletes only a ConfigMap controlled by owner
+// (UID match); a same-name/different-UID one is left intact.
+func TestCleanup_OwnershipUID(t *testing.T) {
+	ctx := context.Background()
+	cmName := ConfigMapNameFor("cell-a")
+	exists := func(p *Provider) bool {
+		err := p.client.Get(ctx, types.NamespacedName{Name: cmName, Namespace: "ntn-system"}, &corev1.ConfigMap{})
+		return err == nil
+	}
+
+	t.Run("deletes an owned ConfigMap", func(t *testing.T) {
+		p := newTestProvider(t)
+		owner := ownerFor("cell-a")
+		if err := p.ApplyCellConfig(ctx, owner, geoSpec(), ownerScheme(t)); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.Cleanup(ctx, owner); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if exists(p) {
+			t.Error("owned ConfigMap should be deleted")
+		}
+	})
+
+	t.Run("skips a same-name ConfigMap owned by a different-UID CR", func(t *testing.T) {
+		other := ownerFor("cell-a")
+		other.UID = "different-uid"
+		p := newTestProviderWith(t, seedConfigMap(t, true, other))
+		if err := p.Cleanup(ctx, ownerFor("cell-a")); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if !exists(p) {
+			t.Error("different-UID ConfigMap must NOT be deleted")
+		}
+	})
+
+	t.Run("skips an unowned ConfigMap", func(t *testing.T) {
+		p := newTestProviderWith(t, seedConfigMap(t, true, nil))
+		if err := p.Cleanup(ctx, ownerFor("cell-a")); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if !exists(p) {
+			t.Error("unowned ConfigMap must NOT be deleted")
+		}
+	})
+}
+
 func TestApplyCellConfig_CreatesConfigMap(t *testing.T) {
 	p := newTestProvider(t)
 	ctx := context.Background()
 
-	err := p.ApplyCellConfig(ctx, "test-cr", geoSpec())
+	err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), geoSpec(), ownerScheme(t))
 	if err != nil {
 		t.Fatalf("ApplyCellConfig error: %v", err)
 	}
@@ -99,14 +269,14 @@ func TestApplyCellConfig_UpdatesExistingConfigMap(t *testing.T) {
 
 	// First apply.
 	spec := geoSpec()
-	err := p.ApplyCellConfig(ctx, "test-cr", spec)
+	err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t))
 	if err != nil {
 		t.Fatalf("first apply: %v", err)
 	}
 
 	// Update koffset and re-apply.
 	spec.NTN.CellSpecificKoffset = 500
-	err = p.ApplyCellConfig(ctx, "test-cr", spec)
+	err = p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t))
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
@@ -127,7 +297,7 @@ func TestGetCellStatus_ReturnsAppliedConfig(t *testing.T) {
 	ctx := context.Background()
 
 	spec := geoSpec()
-	err := p.ApplyCellConfig(ctx, "test-cr", spec)
+	err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t))
 	if err != nil {
 		t.Fatalf("ApplyCellConfig: %v", err)
 	}
@@ -163,7 +333,7 @@ func TestApplyCellConfig_EmptyNamespace(t *testing.T) {
 
 	spec := geoSpec()
 	spec.Provider.Namespace = ""
-	err := p.ApplyCellConfig(ctx, "test-cr", spec)
+	err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t))
 	if err == nil {
 		t.Fatal("expected error for empty namespace")
 	}
@@ -175,13 +345,13 @@ func TestApplyCellConfig_UpdateExisting(t *testing.T) {
 
 	// First apply creates the ConfigMap.
 	spec := geoSpec()
-	if err := p.ApplyCellConfig(ctx, "test-cr", spec); err != nil {
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
 		t.Fatalf("first apply: %v", err)
 	}
 
 	// Second apply with different koffset should update.
 	spec.NTN.CellSpecificKoffset = 200
-	if err := p.ApplyCellConfig(ctx, "test-cr", spec); err != nil {
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
 
@@ -198,7 +368,7 @@ func TestApplyCellConfig_UpdateExisting(t *testing.T) {
 
 func TestApplyCellConfig_NilSpec(t *testing.T) {
 	p := newTestProvider(t)
-	err := p.ApplyCellConfig(context.Background(), "cr", nil)
+	err := p.ApplyCellConfig(context.Background(), ownerFor("cr"), nil, ownerScheme(t))
 	if err == nil {
 		t.Fatal("expected error for nil spec")
 	}
@@ -270,7 +440,7 @@ func TestPushEphemerisUpdate_ECEF(t *testing.T) {
 
 	// First apply to create the ConfigMap.
 	spec := geoSpec()
-	if err := p.ApplyCellConfig(ctx, "test-cr", spec); err != nil {
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
 		t.Fatalf("ApplyCellConfig: %v", err)
 	}
 
@@ -314,7 +484,7 @@ func TestPushEphemerisUpdate_Orbital(t *testing.T) {
 	ctx := context.Background()
 
 	// First apply to create the ConfigMap.
-	if err := p.ApplyCellConfig(ctx, "test-cr", geoSpec()); err != nil {
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), geoSpec(), ownerScheme(t)); err != nil {
 		t.Fatalf("ApplyCellConfig: %v", err)
 	}
 

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -451,7 +451,7 @@ func TestPushEphemerisUpdate_ECEF(t *testing.T) {
 			VelX: 10, VelY: 20, VelZ: 30,
 		},
 	}
-	if err := p.PushEphemerisUpdate(ctx, "test-cr", "ntn-system", update); err != nil {
+	if err := p.PushEphemerisUpdate(ctx, ownerFor("test-cr"), update); err != nil {
 		t.Fatalf("PushEphemerisUpdate: %v", err)
 	}
 
@@ -499,7 +499,7 @@ func TestPushEphemerisUpdate_Orbital(t *testing.T) {
 			MeanAnomaly:    100000,
 		},
 	}
-	if err := p.PushEphemerisUpdate(ctx, "test-cr", "ntn-system", update); err != nil {
+	if err := p.PushEphemerisUpdate(ctx, ownerFor("test-cr"), update); err != nil {
 		t.Fatalf("PushEphemerisUpdate: %v", err)
 	}
 
@@ -527,7 +527,7 @@ func TestPushEphemerisUpdate_Orbital(t *testing.T) {
 func TestPushEphemerisUpdate_BothSet(t *testing.T) {
 	p := newTestProvider(t)
 	err := p.PushEphemerisUpdate(
-		context.Background(), "cr", "ns",
+		context.Background(), ownerFor("cr"),
 		provider.EphemerisUpdate{
 			ECEF:    &ntnv1alpha1.EphemerisECEF{PosX: 1},
 			Orbital: &ntnv1alpha1.EphemerisOrbital{SemiMajorAxis: 1},
@@ -545,7 +545,7 @@ func TestPushEphemerisUpdate_NoConfigMap(t *testing.T) {
 	update := provider.EphemerisUpdate{
 		ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1},
 	}
-	err := p.PushEphemerisUpdate(ctx, "nonexistent", "ntn-system", update)
+	err := p.PushEphemerisUpdate(ctx, ownerFor("nonexistent"), update)
 	if err == nil {
 		t.Fatal("expected error when ConfigMap doesn't exist")
 	}
@@ -554,7 +554,7 @@ func TestPushEphemerisUpdate_NoConfigMap(t *testing.T) {
 func TestPushEphemerisUpdate_NeitherSet(t *testing.T) {
 	p := newTestProvider(t)
 	err := p.PushEphemerisUpdate(
-		context.Background(), "cr", "ns", provider.EphemerisUpdate{},
+		context.Background(), ownerFor("cr"), provider.EphemerisUpdate{},
 	)
 	if err == nil {
 		t.Fatal("expected error when neither ECEF nor Orbital is set")
@@ -588,6 +588,10 @@ cell_cfg:
 		},
 		Data: map[string]string{"geo_ntn.yml": yamlWithComments},
 	}
+	// The push path re-verifies ownership, so the seeded ConfigMap must be owned.
+	if err := controllerutil.SetControllerReference(ownerFor("test"), cm, scheme); err != nil {
+		t.Fatal(err)
+	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"},
 	}
@@ -602,7 +606,7 @@ cell_cfg:
 		},
 	}
 	err := p.PushEphemerisUpdate(
-		context.Background(), "test", "ntn-system", update,
+		context.Background(), ownerFor("test"), update,
 	)
 	if err != nil {
 		t.Fatalf("PushEphemerisUpdate: %v", err)
@@ -647,6 +651,10 @@ func TestPushEphemerisUpdate_MissingGeoNtn(t *testing.T) {
 		},
 		Data: map[string]string{}, // missing geo_ntn.yml
 	}
+	// The push path re-verifies ownership, so the seeded ConfigMap must be owned.
+	if err := controllerutil.SetControllerReference(ownerFor("test"), cm, scheme); err != nil {
+		t.Fatal(err)
+	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"},
 	}
@@ -658,12 +666,26 @@ func TestPushEphemerisUpdate_MissingGeoNtn(t *testing.T) {
 		ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
 	}
 	err := p.PushEphemerisUpdate(
-		context.Background(), "test", "ntn-system", update,
+		context.Background(), ownerFor("test"), update,
 	)
 	if err == nil {
 		t.Fatal("expected error for missing geo_ntn.yml")
 	}
 	if !contains(err.Error(), "missing geo_ntn.yml") {
 		t.Errorf("expected 'missing geo_ntn.yml' in error, got: %v", err)
+	}
+}
+
+// PushEphemerisUpdate must refuse to rewrite a same-named ConfigMap owned by a
+// different CR (defense-in-depth for a foreign object created between apply and
+// push), mirroring ApplyCellConfig/Cleanup.
+func TestPushEphemerisUpdate_RefusesForeignConfigMap(t *testing.T) {
+	other := ownerFor("cell-a")
+	other.UID = "different-uid"
+	p := newTestProviderWith(t, seedConfigMap(t, true, other))
+	err := p.PushEphemerisUpdate(context.Background(), ownerFor("cell-a"),
+		provider.EphemerisUpdate{ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 9, PosY: 9, PosZ: 9}})
+	if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+		t.Fatalf("want ErrConfigMapNotOwned, got %v", err)
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -441,6 +441,65 @@ var _ = Describe("Manager", Ordered, func() {
 			}, 60*time.Second, 2*time.Second).Should(Succeed())
 		})
 
+		It("should recreate a same-named NTNCellConfig with a fresh owned ConfigMap", func() {
+			const testNS = "default"
+			const cmName = "ocudu-ntn-ntn-cell-geo-demo"
+			sample := filepath.Join("config", "samples", "ntn_v1alpha1_ntncellconfig.yaml")
+
+			apply := func() {
+				out, err := utils.Run(exec.Command("kubectl", "apply", "-n", testNS, "-f", sample))
+				Expect(err).NotTo(HaveOccurred(), out)
+			}
+			waitApplied := func() {
+				Eventually(func(g Gomega) {
+					out, err := utils.Run(exec.Command("kubectl", "get", "ntncellconfigs", "ntn-cell-geo-demo",
+						"-n", testNS, "-o", "jsonpath={.status.conditions[?(@.type=='ConfigApplied')].status}"))
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(out).To(Equal("True"))
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			}
+			crUID := func() string {
+				out, err := utils.Run(exec.Command("kubectl", "get", "ntncellconfigs", "ntn-cell-geo-demo",
+					"-n", testNS, "-o", "jsonpath={.metadata.uid}"))
+				Expect(err).NotTo(HaveOccurred())
+				return out
+			}
+			cmOwnerUID := func() string {
+				out, _ := utils.Run(exec.Command("kubectl", "get", "configmap", cmName,
+					"-n", testNS, "-o", "jsonpath={.metadata.ownerReferences[0].uid}"))
+				return out
+			}
+
+			By("creating NTNCellConfig and confirming the ConfigMap is controller-owned by it")
+			apply()
+			DeferCleanup(func() {
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "-n", testNS, "ntncellconfigs",
+					"ntn-cell-geo-demo", "--ignore-not-found", "--timeout=30s"))
+			})
+			waitApplied()
+			firstUID := crUID()
+			Expect(firstUID).NotTo(BeEmpty())
+			Eventually(cmOwnerUID, 30*time.Second, 2*time.Second).Should(Equal(firstUID),
+				"ConfigMap must carry an ownerReference to the CR (controller reference set atomically at create)")
+
+			By("deleting the NTNCellConfig and confirming the ConfigMap is removed")
+			out, err := utils.Run(exec.Command("kubectl", "delete", "-n", testNS, "ntncellconfigs",
+				"ntn-cell-geo-demo", "--timeout=60s"))
+			Expect(err).NotTo(HaveOccurred(), out)
+			Eventually(func(g Gomega) {
+				o, e := utils.Run(exec.Command("kubectl", "get", "configmap", cmName, "-n", testNS))
+				g.Expect(e != nil || strings.Contains(o, "NotFound") || strings.Contains(o, "not found")).To(BeTrue())
+			}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+			By("recreating a same-named NTNCellConfig and confirming a FRESH ConfigMap owned by the new CR")
+			apply()
+			waitApplied()
+			secondUID := crUID()
+			Expect(secondUID).NotTo(Equal(firstUID), "the recreated CR must have a new UID")
+			Eventually(cmOwnerUID, 30*time.Second, 2*time.Second).Should(Equal(secondUID),
+				"the recreated CR must own a fresh ConfigMap, not a stale/foreign one")
+		})
+
 		It("should reconcile SatelliteEphemeris and populate status", func() {
 			const testNS = "default"
 


### PR DESCRIPTION
**PR A of 4** splitting the rejected #209. Ownership correctness — fixes the ConfigMap-cleanup **E2E failure** and closes the ownership gaps.

## Root cause of the E2E failure
`ApplyCellConfig` created the ConfigMap with **no controller reference**; the reference was set only by a best-effort `EnsureOwnership` second write whose error was swallowed. When that write didn't land, the ConfigMap was owned by nobody — so on CR deletion neither Kubernetes GC (no owner ref) nor a name-only cleanup removed it, and it **leaked**. It surfaced once cleanup started checking ownership; before that, cleanup deleted unconditionally and masked it.

## Fix
- **`ApplyCellConfig(ctx, owner client.Object, spec, scheme)`** — sets the controller reference **atomically before Create**, so the ConfigMap is GC-cascaded with the CR from the instant it exists. On update it overwrites only a ConfigMap it **already owns**, **adopts** an unowned one still carrying the operator's management labels (a pre-atomic-ref leftover), and **refuses** a foreign object (owned by another controller, or unlabeled) with `ErrConfigMapNotOwned`.
- **`Cleanup(ctx, owner client.Object)`** — deletes only when the ConfigMap is controller-owned by owner (`metav1.IsControlledBy` — **UID match**), so a same-named object the operator does not own (name reuse / user-created) is left intact.
- The reconciler reports an **`OwnershipConflict`** condition + Warning event on `ErrConfigMapNotOwned`, and no longer calls the now-removed `EnsureOwnership`.

## Verification (full)
- **`make test-e2e` on local Kind: 6/6 specs pass** — including "should handle NTNCellConfig deletion gracefully" (**was failing** on #209) and a **new** "should recreate a same-named NTNCellConfig with a fresh owned ConfigMap".
- Unit: atomic-ref-at-create, different-UID refused, unlabeled refused, labeled-leftover adopted, cleanup deletes-owned / skips-different-UID / skips-unowned.
- `make generate`/`manifests`/`docs` no drift (code-only); `make test` 9/9; `make lint` 0; `helm lint` pass; bundle + nephio CRDs in sync.

Follow-ups (this WO, separate PRs): **B** validation/UX (printer columns, MaxLength, IPv6+port semantic validation), **C** truncation observability (transition-gated), **D** constellation `// Deprecated` (removal deferred to v1alpha2). Supersedes #209.