### PR TITLE
feat(satelliteephemeris): observe cap truncation via status + transition-gated event [WO-16 PR C]

### DIFF
--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -161,11 +161,13 @@ type SatelliteEphemerisStatus struct {
 	// +optional
 	SatelliteCount int `json:"satelliteCount,omitempty"`
 
-	// truncatedSatelliteCount is how many satellites were dropped because the
-	// selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-	// dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-	// eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-	// StatesTruncated event is emitted once per transition into the truncated state.
+	// truncatedSatelliteCount is how many selected satellites were NOT propagated
+	// because the maxPropagatedStates cap (128) had already been reached — the count
+	// actually dropped by the cap, not merely (selected - 128), so satellites that
+	// fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+	// (the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+	// GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+	// StatesTruncated event fires once per transition into the truncated state.
 	// +optional
 	TruncatedSatelliteCount int `json:"truncatedSatelliteCount,omitempty"`
 

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -161,6 +161,14 @@ type SatelliteEphemerisStatus struct {
 	// +optional
 	SatelliteCount int `json:"satelliteCount,omitempty"`
 
+	// truncatedSatelliteCount is how many satellites were dropped because the
+	// selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+	// dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+	// eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+	// StatesTruncated event is emitted once per transition into the truncated state.
+	// +optional
+	TruncatedSatelliteCount int `json:"truncatedSatelliteCount,omitempty"`
+
 	// nextPassWindows contains upcoming contact opportunities.
 	// +optional
 	NextPassWindows []PassWindow `json:"nextPassWindows,omitempty"`
@@ -185,6 +193,10 @@ const (
 	ConditionGPDataFetched   = "GPDataFetched"
 	ConditionGPDataParsed    = "GPDataParsed"
 	ConditionPassesPredicted = "PassesPredicted"
+	// ConditionStatesTruncated is True when the selected satellite set exceeded the
+	// maxPropagatedStates cap and some were omitted from the runtime-push status.
+	// False means every selected satellite fit within the cap.
+	ConditionStatesTruncated = "StatesTruncated"
 	// ConditionUnsupportedOrbitRegime is True when the source contained element
 	// sets whose orbital period is >= 225 min (deep space, roughly MEO and up).
 	// The v1.0 propagator is near-earth SGP4 only, so those sets are rejected

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -360,6 +360,14 @@ spec:
                 description: satelliteCount is the number of satellites currently
                   tracked.
                 type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+                  StatesTruncated event is emitted once per transition into the truncated state.
+                type: integer
             type: object
         required:
         - spec

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -362,11 +362,13 @@ spec:
                 type: integer
               truncatedSatelliteCount:
                 description: |-
-                  truncatedSatelliteCount is how many satellites were dropped because the
-                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-                  StatesTruncated event is emitted once per transition into the truncated state.
+                  truncatedSatelliteCount is how many selected satellites were NOT propagated
+                  because the maxPropagatedStates cap (128) had already been reached — the count
+                  actually dropped by the cap, not merely (selected - 128), so satellites that
+                  fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+                  (the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+                  GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+                  StatesTruncated event fires once per transition into the truncated state.
                 type: integer
             type: object
         required:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -360,6 +360,14 @@ spec:
                 description: satelliteCount is the number of satellites currently
                   tracked.
                 type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+                  StatesTruncated event is emitted once per transition into the truncated state.
+                type: integer
             type: object
         required:
         - spec

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -362,11 +362,13 @@ spec:
                 type: integer
               truncatedSatelliteCount:
                 description: |-
-                  truncatedSatelliteCount is how many satellites were dropped because the
-                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-                  StatesTruncated event is emitted once per transition into the truncated state.
+                  truncatedSatelliteCount is how many selected satellites were NOT propagated
+                  because the maxPropagatedStates cap (128) had already been reached — the count
+                  actually dropped by the cap, not merely (selected - 128), so satellites that
+                  fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+                  (the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+                  GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+                  StatesTruncated event fires once per transition into the truncated state.
                 type: integer
             type: object
         required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -365,11 +365,13 @@ spec:
                 type: integer
               truncatedSatelliteCount:
                 description: |-
-                  truncatedSatelliteCount is how many satellites were dropped because the
-                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-                  StatesTruncated event is emitted once per transition into the truncated state.
+                  truncatedSatelliteCount is how many selected satellites were NOT propagated
+                  because the maxPropagatedStates cap (128) had already been reached — the count
+                  actually dropped by the cap, not merely (selected - 128), so satellites that
+                  fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+                  (the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+                  GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+                  StatesTruncated event fires once per transition into the truncated state.
                 type: integer
             type: object
         required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -363,6 +363,14 @@ spec:
                 description: satelliteCount is the number of satellites currently
                   tracked.
                 type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+                  StatesTruncated event is emitted once per transition into the truncated state.
+                type: integer
             type: object
         required:
         - spec

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3313,6 +3313,17 @@ under the etcd object-size limit.<br/>
           satelliteCount is the number of satellites currently tracked.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>truncatedSatelliteCount</b></td>
+        <td>integer</td>
+        <td>
+          truncatedSatelliteCount is how many satellites were dropped because the
+selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+StatesTruncated event is emitted once per transition into the truncated state.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1359,8 +1359,9 @@ Required: OCUDU rejects a sat_switch_with_resync that has no ntn_cfg.
         <td><b>cellSpecificKoffset</b></td>
         <td>integer</td>
         <td>
-          cellSpecificKoffset is the target cell-specific K_offset in milliseconds
-(1-1023), same semantics as NTNParams.cellSpecificKoffset. 0 omits it.<br/>
+          cellSpecificKoffset is the target cell-specific K_offset in milliseconds,
+same semantics as NTNParams.cellSpecificKoffset: 1-1023, with Minimum 1
+because OCUDU rejects 0. Omit the field to leave it unset.<br/>
           <br/>
             <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 1023<br/>
@@ -3317,11 +3318,13 @@ under the etcd object-size limit.<br/>
         <td><b>truncatedSatelliteCount</b></td>
         <td>integer</td>
         <td>
-          truncatedSatelliteCount is how many satellites were dropped because the
-selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-StatesTruncated event is emitted once per transition into the truncated state.<br/>
+          truncatedSatelliteCount is how many selected satellites were NOT propagated
+because the maxPropagatedStates cap (128) had already been reached — the count
+actually dropped by the cap, not merely (selected - 128), so satellites that
+fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+(the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+StatesTruncated event fires once per transition into the truncated state.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -234,6 +235,52 @@ func issOMMForTest() sgp4.OMM {
 		RAOfAscNode: 276.7884, ArgOfPericenter: 282.5765, MeanAnomaly: 192.7824,
 		ClassificationType: "U", NoradCatID: 25544, ElementSetNo: 999,
 		RevAtEpoch: 47189, BStar: 0.00025892, MeanMotionDot: 0.00019394,
+	}
+}
+
+// PR C: truncation is transition-gated — the Warning note is returned only on the
+// FIRST entry into the truncated state (so the ~3-min re-propagation cadence does
+// not re-fire it), while status.truncatedSatelliteCount + the StatesTruncated
+// condition always reflect the current state.
+func TestPropagateStates_TruncationTransitionGated(t *testing.T) {
+	r := &SatelliteEphemerisReconciler{}
+	const over = 5
+	big := make([]sgp4.OMM, 0, maxPropagatedStates+over)
+	for i := range maxPropagatedStates + over {
+		o := issOMMForTest()
+		o.NoradCatID = 25544 + i
+		big = append(big, o)
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	epoch := time.Now().Add(2 * time.Hour)
+	isTruncated := func() bool {
+		return meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionStatesTruncated)
+	}
+
+	// First reconcile over the cap: status + condition set, event note returned.
+	note1 := r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: big}, epoch)
+	if eph.Status.TruncatedSatelliteCount != over {
+		t.Errorf("TruncatedSatelliteCount = %d, want %d", eph.Status.TruncatedSatelliteCount, over)
+	}
+	if !isTruncated() {
+		t.Error("StatesTruncated condition should be True after exceeding the cap")
+	}
+	if note1 == "" {
+		t.Error("first transition into truncated should return a non-empty event note")
+	}
+
+	// Second reconcile, still over the cap: NO new note (transition-gated → no spam).
+	if note2 := r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: big}, epoch); note2 != "" {
+		t.Errorf("steady-state truncation must not re-emit an event, got %q", note2)
+	}
+
+	// Recover within the cap: count 0, condition False, no note.
+	note3 := r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMForTest()}}, epoch)
+	if eph.Status.TruncatedSatelliteCount != 0 || isTruncated() {
+		t.Error("recovery should clear the truncation count and condition")
+	}
+	if note3 != "" {
+		t.Error("recovery should not emit a truncation Warning")
 	}
 }
 

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -284,6 +284,71 @@ func TestPropagateStates_TruncationTransitionGated(t *testing.T) {
 	}
 }
 
+// badOMMForTest returns an OMM that PropagateToECEF rejects (eccentricity >= 1 is
+// invalid for SGP4), used to prove propagation failures do not inflate the count.
+func badOMMForTest() sgp4.OMM {
+	o := issOMMForTest()
+	o.Eccentricity = 1.5
+	return o
+}
+
+// PR C review follow-up: truncatedSatelliteCount must be the count actually dropped
+// by the cap, NOT (selected - cap). Satellites that fail SGP4 propagation reduce the
+// successful set and must never be reported as cap-truncated.
+func TestPropagateStates_TruncationCountsCapDropsNotPropagationFailures(t *testing.T) {
+	epoch := time.Now().Add(2 * time.Hour)
+	isTruncated := func(eph *ntnv1alpha1.SatelliteEphemeris) bool {
+		return meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionStatesTruncated)
+	}
+	build := func(nBad, nGood int) []sgp4.OMM {
+		omms := make([]sgp4.OMM, 0, nBad+nGood)
+		for i := range nBad {
+			b := badOMMForTest()
+			b.NoradCatID = 40000 + i
+			omms = append(omms, b)
+		}
+		for i := range nGood {
+			g := issOMMForTest()
+			g.NoradCatID = 25544 + i
+			omms = append(omms, g)
+		}
+		return omms
+	}
+
+	// 133 selected, 10 fail → 123 succeed (< 128) → the cap dropped nothing.
+	t.Run("failures below the cap → 0 truncated", func(t *testing.T) {
+		r := &SatelliteEphemerisReconciler{}
+		eph := &ntnv1alpha1.SatelliteEphemeris{}
+		note := r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: build(10, 123)}, epoch)
+		if len(eph.Status.PropagatedStates) != 123 {
+			t.Fatalf("expected 123 propagated states, got %d", len(eph.Status.PropagatedStates))
+		}
+		if eph.Status.TruncatedSatelliteCount != 0 {
+			t.Errorf("cap dropped nothing (123 < 128) but TruncatedSatelliteCount = %d", eph.Status.TruncatedSatelliteCount)
+		}
+		if isTruncated(eph) || note != "" {
+			t.Error("StatesTruncated must be False + no event when the cap dropped nothing")
+		}
+	})
+
+	// 140 selected, 2 fail before the cap → 128 successes reached after 130 OMMs →
+	// 10 remaining un-attempted → truncatedSatelliteCount = 10 (NOT 140-128=12).
+	t.Run("cap reached after some failures → counts only the un-attempted", func(t *testing.T) {
+		r := &SatelliteEphemerisReconciler{}
+		eph := &ntnv1alpha1.SatelliteEphemeris{}
+		r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: build(2, 138)}, epoch)
+		if len(eph.Status.PropagatedStates) != maxPropagatedStates {
+			t.Fatalf("expected %d propagated states, got %d", maxPropagatedStates, len(eph.Status.PropagatedStates))
+		}
+		if eph.Status.TruncatedSatelliteCount != 10 {
+			t.Errorf("expected 10 un-attempted due to cap, got %d", eph.Status.TruncatedSatelliteCount)
+		}
+		if !isTruncated(eph) {
+			t.Error("StatesTruncated must be True when the cap was reached")
+		}
+	})
+}
+
 // #176 producer: propagateStates fills status.propagatedStates from the tracked
 // satellites' SGP4-propagated ECEF at the given future epoch.
 func TestPropagateStates_FillsStatus(t *testing.T) {

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -311,7 +311,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// an earlier version did) made OCUDU back-propagate hours from a position that
 	// was itself SGP4-propagated hours forward, compounding LEO error; a near-now
 	// epoch keeps OCUDU's internal propagation short and forward.
-	r.propagateStates(ctx, eph, result, now.Add(propagationEpochLead))
+	truncEvent := r.propagateStates(ctx, eph, result, now.Add(propagationEpochLead))
 
 	if err := r.Status().Update(ctx, eph); err != nil {
 		return ctrl.Result{}, err
@@ -324,6 +324,13 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// fails NotFound above. (findings.md B-5; deep-review C-#4)
 	if orbitRegimeEvent != "" && r.Recorder != nil {
 		r.Recorder.Eventf(eph, nil, "Warning", "UnsupportedOrbitRegime", "OrbitRegimeGuard", "%s", orbitRegimeEvent)
+	}
+
+	// Same post-persist, transition-gated discipline: emit the StatesTruncated
+	// Warning only when propagateStates reported a fresh entry into the truncated
+	// state, so the ~3-minute re-propagation cadence never re-fires it.
+	if truncEvent != "" && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, "Warning", "StatesTruncated", "StatesTruncated", "%s", truncEvent)
 	}
 
 	// Emit the "fetched" event only on a real successful fetch — not on the
@@ -455,20 +462,24 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	eph *ntnv1alpha1.SatelliteEphemeris,
 	result ephemeris.GPFetchResult,
 	epoch time.Time,
-) {
+) string {
 	var norad []int
 	if eph.Spec.Satellites != nil {
 		norad = eph.Spec.Satellites.NoradIDs
 	}
 	omms := ephemeris.FilterOMMs(result.OMMs, norad)
+	truncated := 0
 	if len(omms) > maxPropagatedStates {
-		// No silent truncation: a satellite beyond the cap won't be pushable at
-		// runtime (its NoradID selector would miss). Tell the operator to narrow
-		// the set with spec.satellites.noradIDs.
+		truncated = len(omms) - maxPropagatedStates
+		// Not silent: a satellite beyond the cap won't be pushable at runtime (its
+		// NoradID selector would miss). It is surfaced as status.truncatedSatelliteCount
+		// + the StatesTruncated condition, and — only on the transition into the
+		// truncated state — a Warning event (see reportStatesTruncated).
 		logf.FromContext(ctx).Info("propagated-state list capped; some satellites omitted from runtime-push status",
 			"tracked", len(omms), "cap", maxPropagatedStates,
 			"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
 	}
+	truncEvent := r.reportStatesTruncated(eph, len(omms), truncated)
 	epochMs := epoch.UnixMilli()
 
 	// I-17: count tracked element sets whose OWN epoch is stale — a data property
@@ -505,6 +516,45 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	}
 	eph.Status.PropagatedStates = states
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
+	return truncEvent
+}
+
+// reportStatesTruncated records status.truncatedSatelliteCount and the
+// StatesTruncated condition, and RETURNS the Warning-event note the caller must
+// emit only AFTER a successful Status().Update ("" = nothing). Like
+// reportOrbitRegime, the note is non-empty only on the FIRST transition into the
+// truncated state, so the short re-propagation cadence (#179) does not re-emit the
+// event on every reconcile; deferring it to post-persist keeps a rolled-back
+// update from firing (and re-firing) an event for a transition that never landed.
+func (r *SatelliteEphemerisReconciler) reportStatesTruncated(eph *ntnv1alpha1.SatelliteEphemeris, selected, truncated int) string {
+	eph.Status.TruncatedSatelliteCount = truncated
+	if truncated == 0 {
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionStatesTruncated,
+			Status:             metav1.ConditionFalse,
+			Reason:             "WithinCap",
+			Message:            "All selected satellites fit within the propagated-state cap",
+			ObservedGeneration: eph.Generation,
+		})
+		return ""
+	}
+	// Read the persisted condition before mutating it, so the note is non-empty
+	// once per entry into the truncated state rather than every reconcile.
+	firstTransition := !meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionStatesTruncated)
+	msg := fmt.Sprintf("selected %d satellites but the propagated-state cap is %d; %d omitted from "+
+		"runtime-push status — narrow spec.satellites.noradIDs or the source URL GROUP=",
+		selected, maxPropagatedStates, truncated)
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionStatesTruncated,
+		Status:             metav1.ConditionTrue,
+		Reason:             "PropagatedStateCapExceeded",
+		Message:            msg,
+		ObservedGeneration: eph.Generation,
+	})
+	if firstTransition {
+		return msg
+	}
+	return ""
 }
 
 // reportOrbitRegime records the UnsupportedOrbitRegime condition and RETURNS the

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -468,18 +468,6 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		norad = eph.Spec.Satellites.NoradIDs
 	}
 	omms := ephemeris.FilterOMMs(result.OMMs, norad)
-	truncated := 0
-	if len(omms) > maxPropagatedStates {
-		truncated = len(omms) - maxPropagatedStates
-		// Not silent: a satellite beyond the cap won't be pushable at runtime (its
-		// NoradID selector would miss). It is surfaced as status.truncatedSatelliteCount
-		// + the StatesTruncated condition, and — only on the transition into the
-		// truncated state — a Warning event (see reportStatesTruncated).
-		logf.FromContext(ctx).Info("propagated-state list capped; some satellites omitted from runtime-push status",
-			"tracked", len(omms), "cap", maxPropagatedStates,
-			"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
-	}
-	truncEvent := r.reportStatesTruncated(eph, len(omms), truncated)
 	epochMs := epoch.UnixMilli()
 
 	// I-17: count tracked element sets whose OWN epoch is stale — a data property
@@ -492,9 +480,18 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		}
 	}
 
-	states := make([]ntnv1alpha1.PropagatedState, 0, len(omms))
+	states := make([]ntnv1alpha1.PropagatedState, 0, min(len(omms), maxPropagatedStates))
+	skippedByCap := 0
 	for i := range omms {
 		if len(states) >= maxPropagatedStates {
+			// The cap is reached; the remaining OMMs are NOT attempted. This is the
+			// truthful count dropped by the cap — propagation failures above already
+			// reduced the successful set, so len(omms)-cap would over-report a
+			// truncation that never actually happened.
+			skippedByCap = len(omms) - i
+			logf.FromContext(ctx).Info("propagated-state list capped; some satellites omitted from runtime-push status",
+				"selected", len(omms), "cap", maxPropagatedStates, "omitted", skippedByCap,
+				"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
 			break
 		}
 		ecef, err := ephemeris.PropagateToECEF(omms[i], epoch)
@@ -515,6 +512,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		})
 	}
 	eph.Status.PropagatedStates = states
+	truncEvent := r.reportStatesTruncated(eph, len(omms), skippedByCap)
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
 	return truncEvent
 }

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -360,6 +360,14 @@ spec:
                 description: satelliteCount is the number of satellites currently
                   tracked.
                 type: integer
+              truncatedSatelliteCount:
+                description: |-
+                  truncatedSatelliteCount is how many satellites were dropped because the
+                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
+                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
+                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
+                  StatesTruncated event is emitted once per transition into the truncated state.
+                type: integer
             type: object
         required:
         - spec

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -362,11 +362,13 @@ spec:
                 type: integer
               truncatedSatelliteCount:
                 description: |-
-                  truncatedSatelliteCount is how many satellites were dropped because the
-                  selected set exceeded the maxPropagatedStates cap (128); 0 when nothing was
-                  dropped. Narrow spec.satellites.noradIDs or the source URL's GROUP= to
-                  eliminate it. Mirrored by the StatesTruncated condition, and a Warning
-                  StatesTruncated event is emitted once per transition into the truncated state.
+                  truncatedSatelliteCount is how many selected satellites were NOT propagated
+                  because the maxPropagatedStates cap (128) had already been reached — the count
+                  actually dropped by the cap, not merely (selected - 128), so satellites that
+                  fail SGP4 propagation do not inflate it. ABSENT or 0 means nothing was dropped
+                  (the field is omitempty). Narrow spec.satellites.noradIDs or the source URL's
+                  GROUP= to eliminate it. Mirrored by the StatesTruncated condition; a Warning
+                  StatesTruncated event fires once per transition into the truncated state.
                 type: integer
             type: object
         required:


### PR DESCRIPTION
**PR C of 4** splitting the rejected #209. Truncation observability — done the way #209 did it *wrong* (an event every reconcile).

The `maxPropagatedStates=128` cap dropped satellites with only a log line. It is now observable **without flooding the event stream**:

- **`status.truncatedSatelliteCount`** — how many satellites were dropped (0 when none); visible every reconcile via `kubectl get -o yaml`.
- **`StatesTruncated` condition** (True/False) — reflects the current state idempotently.
- **A Warning `StatesTruncated` event fires ONLY on the transition INTO the truncated state** — not on every ~3-minute re-propagation (#179). This mirrors the existing `reportOrbitRegime` discipline: `reportStatesTruncated` returns the event note only when `meta.IsStatusConditionTrue` was false before this reconcile, and `Reconcile` emits it **after** a successful `Status().Update`, so a rolled-back persist cannot fire (and then re-fire) an event for a transition that never landed.

## Verification
- **`TestPropagateStates_TruncationTransitionGated`**: a first over-cap reconcile sets the count/condition and returns a note; a second steady-state reconcile returns `""` (no re-emit → **no 3-min spam**); recovery clears the count + condition.
- `make test-e2e` green (5/5 on local Kind); suite 9/9; `make lint` 0; CRD status field regenerated + 4-copy drift-checked; `make docs` refreshed.

Supersedes the truncation part of #209 (which fired the event on every reconcile). Depends conceptually on nothing, but shares the origin/main `configMapRef` e2e flake fixed by PR A #210.