### PR TITLE
feat(api): condition columns, string caps, IPv6+port endpoint validation [WO-16 PR B]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Validation tightening (may reject previously-accepted values).** Every
+  free-form spec string now carries a `maxLength` and every unbounded list a
+  `maxItems`, so an over-long or unbounded value is refused at admission instead
+  of bloating etcd or a downstream ConfigMap. Caps follow the field's real
+  domain: Kubernetes names/namespaces 253/63, URLs 2048, free text 1024,
+  numeric-string fields 32, `satellites.noradIDs` 512 items, `bands`/`groundStations`
+  lists bounded with per-item length. Objects authored under ≤ 0.6.0 that exceed
+  a new bound are rejected on their next apply/edit (unset fields are unaffected).
+- **`provider.remoteControl.endpoint` validation hardened.** Beyond the existing
+  `host:port` shape check, CEL now enforces the port range (1–65535), that a
+  bracketed host is a valid IP (`[::1]:8001`), that an all-numeric host is a real
+  IPv4 (so `999.999.999.999:1` is refused rather than treated as a hostname), and
+  the RFC 1035 DNS length limits (whole host ≤ 253, each label 1–63). A mistyped
+  endpoint is now a permanent admission error instead of a silent tight-requeue.
+- **Minimum Kubernetes version raised to 1.31.** The endpoint host CEL rules use
+  the `isIP()` / IP-address CEL library, which is available only from Kubernetes
+  1.31. `Chart.yaml` `kubeVersion`, the OLM CSV `minKubeVersion`, and the Nephio
+  package/compat docs are updated in lockstep.
+- Added condition/status print columns to the CRDs for quicker `kubectl get`
+  triage.
+
 ## [0.6.0] - 2026-07-09
 
 Promotion of `0.6.0-rc.1` after a short soak (the rc's release pipeline —

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ graph TB
 ### Prerequisites
 
 - Go 1.26+
-- Kubernetes 1.29+ (for CEL validation)
+- Kubernetes 1.31+ (CEL validation, incl. the IP-address library used to validate the gNB remote-control endpoint)
 - kubectl
 - Helm v3.16+ (optional, for Helm-based install)
 - kpt v1.0.0-beta.55+ (optional, for Nephio kpt package install)

--- a/api/v1alpha1/groundstationlifecycle_types.go
+++ b/api/v1alpha1/groundstationlifecycle_types.go
@@ -25,14 +25,17 @@ import (
 type HardwareSpec struct {
 	// vendor is the hardware manufacturer (e.g., "ennoconn").
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Vendor string `json:"vendor"`
 
 	// model is the hardware model identifier.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Model string `json:"model"`
 
 	// antennaType is the antenna type (e.g., "flat-panel", "parabolic").
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	AntennaType string `json:"antennaType,omitempty"`
 
 	// bands lists the supported frequency bands (e.g., ["Ka", "Ku", "S"]).
@@ -48,14 +51,17 @@ type HardwareSpec struct {
 type GeoLocation struct {
 	// lat is the latitude in decimal degrees (string, e.g., "25.0330").
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	Lat string `json:"lat"`
 
 	// lon is the longitude in decimal degrees (string, e.g., "121.5654").
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	Lon string `json:"lon"`
 
 	// alt is the altitude in meters above sea level (string, e.g., "15").
 	// +optional
+	// +kubebuilder:validation:MaxLength=32
 	Alt string `json:"alt,omitempty"`
 }
 
@@ -72,6 +78,7 @@ type DeploymentSpec struct {
 
 	// gitopsRepo is the Git repository URL for GitOps-managed configuration.
 	// +optional
+	// +kubebuilder:validation:MaxLength=2048
 	GitopsRepo string `json:"gitopsRepo,omitempty"`
 }
 
@@ -83,6 +90,7 @@ type MonitoringSpec struct {
 
 	// endpoint is the monitoring endpoint of the ground station agent.
 	// +optional
+	// +kubebuilder:validation:MaxLength=261
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
@@ -94,6 +102,7 @@ type FirmwareSpec struct {
 
 	// channel is the firmware update channel (e.g., "stable", "beta").
 	// +kubebuilder:default="stable"
+	// +kubebuilder:validation:MaxLength=64
 	Channel string `json:"channel,omitempty"`
 
 	// maintenanceWindow is the time window for updates.

--- a/api/v1alpha1/groundstationlifecycle_types.go
+++ b/api/v1alpha1/groundstationlifecycle_types.go
@@ -40,6 +40,8 @@ type HardwareSpec struct {
 
 	// bands lists the supported frequency bands (e.g., ["Ka", "Ku", "S"]).
 	// +optional
+	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:items:MaxLength=16
 	Bands []string `json:"bands,omitempty"`
 }
 

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -82,15 +82,19 @@ type RemoteControlRef struct {
 	// — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
 	// Validation is layered: the pattern enforces the bare host:port shape with a
 	// DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-	// (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-	// a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-	// a permanent admission error beats a silent tight-requeue on a mistyped value.
+	// (1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+	// valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+	// that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+	// 1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+	// value. The pattern alone cannot bound the label/host length (a regex quantifier
+	// would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=261
 	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$`
 	// +kubebuilder:validation:XValidation:rule="int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535",message="endpoint port must be between 1 and 65535"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']')))",message="a bracketed endpoint host must be a valid IP address"
 	// +kubebuilder:validation:XValidation:rule="!self.substring(0, self.lastIndexOf(':')).matches('^[0-9.]+$') || isIP(self.substring(0, self.lastIndexOf(':')))",message="an all-numeric endpoint host must be a valid IPv4 address"
+	// +kubebuilder:validation:XValidation:rule="self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size() <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l, l.size() >= 1 && l.size() <= 63))",message="endpoint host must be a DNS name of at most 253 characters with each dot-separated label 1-63 characters"
 	Endpoint string `json:"endpoint"`
 
 	// tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -42,6 +42,7 @@ type NTNCellConfigSpec struct {
 	// on the provider reconcile path. The static ephemeris in spec.ntn
 	// (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	EphemerisRef string `json:"ephemerisRef,omitempty"`
 
@@ -70,20 +71,23 @@ type CellID struct {
 	NCI int64 `json:"nci"`
 }
 
-// +kubebuilder:validation:XValidation:rule="int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1]) <= 65535",message="endpoint port must be in 1-65535"
 // RemoteControlRef configures the gNB remote_control WebSocket for live NTN
 // config push (OCUDU ntn_config_update). OCUDU's remote_control server is
 // plaintext/unauthenticated (localhost by default), so the safe deployment is a
 // sidecar next to the gNB pod; cross-pod requires a NetworkPolicy.
 type RemoteControlRef struct {
-	// endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-	// The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-	// like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-	// enforces bare host:port (a permanent admission error beats a silent
-	// tight-requeue on a mistyped endpoint).
+	// endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+	// ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+	// clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+	// — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+	// Validation is layered: the pattern enforces the bare host:port shape, and CEL
+	// rules enforce the port range (1-65535) and that a bracketed host is a real IP
+	// (a permanent admission error beats a silent tight-requeue on a mistyped value).
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=261
-	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+:[0-9]{1,5}$`
+	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$`
+	// +kubebuilder:validation:XValidation:rule="int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535",message="endpoint port must be between 1 and 65535"
+	// +kubebuilder:validation:XValidation:rule="!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']')))",message="a bracketed endpoint host must be a valid IP address"
 	Endpoint string `json:"endpoint"`
 
 	// tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -113,6 +117,7 @@ type RemoteControlTLS struct {
 	// "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
 	// replayable, so it is only ever sent over the wss:// (TLS) connection.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	SecretName string `json:"secretName"`
 
 	// serverName overrides the TLS ServerName (SNI) verified against the server
@@ -132,6 +137,7 @@ type ProviderRef struct {
 
 	// namespace where the provider resources (e.g., OCUDU gNB) are deployed.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace,omitempty"`
 
 	// remoteControl configures the gNB remote_control WebSocket for live NTN
@@ -142,6 +148,7 @@ type ProviderRef struct {
 
 	// endpoint is the provider-specific endpoint (e.g., O1 NETCONF address).
 	// +optional
+	// +kubebuilder:validation:MaxLength=261
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
@@ -666,6 +673,7 @@ const (
 // +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider.type`
 // +kubebuilder:printcolumn:name="Koffset",type=integer,JSONPath=`.spec.ntn.cellSpecificKoffset`
 // +kubebuilder:printcolumn:name="Payload",type=string,JSONPath=`.spec.ntn.payloadType`
+// +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=`.status.conditions[?(@.type=="ConfigApplied")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NTNCellConfig manages NTN-specific radio parameters for a gNB cell,

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -80,14 +80,17 @@ type RemoteControlRef struct {
 	// ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
 	// clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
 	// — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-	// Validation is layered: the pattern enforces the bare host:port shape, and CEL
-	// rules enforce the port range (1-65535) and that a bracketed host is a real IP
-	// (a permanent admission error beats a silent tight-requeue on a mistyped value).
+	// Validation is layered: the pattern enforces the bare host:port shape with a
+	// DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+	// (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+	// a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+	// a permanent admission error beats a silent tight-requeue on a mistyped value.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=261
-	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$`
+	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$`
 	// +kubebuilder:validation:XValidation:rule="int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535",message="endpoint port must be between 1 and 65535"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']')))",message="a bracketed endpoint host must be a valid IP address"
+	// +kubebuilder:validation:XValidation:rule="!self.substring(0, self.lastIndexOf(':')).matches('^[0-9.]+$') || isIP(self.substring(0, self.lastIndexOf(':')))",message="an all-numeric endpoint host must be a valid IPv4 address"
 	Endpoint string `json:"endpoint"`
 
 	// tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -28,6 +28,7 @@ import (
 type NTNSliceSpec struct {
 	// tenant is the organization or entity that owns this slice.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Tenant string `json:"tenant"`
 
 	// terrestrialPath defines the primary terrestrial connectivity.
@@ -101,6 +102,7 @@ type PrometheusMetricsSource struct {
 	// endpoint is the base URL of the Prometheus HTTP API.
 	// +kubebuilder:validation:Pattern=`^https?://`
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=2048
 	Endpoint string `json:"endpoint"`
 
 	// queryTimeout limits the wall-clock time spent on each individual
@@ -123,15 +125,18 @@ type PrometheusMetricsSource struct {
 type PrometheusQueries struct {
 	// rsrpDbm is a PromQL expression returning a scalar in dBm.
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	RsrpDbm string `json:"rsrpDbm,omitempty"`
 
 	// latencyMs is a PromQL expression returning a scalar in milliseconds.
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	LatencyMs string `json:"latencyMs,omitempty"`
 
 	// packetLossPercent is a PromQL expression returning a scalar in
 	// percent (0-100).
 	// +optional
+	// +kubebuilder:validation:MaxLength=1024
 	PacketLossPercent string `json:"packetLossPercent,omitempty"`
 }
 
@@ -139,10 +144,12 @@ type PrometheusQueries struct {
 type PathSpec struct {
 	// provider is the network operator name (e.g., "chunghwa-telecom").
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Provider string `json:"provider"`
 
 	// apn is the Access Point Name.
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
 	APN string `json:"apn,omitempty"`
 
 	// priority is the path priority.
@@ -157,6 +164,7 @@ type SatellitePathSpec struct {
 	// ephemerisRef is the name of the SatelliteEphemeris resource
 	// used to determine satellite pass availability.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	EphemerisRef string `json:"ephemerisRef"`
 }
 
@@ -199,6 +207,7 @@ type FailoverPolicy struct {
 	// failover fires at RSRP < -120, but switchback requires RSRP >= -110.
 	// +kubebuilder:validation:Pattern=`^[0-9]+\.?[0-9]*$`
 	// +optional
+	// +kubebuilder:validation:MaxLength=32
 	HysteresisMargin string `json:"hysteresisMargin,omitempty"`
 
 	// confirmationSamples is the number of CONSECUTIVE reconcile samples on which
@@ -339,6 +348,7 @@ const (
 // +kubebuilder:printcolumn:name="Tenant",type=string,JSONPath=`.spec.tenant`
 // +kubebuilder:printcolumn:name="Active Path",type=string,JSONPath=`.status.activePathType`
 // +kubebuilder:printcolumn:name="Failovers",type=integer,JSONPath=`.status.failoverCount`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="FailoverReady")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NTNSlice manages terrestrial-satellite network slice failover,

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -75,6 +75,7 @@ type SatelliteSelector struct {
 
 	// noradIDs is an explicit list of NORAD catalog IDs to track.
 	// +optional
+	// +kubebuilder:validation:MaxItems=512
 	NoradIDs []int `json:"noradIDs,omitempty"`
 }
 
@@ -83,6 +84,8 @@ type PassPredictionSpec struct {
 	// groundStations is a list of GroundStationLifecycle resource names
 	// to compute pass windows against.
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:items:MaxLength=253
 	GroundStations []string `json:"groundStations"`
 
 	// minElevation is the minimum elevation angle in degrees (string, e.g., "10").

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -41,6 +41,7 @@ type EphemerisSource struct {
 	// For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^https?://`
+	// +kubebuilder:validation:MaxLength=2048
 	URL string `json:"url"`
 
 	// refreshInterval is how often to re-fetch GP data.
@@ -58,9 +59,11 @@ type EphemerisSource struct {
 // SecretReference points to a Kubernetes Secret.
 type SecretReference struct {
 	// name of the Secret.
+	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
 	// key within the Secret data.
 	// +kubebuilder:default="password"
+	// +kubebuilder:validation:MaxLength=253
 	Key string `json:"key,omitempty"`
 }
 
@@ -85,6 +88,7 @@ type PassPredictionSpec struct {
 	// minElevation is the minimum elevation angle in degrees (string, e.g., "10").
 	// +kubebuilder:default="10"
 	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:MaxLength=32
 	MinElevation string `json:"minElevation,omitempty"`
 
 	// horizon is how far into the future to predict passes.
@@ -196,6 +200,7 @@ const (
 // +kubebuilder:resource:shortName=sateph
 // +kubebuilder:printcolumn:name="Satellites",type=integer,JSONPath=`.status.satelliteCount`
 // +kubebuilder:printcolumn:name="Last Updated",type=date,JSONPath=`.status.lastUpdated`
+// +kubebuilder:printcolumn:name="Fetched",type=string,JSONPath=`.status.conditions[?(@.type=="GPDataFetched")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack),

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ spec:
     - **NTNSlice**: Terrestrial-satellite failover with hysteresis, QoS mapping
 
     ### Prerequisites
-    - Kubernetes 1.29+
+    - Kubernetes 1.31+ (the CRD validation uses the CEL IP-address library, added in 1.31)
     - cert-manager (optional, for metrics TLS)
   displayName: NTN Operators
   icon:
@@ -219,7 +219,7 @@ spec:
     - email: hctsai@linux.com
       name: thc1006
   maturity: alpha
-  minKubeVersion: "1.29.0"
+  minKubeVersion: "1.31.0"
   provider:
     name: ntn-operators
     url: https://github.com/thc1006/ntn-operators

--- a/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/bundle/manifests/ntn.operators.dev_groundstationlifecycles.yaml
@@ -142,7 +142,9 @@ spec:
                     description: bands lists the supported frequency bands (e.g.,
                       ["Ka", "Ku", "S"]).
                     items:
+                      maxLength: 16
                       type: string
+                    maxItems: 16
                     type: array
                   model:
                     description: model is the hardware model identifier.

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -832,12 +832,14 @@ spec:
                           ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
                           clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
-                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
-                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
+                          Validation is layered: the pattern enforces the bare host:port shape with a
+                          DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+                          a permanent admission error beats a silent tight-requeue on a mistyped value.
                         maxLength: 261
                         minLength: 1
-                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
                         type: string
                         x-kubernetes-validations:
                         - message: endpoint port must be between 1 and 65535
@@ -847,6 +849,10 @@ spec:
                         - message: a bracketed endpoint host must be a valid IP address
                           rule: '!self.startsWith(''['') || isIP(self.substring(1,
                             self.lastIndexOf('']'')))'
+                        - message: an all-numeric endpoint host must be a valid IPv4
+                            address
+                          rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
+                            || isIP(self.substring(0, self.lastIndexOf('':'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -809,10 +813,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -822,15 +828,25 @@ spec:
                     properties:
                       endpoint:
                         description: |-
-                          endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-                          The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-                          like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-                          enforces bare host:port (a permanent admission error beats a silent
-                          tight-requeue on a mistyped endpoint).
+                          endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+                          ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+                          clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+                          — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
+                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
+                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
+                        x-kubernetes-validations:
+                        - message: endpoint port must be between 1 and 65535
+                          rule: int(self.substring(self.lastIndexOf(':') + 1)) >=
+                            1 && int(self.substring(self.lastIndexOf(':') + 1)) <=
+                            65535
+                        - message: a bracketed endpoint host must be a valid IP address
+                          rule: '!self.startsWith(''['') || isIP(self.substring(1,
+                            self.lastIndexOf('']'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -856,6 +872,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:
@@ -873,10 +890,6 @@ spec:
                     required:
                     - endpoint
                     type: object
-                    x-kubernetes-validations:
-                    - message: endpoint port must be in 1-65535
-                      rule: int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1])
-                        <= 65535
                   type:
                     description: type is the provider type. Currently only "ocudu"
                       is supported.

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -834,9 +834,12 @@ spec:
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
                           Validation is layered: the pattern enforces the bare host:port shape with a
                           DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-                          a permanent admission error beats a silent tight-requeue on a mistyped value.
+                          (1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+                          valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+                          that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+                          1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+                          value. The pattern alone cannot bound the label/host length (a regex quantifier
+                          would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
@@ -853,6 +856,11 @@ spec:
                             address
                           rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
                             || isIP(self.substring(0, self.lastIndexOf('':'')))'
+                        - message: endpoint host must be a DNS name of at most 253
+                            characters with each dot-separated label 1-63 characters
+                          rule: self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size()
+                            <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l,
+                            l.size() >= 1 && l.size() <= 63))
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -71,7 +71,9 @@ spec:
                       groundStations is a list of GroundStationLifecycle resource names
                       to compute pass windows against.
                     items:
+                      maxLength: 253
                       type: string
+                    maxItems: 64
                     minItems: 1
                     type: array
                   horizon:
@@ -101,6 +103,7 @@ spec:
                       to track.
                     items:
                       type: integer
+                    maxItems: 512
                     type: array
                 type: object
               source:

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/config/crd/bases/ntn.operators.dev_groundstationlifecycles.yaml
@@ -142,7 +142,9 @@ spec:
                     description: bands lists the supported frequency bands (e.g.,
                       ["Ka", "Ku", "S"]).
                     items:
+                      maxLength: 16
                       type: string
+                    maxItems: 16
                     type: array
                   model:
                     description: model is the hardware model identifier.

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -832,12 +832,14 @@ spec:
                           ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
                           clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
-                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
-                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
+                          Validation is layered: the pattern enforces the bare host:port shape with a
+                          DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+                          a permanent admission error beats a silent tight-requeue on a mistyped value.
                         maxLength: 261
                         minLength: 1
-                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
                         type: string
                         x-kubernetes-validations:
                         - message: endpoint port must be between 1 and 65535
@@ -847,6 +849,10 @@ spec:
                         - message: a bracketed endpoint host must be a valid IP address
                           rule: '!self.startsWith(''['') || isIP(self.substring(1,
                             self.lastIndexOf('']'')))'
+                        - message: an all-numeric endpoint host must be a valid IPv4
+                            address
+                          rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
+                            || isIP(self.substring(0, self.lastIndexOf('':'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -809,10 +813,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -822,15 +828,25 @@ spec:
                     properties:
                       endpoint:
                         description: |-
-                          endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-                          The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-                          like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-                          enforces bare host:port (a permanent admission error beats a silent
-                          tight-requeue on a mistyped endpoint).
+                          endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+                          ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+                          clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+                          — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
+                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
+                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
+                        x-kubernetes-validations:
+                        - message: endpoint port must be between 1 and 65535
+                          rule: int(self.substring(self.lastIndexOf(':') + 1)) >=
+                            1 && int(self.substring(self.lastIndexOf(':') + 1)) <=
+                            65535
+                        - message: a bracketed endpoint host must be a valid IP address
+                          rule: '!self.startsWith(''['') || isIP(self.substring(1,
+                            self.lastIndexOf('']'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -856,6 +872,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:
@@ -873,10 +890,6 @@ spec:
                     required:
                     - endpoint
                     type: object
-                    x-kubernetes-validations:
-                    - message: endpoint port must be in 1-65535
-                      rule: int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1])
-                        <= 65535
                   type:
                     description: type is the provider type. Currently only "ocudu"
                       is supported.

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -834,9 +834,12 @@ spec:
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
                           Validation is layered: the pattern enforces the bare host:port shape with a
                           DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-                          a permanent admission error beats a silent tight-requeue on a mistyped value.
+                          (1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+                          valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+                          that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+                          1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+                          value. The pattern alone cannot bound the label/host length (a regex quantifier
+                          would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
@@ -853,6 +856,11 @@ spec:
                             address
                           rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
                             || isIP(self.substring(0, self.lastIndexOf('':'')))'
+                        - message: endpoint host must be a DNS name of at most 253
+                            characters with each dot-separated label 1-63 characters
+                          rule: self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size()
+                            <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l,
+                            l.size() >= 1 && l.size() <= 63))
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -71,7 +71,9 @@ spec:
                       groundStations is a list of GroundStationLifecycle resource names
                       to compute pass windows against.
                     items:
+                      maxLength: 253
                       type: string
+                    maxItems: 64
                     minItems: 1
                     type: array
                   horizon:
@@ -101,6 +103,7 @@ spec:
                       to track.
                     items:
                       type: integer
+                    maxItems: 512
                     type: array
                 type: object
               source:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -6,6 +6,10 @@ type: application
 version: 0.6.0
 appVersion: "0.6.0"
 
+# The CRD validation uses the CEL IP-address library (isIP), available since
+# Kubernetes 1.31; -0 admits vendor/pre-release version strings (e.g. GKE/EKS).
+kubeVersion: ">=1.31.0-0"
+
 keywords:
   - kubernetes
   - operator

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -145,7 +145,9 @@ spec:
                     description: bands lists the supported frequency bands (e.g.,
                       ["Ka", "Ku", "S"]).
                     items:
+                      maxLength: 16
                       type: string
+                    maxItems: 16
                     type: array
                   model:
                     description: model is the hardware model identifier.

--- a/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/groundstationlifecycles.ntn.operators.dev.yaml
@@ -69,6 +69,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -86,15 +87,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -120,6 +124,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -134,6 +139,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -143,10 +149,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -159,6 +167,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -157,6 +160,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -812,10 +816,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -825,15 +831,25 @@ spec:
                     properties:
                       endpoint:
                         description: |-
-                          endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-                          The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-                          like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-                          enforces bare host:port (a permanent admission error beats a silent
-                          tight-requeue on a mistyped endpoint).
+                          endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+                          ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+                          clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+                          — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
+                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
+                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
+                        x-kubernetes-validations:
+                        - message: endpoint port must be between 1 and 65535
+                          rule: int(self.substring(self.lastIndexOf(':') + 1)) >=
+                            1 && int(self.substring(self.lastIndexOf(':') + 1)) <=
+                            65535
+                        - message: a bracketed endpoint host must be a valid IP address
+                          rule: '!self.startsWith(''['') || isIP(self.substring(1,
+                            self.lastIndexOf('']'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -859,6 +875,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:
@@ -876,10 +893,6 @@ spec:
                     required:
                     - endpoint
                     type: object
-                    x-kubernetes-validations:
-                    - message: endpoint port must be in 1-65535
-                      rule: int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1])
-                        <= 65535
                   type:
                     description: type is the provider type. Currently only "ocudu"
                       is supported.

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -837,9 +837,12 @@ spec:
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
                           Validation is layered: the pattern enforces the bare host:port shape with a
                           DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-                          a permanent admission error beats a silent tight-requeue on a mistyped value.
+                          (1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+                          valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+                          that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+                          1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+                          value. The pattern alone cannot bound the label/host length (a regex quantifier
+                          would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
@@ -856,6 +859,11 @@ spec:
                             address
                           rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
                             || isIP(self.substring(0, self.lastIndexOf('':'')))'
+                        - message: endpoint host must be a DNS name of at most 253
+                            characters with each dot-separated label 1-63 characters
+                          rule: self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size()
+                            <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l,
+                            l.size() >= 1 && l.size() <= 63))
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -835,12 +835,14 @@ spec:
                           ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
                           clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
-                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
-                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
+                          Validation is layered: the pattern enforces the bare host:port shape with a
+                          DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+                          a permanent admission error beats a silent tight-requeue on a mistyped value.
                         maxLength: 261
                         minLength: 1
-                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
                         type: string
                         x-kubernetes-validations:
                         - message: endpoint port must be between 1 and 65535
@@ -850,6 +852,10 @@ spec:
                         - message: a bracketed endpoint host must be a valid IP address
                           rule: '!self.startsWith(''['') || isIP(self.substring(1,
                             self.lastIndexOf('']'')))'
+                        - message: an all-numeric endpoint host must be a valid IPv4
+                            address
+                          rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
+                            || isIP(self.substring(0, self.lastIndexOf('':'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -109,6 +112,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -173,6 +177,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -183,15 +188,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -253,11 +261,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -268,6 +278,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -298,6 +309,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -305,6 +317,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -314,6 +327,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -74,7 +74,9 @@ spec:
                       groundStations is a list of GroundStationLifecycle resource names
                       to compute pass windows against.
                     items:
+                      maxLength: 253
                       type: string
+                    maxItems: 64
                     minItems: 1
                     type: array
                   horizon:
@@ -104,6 +106,7 @@ spec:
                       to track.
                     items:
                       type: integer
+                    maxItems: 512
                     type: array
                 type: object
               source:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -82,6 +85,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -114,9 +118,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -144,6 +150,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1840,8 +1840,6 @@ provider specifies which NTN backend to configure.
           remoteControl configures the gNB remote_control WebSocket for live NTN
 config push. When set together with spec.cellID, the operator pushes runtime
 ntn_config_update commands; otherwise it uses the ConfigMap path only.<br/>
-          <br/>
-            <i>Validations</i>:<li>int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1]) <= 65535: endpoint port must be in 1-65535</li>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1870,13 +1868,83 @@ ntn_config_update commands; otherwise it uses the ConfigMap path only.
         <td><b>endpoint</b></td>
         <td>string</td>
         <td>
-          endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-enforces bare host:port (a permanent admission error beats a silent
-tight-requeue on a mistyped endpoint).<br/>
+          endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+— a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+Validation is layered: the pattern enforces the bare host:port shape, and CEL
+rules enforce the port range (1-65535) and that a bracketed host is a real IP
+(a permanent admission error beats a silent tight-requeue on a mistyped value).<br/>
+          <br/>
+            <i>Validations</i>:<li>int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535: endpoint port must be between 1 and 65535</li><li>!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']'))): a bracketed endpoint host must be a valid IP address</li>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b><a href="#ntncellconfigspecproviderremotecontroltls">tls</a></b></td>
+        <td>object</td>
+        <td>
+          tls, when set, secures the runtime push: the provider dials wss:// (TLS)
+instead of plaintext ws:// and authenticates with the material in the
+referenced Secret. Omit it to keep the plaintext ws:// behavior (N-12).<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### NTNCellConfig.spec.provider.remoteControl.tls
+<sup><sup>[↩ Parent](#ntncellconfigspecproviderremotecontrol)</sup></sup>
+
+
+
+tls, when set, secures the runtime push: the provider dials wss:// (TLS)
+instead of plaintext ws:// and authenticates with the material in the
+referenced Secret. Omit it to keep the plaintext ws:// behavior (N-12).
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>mode</b></td>
+        <td>enum</td>
+        <td>
+          mode selects the transport-security posture:
+  "tls"  — dial wss://, verify the server certificate, and (if the Secret
+           carries a token) send it as an Authorization: Bearer header.
+  "mtls" — additionally present a client certificate (mutual TLS); the
+           Secret MUST then carry tls.crt + tls.key.<br/>
+          <br/>
+            <i>Enum</i>: tls, mtls<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>secretName</b></td>
+        <td>string</td>
+        <td>
+          secretName is the Secret (in this NTNCellConfig's namespace) holding the TLS
+trust and auth material. Recognized keys: "ca.crt" (PEM CA to verify the
+gNB/proxy server certificate — omit to use the system roots), "token" (the
+shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
+"tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
+replayable, so it is only ever sent over the wss:// (TLS) connection.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>serverName</b></td>
+        <td>string</td>
+        <td>
+          serverName overrides the TLS ServerName (SNI) verified against the server
+certificate's SubjectAltNames. Defaults to the endpoint host. Set it when the
+gNB/proxy certificate's SAN does not match the dialed host (e.g. an IP
+endpoint fronted by a DNS-named certificate).<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -2232,6 +2300,8 @@ with terrestrial-satellite failover policy.
         <td>object</td>
         <td>
           failoverPolicy defines when and how to switch between paths.<br/>
+          <br/>
+            <i>Validations</i>:<li>self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)? *$')): each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite number (e.g. 'rsrp < -120')</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -2314,10 +2384,30 @@ failoverPolicy defines when and how to switch between paths.
         <td>
           triggers defines conditions that initiate failover (OR logic).
 Format: "metric operator value" (e.g., "rsrp < -120").
-Validated at runtime by the failover engine (pkg/slice.ParseTrigger).
+Validated at admission by the XValidation rule on this type and at runtime by
+the failover engine (pkg/slice.ParseTrigger).
 Order is intentionally not significant; set merge semantics are desired.<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>confirmationSamples</b></td>
+        <td>integer</td>
+        <td>
+          confirmationSamples is the number of CONSECUTIVE reconcile samples on which
+the terrestrial triggers must fire before a failover to satellite is taken
+(production load balancers such as AWS ALB / GCP count consecutive, not
+windowed, probe results). It absorbs a single-sample blip so one noisy
+reading does not trip a switch. 1 (the default when unset) preserves the
+prior immediate-failover behavior; a value of N delays failover by up to
+(N-1) reconcile intervals. The confirmation counter is kept in memory and
+resets on any healthy reliable sample; losing it on a controller restart or
+leader-election handoff only re-requires confirmation (a DELAY), never causes
+a spurious switch.<br/>
+          <br/>
+            <i>Minimum</i>: 1<br/>
+            <i>Maximum</i>: 10<br/>
+        </td>
+        <td>false</td>
       </tr><tr>
         <td><b>hysteresisMargin</b></td>
         <td>string</td>
@@ -2328,6 +2418,20 @@ oscillate near the threshold. The value uses the same unit as
 the trigger (dB for RSRP, ms for latency, percent for packetLoss).
 Example: with trigger "rsrp < -120" and hysteresisMargin "10",
 failover fires at RSRP < -120, but switchback requires RSRP >= -110.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minTerrestrialDwell</b></td>
+        <td>string</td>
+        <td>
+          minTerrestrialDwell is the minimum time the terrestrial path must be held
+after a switchback before another failover to satellite may be taken. It
+bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
+— a genuinely failing terrestrial still fails over once the dwell elapses,
+so it never indefinitely blocks a real failover. 0 (the default) disables
+it; 30s–120s is a sane range relative to a LEO pass.<br/>
+          <br/>
+            <i>Format</i>: duration<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2877,6 +2981,12 @@ SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack)
 orbital propagation (SGP4 via akhenakh/sgp4), and pass prediction for a set of
 satellites against ground stations.
 
+Orbit-regime support: v1.0 is LEO-only. The propagator is the near-earth SGP4
+model; element sets whose orbital period is >= 225 minutes (deep space —
+roughly MEO and above, e.g. O3b or GEO) are rejected rather than propagated
+into a wrong position, and surface as the UnsupportedOrbitRegime status
+condition. Multi-orbit (MEO/GEO) support is a v1.1 roadmap item.
+
 <table>
     <thead>
         <tr>
@@ -3004,7 +3114,11 @@ CelesTrak updates every 2 hours; setting this below 2h wastes bandwidth.<br/>
         <td><b>url</b></td>
         <td>string</td>
         <td>
-          url is the endpoint to fetch GP data from.
+          url is the endpoint to fetch GP data from. Use https for any public
+source: a cleartext http:// URL that resolves to a public IP is refused
+at runtime (InsecureURL condition) because an on-path attacker could
+inject forged OMM data that is propagated into SIB19. http:// is permitted
+only for a private/in-cluster mirror (NetworkPolicy-protected).
 For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
 For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...<br/>
         </td>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1872,11 +1872,13 @@ ntn_config_update commands; otherwise it uses the ConfigMap path only.
 ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
 clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
 — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-Validation is layered: the pattern enforces the bare host:port shape, and CEL
-rules enforce the port range (1-65535) and that a bracketed host is a real IP
-(a permanent admission error beats a silent tight-requeue on a mistyped value).<br/>
+Validation is layered: the pattern enforces the bare host:port shape with a
+DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+(1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+a permanent admission error beats a silent tight-requeue on a mistyped value.<br/>
           <br/>
-            <i>Validations</i>:<li>int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535: endpoint port must be between 1 and 65535</li><li>!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']'))): a bracketed endpoint host must be a valid IP address</li>
+            <i>Validations</i>:<li>int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535: endpoint port must be between 1 and 65535</li><li>!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']'))): a bracketed endpoint host must be a valid IP address</li><li>!self.substring(0, self.lastIndexOf(':')).matches('^[0-9.]+$') || isIP(self.substring(0, self.lastIndexOf(':'))): an all-numeric endpoint host must be a valid IPv4 address</li>
         </td>
         <td>true</td>
       </tr><tr>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1874,11 +1874,14 @@ clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
 — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
 Validation is layered: the pattern enforces the bare host:port shape with a
 DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-(1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-a permanent admission error beats a silent tight-requeue on a mistyped value.<br/>
+(1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+value. The pattern alone cannot bound the label/host length (a regex quantifier
+would, but the DNS-1123 label form makes that unreadable), so CEL carries it.<br/>
           <br/>
-            <i>Validations</i>:<li>int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535: endpoint port must be between 1 and 65535</li><li>!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']'))): a bracketed endpoint host must be a valid IP address</li><li>!self.substring(0, self.lastIndexOf(':')).matches('^[0-9.]+$') || isIP(self.substring(0, self.lastIndexOf(':'))): an all-numeric endpoint host must be a valid IPv4 address</li>
+            <i>Validations</i>:<li>int(self.substring(self.lastIndexOf(':') + 1)) >= 1 && int(self.substring(self.lastIndexOf(':') + 1)) <= 65535: endpoint port must be between 1 and 65535</li><li>!self.startsWith('[') || isIP(self.substring(1, self.lastIndexOf(']'))): a bracketed endpoint host must be a valid IP address</li><li>!self.substring(0, self.lastIndexOf(':')).matches('^[0-9.]+$') || isIP(self.substring(0, self.lastIndexOf(':'))): an all-numeric endpoint host must be a valid IPv4 address</li><li>self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size() <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l, l.size() >= 1 && l.size() <= 63)): endpoint host must be a DNS name of at most 253 characters with each dot-separated label 1-63 characters</li>
         </td>
         <td>true</td>
       </tr><tr>

--- a/internal/controller/ntncellconfig_admission_test.go
+++ b/internal/controller/ntncellconfig_admission_test.go
@@ -77,10 +77,45 @@ var _ = Describe("NTNCellConfig remoteControl.endpoint admission (CEL)", func() 
 		Entry("dashes-only host", "---:8001", false),
 		Entry("underscore host (not DNS-1123)", "_host:8001", false),
 	)
+
+	// RFC 1035 DNS length limits: the whole host <= 253 and each dot-separated
+	// label 1-63. The shape Pattern cannot bound these lengths, so a dedicated CEL
+	// rule carries them. Each boundary below sits within MaxLength=261 and passes
+	// the Pattern, so ONLY the length rule can reject the over-limit case — which is
+	// what isolates the rule. (A valid host:port therefore tops out at 259 chars:
+	// 253 host + ':' + 5-digit port; MaxLength=261 is a loose outer backstop that
+	// this tighter DNS-host bound sits under, so a 261/262 MaxLength pair is not
+	// separately testable with a well-formed endpoint.)
+	mkHost := func(labels ...int) string {
+		parts := make([]string, len(labels))
+		for i, n := range labels {
+			parts[i] = strings.Repeat("a", n)
+		}
+		return strings.Join(parts, ".")
+	}
+	DescribeTable("remoteControl.endpoint DNS host length (label<=63, host<=253)",
+		func(host string, accepted bool) {
+			cc := mkCC(host + ":8001")
+			err := k8sClient.Create(ctx, cc)
+			if accepted {
+				Expect(err).NotTo(HaveOccurred(), "host len %d should be admitted", len(host))
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, cc) })
+			} else {
+				Expect(err).To(HaveOccurred(), "host len %d should be rejected", len(host))
+			}
+		},
+		Entry("single label at 63", mkHost(63), true),
+		Entry("single label over at 64", mkHost(64), false),
+		Entry("multi-label host at 253", mkHost(63, 63, 63, 61), true),
+		Entry("multi-label host over at 254", mkHost(63, 63, 63, 62), false),
+	)
 })
 
-// Real admission-time boundary checks for the MaxLength ratchets — one accept-at-limit
-// / reject-over-limit pair per limit category, against the envtest API server.
+// Real admission-time boundary checks for the MaxLength ratchets. These are a
+// representative sample — one accept-at-limit / reject-over-limit pair for each
+// distinct limit VALUE in play (63, 2048, 253, 32), against the envtest API server —
+// not exhaustive coverage of every MaxLength-annotated field; fields sharing a limit
+// are validated by the same generated schema bound, so one probe per value suffices.
 var _ = Describe("CRD string-length admission (MaxLength boundaries)", func() {
 	rep := func(c string, n int) string { return strings.Repeat(c, n) }
 	seq := 0

--- a/internal/controller/ntncellconfig_admission_test.go
+++ b/internal/controller/ntncellconfig_admission_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// These run against the envtest API server, so they exercise the CRD's real CEL
+// x-kubernetes-validations for remoteControl.endpoint (port range 1-65535 and a
+// bracketed host being a valid IP), not just the Go structs.
+var _ = Describe("NTNCellConfig remoteControl.endpoint admission (CEL)", func() {
+	admCount := 0
+	mkCC := func(endpoint string) *ntnv1alpha1.NTNCellConfig {
+		admCount++
+		return &ntnv1alpha1.NTNCellConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("adm-endpoint-%d", admCount), Namespace: "default"},
+			Spec: ntnv1alpha1.NTNCellConfigSpec{
+				Provider: ntnv1alpha1.ProviderRef{
+					Type:          "ocudu",
+					RemoteControl: &ntnv1alpha1.RemoteControlRef{Endpoint: endpoint},
+				},
+				CellID: &ntnv1alpha1.CellID{PLMN: "00101", NCI: 6733824},
+				NTN: ntnv1alpha1.NTNParams{
+					EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 111, PosY: 222, PosZ: 333},
+				},
+			},
+		}
+	}
+
+	DescribeTable("accepts valid host:port (incl. IPv6) and rejects bad port / non-IP",
+		func(endpoint string, accepted bool) {
+			cc := mkCC(endpoint)
+			err := k8sClient.Create(ctx, cc)
+			if accepted {
+				Expect(err).NotTo(HaveOccurred(), "endpoint %q should be admitted", endpoint)
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, cc) })
+			} else {
+				Expect(err).To(HaveOccurred(), "endpoint %q should be rejected", endpoint)
+			}
+		},
+		Entry("IPv4 host:port", "127.0.0.1:8001", true),
+		Entry("hostname:port", "gnb.internal:8001", true),
+		Entry("IPv6 literal", "[::1]:8001", true),
+		Entry("full IPv6 literal", "[2001:db8::1]:443", true),
+		Entry("port above 65535", "127.0.0.1:99999", false),
+		Entry("port zero", "127.0.0.1:0", false),
+		Entry("bracketed hex that is not a valid IP", "[fff]:443", false),
+		Entry("missing port", "127.0.0.1", false),
+		Entry("scheme included (must be bare host:port)", "ws://127.0.0.1:8001", false),
+	)
+})

--- a/internal/controller/ntncellconfig_admission_test.go
+++ b/internal/controller/ntncellconfig_admission_test.go
@@ -18,10 +18,13 @@ package controller
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 )
@@ -68,5 +71,90 @@ var _ = Describe("NTNCellConfig remoteControl.endpoint admission (CEL)", func() 
 		Entry("bracketed hex that is not a valid IP", "[fff]:443", false),
 		Entry("missing port", "127.0.0.1", false),
 		Entry("scheme included (must be bare host:port)", "ws://127.0.0.1:8001", false),
+		Entry("out-of-range IPv4 (all-numeric host must be a real IPv4)", "999.999.999.999:8001", false),
+		Entry("IPv4 octet over 255", "300.1.1.1:443", false),
+		Entry("double-dot hostname", "foo..bar:8001", false),
+		Entry("dashes-only host", "---:8001", false),
+		Entry("underscore host (not DNS-1123)", "_host:8001", false),
+	)
+})
+
+// Real admission-time boundary checks for the MaxLength ratchets — one accept-at-limit
+// / reject-over-limit pair per limit category, against the envtest API server.
+var _ = Describe("CRD string-length admission (MaxLength boundaries)", func() {
+	rep := func(c string, n int) string { return strings.Repeat(c, n) }
+	seq := 0
+	nm := func(p string) string { seq++; return fmt.Sprintf("%s-%d", p, seq) }
+	assertAdmit := func(err error, accepted bool, obj client.Object, what string) {
+		if accepted {
+			Expect(err).NotTo(HaveOccurred(), "%s should be admitted", what)
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, obj) })
+		} else {
+			Expect(err).To(HaveOccurred(), "%s should be rejected", what)
+		}
+	}
+
+	DescribeTable("NTNCellConfig provider.namespace (limit 63)",
+		func(nsLen int, ok bool) {
+			cc := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: nm("adm-ns"), Namespace: "default"},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: rep("a", nsLen)},
+					NTN:      ntnv1alpha1.NTNParams{EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3}},
+				},
+			}
+			assertAdmit(k8sClient.Create(ctx, cc), ok, cc, fmt.Sprintf("namespace len %d", nsLen))
+		},
+		Entry("at 63", 63, true),
+		Entry("over at 64", 64, false),
+	)
+
+	mkEph := func(mutate func(*ntnv1alpha1.SatelliteEphemeris)) *ntnv1alpha1.SatelliteEphemeris {
+		eph := &ntnv1alpha1.SatelliteEphemeris{
+			ObjectMeta: metav1.ObjectMeta{Name: nm("adm-eph"), Namespace: "default"},
+			Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+				Source: ntnv1alpha1.EphemerisSource{
+					Type: "CelesTrak", URL: "https://celestrak.org/x",
+					RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+				},
+			},
+		}
+		mutate(eph)
+		return eph
+	}
+
+	DescribeTable("SatelliteEphemeris source.url (limit 2048)",
+		func(urlLen int, ok bool) {
+			eph := mkEph(func(e *ntnv1alpha1.SatelliteEphemeris) {
+				e.Spec.Source.URL = "https://" + rep("a", urlLen-len("https://"))
+			})
+			assertAdmit(k8sClient.Create(ctx, eph), ok, eph, fmt.Sprintf("url len %d", urlLen))
+		},
+		Entry("at 2048", 2048, true),
+		Entry("over at 2049", 2049, false),
+	)
+
+	DescribeTable("SatelliteEphemeris credentials.name (limit 253)",
+		func(nameLen int, ok bool) {
+			eph := mkEph(func(e *ntnv1alpha1.SatelliteEphemeris) {
+				e.Spec.Source.Credentials = &ntnv1alpha1.SecretReference{Name: rep("a", nameLen)}
+			})
+			assertAdmit(k8sClient.Create(ctx, eph), ok, eph, fmt.Sprintf("cred name len %d", nameLen))
+		},
+		Entry("at 253", 253, true),
+		Entry("over at 254", 254, false),
+	)
+
+	DescribeTable("SatelliteEphemeris minElevation numeric string (limit 32)",
+		func(mLen int, ok bool) {
+			eph := mkEph(func(e *ntnv1alpha1.SatelliteEphemeris) {
+				e.Spec.PassPrediction = &ntnv1alpha1.PassPredictionSpec{
+					GroundStations: []string{"gs-1"}, MinElevation: rep("1", mLen),
+				}
+			})
+			assertAdmit(k8sClient.Create(ctx, eph), ok, eph, fmt.Sprintf("minElevation len %d", mLen))
+		},
+		Entry("at 32", 32, true),
+		Entry("over at 33", 33, false),
 	)
 })

--- a/nephio/README.md
+++ b/nephio/README.md
@@ -120,7 +120,7 @@ For multi-arch images (OCI image index, e.g. `set-labels`), pin the **index** di
 | Nephio | R6 (released 2026-04-01) |
 | Porch | v1.5.6+ |
 | `kpt` CLI | v1.0.0-beta.55 or newer |
-| Kubernetes | 1.29+ (CEL validation is GA from 1.29) |
+| Kubernetes | 1.31+ (the endpoint CEL uses the `isIP` IP-address library, added in 1.31) |
 | KRM function registry | `ghcr.io/kptdev/krm-functions-catalog` (Nephio R6 canonical; `gcr.io/kpt-fn/` tags are still current and functional) |
 | KRM function pinning | `@sha256:` digest (enforced by `hack/check-kptfile-digest-pin.sh` and `test/nephio/validate.sh` T15) |
 

--- a/nephio/packages/ntn-operators-crds/README.md
+++ b/nephio/packages/ntn-operators-crds/README.md
@@ -18,7 +18,7 @@ The CRD YAMLs are regenerated from `api/v1alpha1/*_types.go` via `controller-gen
 
 ## Prerequisites
 
-- Kubernetes 1.29+ (CEL validation is used extensively, and is GA from 1.29)
+- Kubernetes 1.31+ (the CRD validation uses the CEL IP-address library `isIP`, added in 1.31)
 - `kpt` v1.0.0-beta.55+ for package consumption (`kpt version`)
 - Cluster-admin permissions on the target cluster (CRD install is cluster-scoped)
 
@@ -73,10 +73,10 @@ Warning: deleting a CRD cascade-deletes every CustomResource of that kind. If yo
 
 ## Version compatibility
 
-| ntn-operators tag | Nephio release tested | K8s tested |
-|---|---|---|
-| `main` | R6 (Porch v1.5.6) | 1.29 - 1.35 |
-| `v0.1.0` | (not validated on Nephio) | 1.29+ |
+| ntn-operators tag | Nephio release tested | K8s minimum | K8s CI-exercised |
+|---|---|---|---|
+| `main` | R6 (Porch v1.5.6) | 1.31 (isIP CEL) | envtest 1.35 + Kind e2e |
+| `v0.1.0` | (not validated on Nephio) | 1.29 (pre-isIP) | — |
 
 ## License
 

--- a/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
@@ -66,6 +66,7 @@ spec:
                   gitopsRepo:
                     description: gitopsRepo is the Git repository URL for GitOps-managed
                       configuration.
+                    maxLength: 2048
                     type: string
                   k8sDistro:
                     default: k3s
@@ -83,15 +84,18 @@ spec:
                       alt:
                         description: alt is the altitude in meters above sea level
                           (string, e.g., "15").
+                        maxLength: 32
                         type: string
                       lat:
                         description: lat is the latitude in decimal degrees (string,
                           e.g., "25.0330").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                       lon:
                         description: lon is the longitude in decimal degrees (string,
                           e.g., "121.5654").
+                        maxLength: 32
                         pattern: ^-?[0-9]+\.?[0-9]*$
                         type: string
                     required:
@@ -117,6 +121,7 @@ spec:
                     default: stable
                     description: channel is the firmware update channel (e.g., "stable",
                       "beta").
+                    maxLength: 64
                     type: string
                   maintenanceWindow:
                     description: |-
@@ -131,6 +136,7 @@ spec:
                   antennaType:
                     description: antennaType is the antenna type (e.g., "flat-panel",
                       "parabolic").
+                    maxLength: 64
                     type: string
                   bands:
                     description: bands lists the supported frequency bands (e.g.,
@@ -140,10 +146,12 @@ spec:
                     type: array
                   model:
                     description: model is the hardware model identifier.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   vendor:
                     description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -156,6 +164,7 @@ spec:
                   endpoint:
                     description: endpoint is the monitoring endpoint of the ground
                       station agent.
+                    maxLength: 261
                     type: string
                   healthCheckInterval:
                     default: 30s

--- a/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/groundstationlifecycles-crd.yaml
@@ -142,7 +142,9 @@ spec:
                     description: bands lists the supported frequency bands (e.g.,
                       ["Ka", "Ku", "S"]).
                     items:
+                      maxLength: 16
                       type: string
+                    maxItems: 16
                     type: array
                   model:
                     description: model is the hardware model identifier.

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -832,12 +832,14 @@ spec:
                           ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
                           clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
-                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
-                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
-                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
+                          Validation is layered: the pattern enforces the bare host:port shape with a
+                          DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
+                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
+                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
+                          a permanent admission error beats a silent tight-requeue on a mistyped value.
                         maxLength: 261
                         minLength: 1
-                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
                         type: string
                         x-kubernetes-validations:
                         - message: endpoint port must be between 1 and 65535
@@ -847,6 +849,10 @@ spec:
                         - message: a bracketed endpoint host must be a valid IP address
                           rule: '!self.startsWith(''['') || isIP(self.substring(1,
                             self.lastIndexOf('']'')))'
+                        - message: an all-numeric endpoint host must be a valid IPv4
+                            address
+                          rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
+                            || isIP(self.substring(0, self.lastIndexOf('':'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.ntn.payloadType
       name: Payload
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ConfigApplied")].status
+      name: Applied
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +157,7 @@ spec:
                   referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
                   on the provider reconcile path. The static ephemeris in spec.ntn
                   (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                maxLength: 253
                 minLength: 1
                 type: string
               ntn:
@@ -809,10 +813,12 @@ spec:
                   endpoint:
                     description: endpoint is the provider-specific endpoint (e.g.,
                       O1 NETCONF address).
+                    maxLength: 261
                     type: string
                   namespace:
                     description: namespace where the provider resources (e.g., OCUDU
                       gNB) are deployed.
+                    maxLength: 63
                     type: string
                   remoteControl:
                     description: |-
@@ -822,15 +828,25 @@ spec:
                     properties:
                       endpoint:
                         description: |-
-                          endpoint is host:port of the gNB remote_control server (e.g. "127.0.0.1:8001").
-                          The provider prepends ws://, so include NEITHER a scheme nor a path — a value
-                          like "ws://host:8001" would dial "ws://ws://host:8001" and fail. The pattern
-                          enforces bare host:port (a permanent admission error beats a silent
-                          tight-requeue on a mistyped endpoint).
+                          endpoint is host:port of the gNB remote_control server — a hostname/IPv4
+                          ("127.0.0.1:8001") or a bracketed IPv6 literal ("[::1]:8001") for dual-stack
+                          clusters. The provider prepends ws://, so include NEITHER a scheme nor a path
+                          — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
+                          Validation is layered: the pattern enforces the bare host:port shape, and CEL
+                          rules enforce the port range (1-65535) and that a bracketed host is a real IP
+                          (a permanent admission error beats a silent tight-requeue on a mistyped value).
                         maxLength: 261
                         minLength: 1
-                        pattern: ^[a-zA-Z0-9._-]+:[0-9]{1,5}$
+                        pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9._-]+):[0-9]{1,5}$
                         type: string
+                        x-kubernetes-validations:
+                        - message: endpoint port must be between 1 and 65535
+                          rule: int(self.substring(self.lastIndexOf(':') + 1)) >=
+                            1 && int(self.substring(self.lastIndexOf(':') + 1)) <=
+                            65535
+                        - message: a bracketed endpoint host must be a valid IP address
+                          rule: '!self.startsWith(''['') || isIP(self.substring(1,
+                            self.lastIndexOf('']'')))'
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)
@@ -856,6 +872,7 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           serverName:
@@ -873,10 +890,6 @@ spec:
                     required:
                     - endpoint
                     type: object
-                    x-kubernetes-validations:
-                    - message: endpoint port must be in 1-65535
-                      rule: int(self.endpoint.split(':')[1]) >= 1 && int(self.endpoint.split(':')[1])
-                        <= 65535
                   type:
                     description: type is the provider type. Currently only "ocudu"
                       is supported.

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -834,9 +834,12 @@ spec:
                           — a value like "ws://host:8001" would dial "ws://ws://host:8001" and fail.
                           Validation is layered: the pattern enforces the bare host:port shape with a
                           DNS-1123 hostname or bracketed IPv6, and CEL rules enforce the port range
-                          (1-65535), that a bracketed host is a valid IP, and that an all-numeric host is
-                          a valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname) —
-                          a permanent admission error beats a silent tight-requeue on a mistyped value.
+                          (1-65535), that a bracketed host is a valid IP, that an all-numeric host is a
+                          valid IPv4 (so "999.999.999.999:1" is rejected, not treated as a hostname), and
+                          that a DNS host obeys the RFC 1035 length limits (whole name <= 253, each label
+                          1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
+                          value. The pattern alone cannot bound the label/host length (a regex quantifier
+                          would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$
@@ -853,6 +856,11 @@ spec:
                             address
                           rule: '!self.substring(0, self.lastIndexOf('':'')).matches(''^[0-9.]+$'')
                             || isIP(self.substring(0, self.lastIndexOf('':'')))'
+                        - message: endpoint host must be a DNS name of at most 253
+                            characters with each dot-separated label 1-63 characters
+                          rule: self.startsWith('[') || (self.substring(0, self.lastIndexOf(':')).size()
+                            <= 253 && self.substring(0, self.lastIndexOf(':')).split('.').all(l,
+                            l.size() >= 1 && l.size() <= 63))
                       tls:
                         description: |-
                           tls, when set, secures the runtime push: the provider dials wss:// (TLS)

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.failoverCount
       name: Failovers
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="FailoverReady")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -106,6 +109,7 @@ spec:
                       the trigger (dB for RSRP, ms for latency, percent for packetLoss).
                       Example: with trigger "rsrp < -120" and hysteresisMargin "10",
                       failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    maxLength: 32
                     pattern: ^[0-9]+\.?[0-9]*$
                     type: string
                   minTerrestrialDwell:
@@ -170,6 +174,7 @@ spec:
                       endpoint:
                         description: endpoint is the base URL of the Prometheus HTTP
                           API.
+                        maxLength: 2048
                         minLength: 1
                         pattern: ^https?://
                         type: string
@@ -180,15 +185,18 @@ spec:
                           latencyMs:
                             description: latencyMs is a PromQL expression returning
                               a scalar in milliseconds.
+                            maxLength: 1024
                             type: string
                           packetLossPercent:
                             description: |-
                               packetLossPercent is a PromQL expression returning a scalar in
                               percent (0-100).
+                            maxLength: 1024
                             type: string
                           rsrpDbm:
                             description: rsrpDbm is a PromQL expression returning
                               a scalar in dBm.
+                            maxLength: 1024
                             type: string
                         type: object
                       queryTimeout:
@@ -250,11 +258,13 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   ephemerisRef:
                     description: |-
                       ephemerisRef is the name of the SatelliteEphemeris resource
                       used to determine satellite pass availability.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   priority:
@@ -265,6 +275,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:
@@ -295,6 +306,7 @@ spec:
                 type: object
               tenant:
                 description: tenant is the organization or entity that owns this slice.
+                maxLength: 253
                 minLength: 1
                 type: string
               terrestrialPath:
@@ -302,6 +314,7 @@ spec:
                 properties:
                   apn:
                     description: apn is the Access Point Name.
+                    maxLength: 253
                     type: string
                   priority:
                     description: priority is the path priority.
@@ -311,6 +324,7 @@ spec:
                     type: string
                   provider:
                     description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    maxLength: 253
                     minLength: 1
                     type: string
                 required:

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -71,7 +71,9 @@ spec:
                       groundStations is a list of GroundStationLifecycle resource names
                       to compute pass windows against.
                     items:
+                      maxLength: 253
                       type: string
+                    maxItems: 64
                     minItems: 1
                     type: array
                   horizon:
@@ -101,6 +103,7 @@ spec:
                       to track.
                     items:
                       type: integer
+                    maxItems: 512
                     type: array
                 type: object
               source:

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.lastUpdated
       name: Last Updated
       type: date
+    - jsonPath: .status.conditions[?(@.type=="GPDataFetched")].status
+      name: Fetched
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -79,6 +82,7 @@ spec:
                     default: "10"
                     description: minElevation is the minimum elevation angle in degrees
                       (string, e.g., "10").
+                    maxLength: 32
                     pattern: ^-?[0-9]+\.?[0-9]*$
                     type: string
                 required:
@@ -111,9 +115,11 @@ spec:
                       key:
                         default: password
                         description: key within the Secret data.
+                        maxLength: 253
                         type: string
                       name:
                         description: name of the Secret.
+                        maxLength: 253
                         type: string
                     required:
                     - name
@@ -141,6 +147,7 @@ spec:
                       only for a private/in-cluster mirror (NetworkPolicy-protected).
                       For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
                       For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    maxLength: 2048
                     minLength: 1
                     pattern: ^https?://
                     type: string


### PR DESCRIPTION
**PR B of 4** splitting the rejected #209. Validation **tightening** + UX hardening — not additive: an over-limit or malformed value authored under ≤ 0.6.0 is now **refused on its next apply/edit** (unset fields are unaffected). See the CHANGELOG `[Unreleased]` § for the upgrade note.

- **Condition-status printer column** on `kubectl get`: SatelliteEphemeris **Fetched** (GPDataFetched), NTNCellConfig **Applied** (ConfigApplied), NTNSlice **Ready** (FailoverReady). GroundStation already prints Phase.
- **MaxLength** on **26** previously-unbounded spec strings (refs/secret names 253, namespace 63, endpoints 261, URLs 2048, PromQL 1024, numeric strings 32) and **MaxItems** on the unbounded lists (`noradIDs` 512, `bands`/`groundStations` with per-item length). Enum / fixed-pattern / status fields left alone.
- **`RemoteControlRef.endpoint`: real IPv6 + port + DNS-length semantic validation.** The pattern is widened to accept a bracketed IPv6 literal (`[::1]:8001`), and CEL rules enforce the **port range (1-65535)**, that a bracketed host is a **valid IP (`isIP`)**, that an all-numeric host is a real **IPv4** (so `999.999.999.999:1` is refused, not treated as a hostname), and the **RFC 1035 DNS length limits** (whole host ≤ 253, each label 1-63). This **replaces a pre-existing type-level rule** — `int(self.endpoint.split(':')[1])` — that split on the *first* colon and thus **rejected every IPv6 literal** (so #209's widened pattern would have admitted a value the stale rule then bounced). A valid `host:port` therefore tops out at 259 chars, so `MaxLength=261` is a loose outer backstop the tighter DNS bound sits under. `isIP` needs the CEL IP library (**K8s 1.31+**), so the README prerequisite, `Chart.yaml` `kubeVersion`, the OLM CSV `minKubeVersion`, and the Nephio compat docs are raised `1.29 → 1.31` in lockstep.

## Verification (full)
- **envtest admission table** (real API server): accepts IPv4 / hostname / IPv6 / full-IPv6; rejects `port>65535`, `port 0`, a bracketed non-IP (`[fff]:443`), a missing port, a scheme-prefixed value, `999.999.999.999`, `foo..bar`, `---`, `_host`. **DNS-length boundary specs**: label **63 accepted / 64 rejected**, host **253 accepted / 254 rejected** — each within MaxLength and passing the Pattern, so only the length rule can reject it. MaxLength boundary pairs (63/64, 2048/2049, 253/254, 32/33). 30 admission specs, 0 failed.
- `make generate`/`manifests`/`docs` regenerated + **4-copy drift-checked** (`bundle-verify-sync` + `nephio-verify-sync` clean); `make test` (envtest, K8s 1.36) green; `golangci-lint` **0 issues**; `helm lint` pass; `nephio-validate` **17/17** (incl. the T13 CRD drift check).

Note: the `configMapRef` e2e flake is inherent to origin/main's cache-lag ConfigMap read-back and is fixed by **PR A #210** (uncached APIReader read-back) — merging A first makes B/C/D CI deterministic. Supersedes part of #209.
