### PR TITLE
docs(api): deprecate (not remove) spec.satellites.constellation [WO-16 PR D]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added condition/status print columns to the CRDs for quicker `kubectl get`
   triage.
 
+### Deprecated
+
+- `SatelliteEphemeris.spec.satellites.constellation` has never been consumed by the
+  controller (it performs no filtering) and is now deprecated. Select a CelesTrak
+  constellation through `spec.source.url` (the `GROUP=` query parameter, e.g.
+  `GROUP=oneweb`), or filter explicit satellites with `spec.satellites.noradIDs`.
+  The field remains accepted in `v1alpha1`; removal is deferred to a future
+  versioned API migration (conversion + stored-object migration), tracked as a
+  separate issue — a version rename alone does not safely drop the data.
+
 ## [0.6.0] - 2026-07-09
 
 Promotion of `0.6.0-rc.1` after a short soak (the rc's release pipeline —

--- a/README.md
+++ b/README.md
@@ -182,10 +182,9 @@ metadata:
 spec:
   source:
     type: CelesTrak
+    # GROUP=oneweb selects the constellation server-side — no client-side filter.
     url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -69,11 +69,14 @@ type SecretReference struct {
 
 // SatelliteSelector defines which satellites to track.
 type SatelliteSelector struct {
-	// constellation is DEPRECATED and performs NO server-side filtering — it has
-	// never been read by the controller. Select a constellation in the source URL
-	// instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-	// that constellation's element sets) and/or list explicit noradIDs. Kept for one
-	// release for compatibility; scheduled for removal in v1alpha2.
+	// constellation is DEPRECATED and performs no filtering at all — the controller
+	// has never consumed it (neither server- nor client-side). Select a constellation
+	// in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+	// returns only that constellation's element sets) and/or list explicit noradIDs.
+	// It stays accepted in v1alpha1; removal is deferred to a future versioned API
+	// migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+	// round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+	// a version rename alone is not enough to safely drop the data.
 	//
 	// Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
 	// +optional

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -69,7 +69,13 @@ type SecretReference struct {
 
 // SatelliteSelector defines which satellites to track.
 type SatelliteSelector struct {
-	// constellation filters by constellation name (e.g., "oneweb", "starlink").
+	// constellation is DEPRECATED and performs NO server-side filtering — it has
+	// never been read by the controller. Select a constellation in the source URL
+	// instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+	// that constellation's element sets) and/or list explicit noradIDs. Kept for one
+	// release for compatibility; scheduled for removal in v1alpha2.
+	//
+	// Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
 	// +optional
 	Constellation string `json:"constellation,omitempty"`
 

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -95,8 +95,14 @@ spec:
                   source.
                 properties:
                   constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
+                    description: |-
+                      constellation is DEPRECATED and performs NO server-side filtering — it has
+                      never been read by the controller. Select a constellation in the source URL
+                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
+                      release for compatibility; scheduled for removal in v1alpha2.
+
+                      Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -96,11 +96,14 @@ spec:
                 properties:
                   constellation:
                     description: |-
-                      constellation is DEPRECATED and performs NO server-side filtering — it has
-                      never been read by the controller. Select a constellation in the source URL
-                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
-                      release for compatibility; scheduled for removal in v1alpha2.
+                      constellation is DEPRECATED and performs no filtering at all — the controller
+                      has never consumed it (neither server- nor client-side). Select a constellation
+                      in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+                      returns only that constellation's element sets) and/or list explicit noradIDs.
+                      It stays accepted in v1alpha1; removal is deferred to a future versioned API
+                      migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+                      round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+                      a version rename alone is not enough to safely drop the data.
 
                       Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -95,8 +95,14 @@ spec:
                   source.
                 properties:
                   constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
+                    description: |-
+                      constellation is DEPRECATED and performs NO server-side filtering — it has
+                      never been read by the controller. Select a constellation in the source URL
+                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
+                      release for compatibility; scheduled for removal in v1alpha2.
+
+                      Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -96,11 +96,14 @@ spec:
                 properties:
                   constellation:
                     description: |-
-                      constellation is DEPRECATED and performs NO server-side filtering — it has
-                      never been read by the controller. Select a constellation in the source URL
-                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
-                      release for compatibility; scheduled for removal in v1alpha2.
+                      constellation is DEPRECATED and performs no filtering at all — the controller
+                      has never consumed it (neither server- nor client-side). Select a constellation
+                      in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+                      returns only that constellation's element sets) and/or list explicit noradIDs.
+                      It stays accepted in v1alpha1; removal is deferred to a future versioned API
+                      migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+                      round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+                      a version rename alone is not enough to safely drop the data.
 
                       Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string

--- a/config/samples/ntn_v1alpha1_satelliteephemeris.yaml
+++ b/config/samples/ntn_v1alpha1_satelliteephemeris.yaml
@@ -8,10 +8,9 @@ metadata:
 spec:
   source:
     type: CelesTrak
+    # GROUP=oneweb selects the constellation server-side — no client-side filter.
     url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -98,8 +98,14 @@ spec:
                   source.
                 properties:
                   constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
+                    description: |-
+                      constellation is DEPRECATED and performs NO server-side filtering — it has
+                      never been read by the controller. Select a constellation in the source URL
+                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
+                      release for compatibility; scheduled for removal in v1alpha2.
+
+                      Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -99,11 +99,14 @@ spec:
                 properties:
                   constellation:
                     description: |-
-                      constellation is DEPRECATED and performs NO server-side filtering — it has
-                      never been read by the controller. Select a constellation in the source URL
-                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
-                      release for compatibility; scheduled for removal in v1alpha2.
+                      constellation is DEPRECATED and performs no filtering at all — the controller
+                      has never consumed it (neither server- nor client-side). Select a constellation
+                      in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+                      returns only that constellation's element sets) and/or list explicit noradIDs.
+                      It stays accepted in v1alpha1; removal is deferred to a future versioned API
+                      migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+                      round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+                      a version rename alone is not enough to safely drop the data.
 
                       Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3244,7 +3244,13 @@ satellites filters which satellites to track from the source.
         <td><b>constellation</b></td>
         <td>string</td>
         <td>
-          constellation filters by constellation name (e.g., "oneweb", "starlink").<br/>
+          constellation is DEPRECATED and performs NO server-side filtering — it has
+never been read by the controller. Select a constellation in the source URL
+instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+that constellation's element sets) and/or list explicit noradIDs. Kept for one
+release for compatibility; scheduled for removal in v1alpha2.
+
+Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3244,11 +3244,14 @@ satellites filters which satellites to track from the source.
         <td><b>constellation</b></td>
         <td>string</td>
         <td>
-          constellation is DEPRECATED and performs NO server-side filtering — it has
-never been read by the controller. Select a constellation in the source URL
-instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-that constellation's element sets) and/or list explicit noradIDs. Kept for one
-release for compatibility; scheduled for removal in v1alpha2.
+          constellation is DEPRECATED and performs no filtering at all — the controller
+has never consumed it (neither server- nor client-side). Select a constellation
+in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+returns only that constellation's element sets) and/or list explicit noradIDs.
+It stays accepted in v1alpha1; removal is deferred to a future versioned API
+migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+a version rename alone is not enough to safely drop the data.
 
 Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.<br/>
         </td>

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -95,8 +95,14 @@ spec:
                   source.
                 properties:
                   constellation:
-                    description: constellation filters by constellation name (e.g.,
-                      "oneweb", "starlink").
+                    description: |-
+                      constellation is DEPRECATED and performs NO server-side filtering — it has
+                      never been read by the controller. Select a constellation in the source URL
+                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
+                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
+                      release for compatibility; scheduled for removal in v1alpha2.
+
+                      Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string
                   noradIDs:
                     description: noradIDs is an explicit list of NORAD catalog IDs

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -96,11 +96,14 @@ spec:
                 properties:
                   constellation:
                     description: |-
-                      constellation is DEPRECATED and performs NO server-side filtering — it has
-                      never been read by the controller. Select a constellation in the source URL
-                      instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb, returns only
-                      that constellation's element sets) and/or list explicit noradIDs. Kept for one
-                      release for compatibility; scheduled for removal in v1alpha2.
+                      constellation is DEPRECATED and performs no filtering at all — the controller
+                      has never consumed it (neither server- nor client-side). Select a constellation
+                      in the source URL instead (CelesTrak's GROUP= query parameter, e.g. GROUP=oneweb,
+                      returns only that constellation's element sets) and/or list explicit noradIDs.
+                      It stays accepted in v1alpha1; removal is deferred to a future versioned API
+                      migration — a v1alpha2 that drops it must ship conversion so v1alpha1<->v1alpha2
+                      round-trips losslessly, plus stored-object migration and storedVersions cleanup;
+                      a version rename alone is not enough to safely drop the data.
 
                       Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs.
                     type: string

--- a/nephio/packages/ntn-workloads-sample/README.md
+++ b/nephio/packages/ntn-workloads-sample/README.md
@@ -98,7 +98,7 @@ spec:
 |---|---|
 | Target namespace | `Kptfile` → `pipeline.mutators[set-namespace].configMap.namespace` |
 | Labels stamped on all CRs | `Kptfile` → `pipeline.mutators[set-labels].configMap` |
-| Satellite constellation | `satelliteephemeris-sample.yaml` → `spec.satellites.constellation` + `spec.source.url` |
+| Satellite selection | `satelliteephemeris-sample.yaml` → `spec.source.url` (the CelesTrak `GROUP=` query parameter, e.g. `GROUP=oneweb`) or `spec.satellites.noradIDs`. The former `spec.satellites.constellation` field is deprecated and has never filtered data. |
 | Ground station hardware / location | `groundstationlifecycle-sample.yaml` → `spec.hardware`, `spec.deployment.location` |
 | Cell ephemeris / payload type | `ntncellconfig-sample.yaml` → `spec.ntn` |
 | Failover triggers / QoS / billing | `ntnslice-sample.yaml` → `spec.failoverPolicy`, `spec.qosMapping`, `spec.billing` |

--- a/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
+++ b/nephio/packages/ntn-workloads-sample/satelliteephemeris-sample.yaml
@@ -8,10 +8,9 @@ metadata:
 spec:
   source:
     type: CelesTrak
+    # GROUP=oneweb selects the constellation server-side — no client-side filter.
     url: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01

--- a/test/e2e/fixtures/satelliteephemeris-e2e.yaml
+++ b/test/e2e/fixtures/satelliteephemeris-e2e.yaml
@@ -16,8 +16,6 @@ spec:
     type: CelesTrak
     url: http://celestrak-mock.default.svc.cluster.local/gp.json
     refreshInterval: 4h
-  satellites:
-    constellation: oneweb
   passPrediction:
     groundStations:
       - gs-taipei-01


### PR DESCRIPTION
**PR D of 4** splitting the rejected #209. Handles the dead `constellation` field as an **explicit deprecation**, not an in-place v1alpha1 removal.

`spec.satellites.constellation` has zero readers and does no filtering — constellation selection already works via the source URL (CelesTrak `GROUP=oneweb`, server-side) and `spec.satellites.noradIDs` (client-side). Rather than remove it outright inside v1alpha1 (the breaking change #209 mixed into a hygiene PR), this **keeps it for one release and marks it deprecated**:

- A `// Deprecated: select the constellation via source.url (GROUP=) or spec.satellites.noradIDs` **godoc marker** + descriptive comment → visible in the CRD field description, `kubectl explain`, and `api-reference.md`.
- Dropped the redundant `constellation: oneweb` from the README example and the three samples/fixtures (their source URL already carries `GROUP=oneweb`), so **nothing the project ships demonstrates the deprecated field**.

**Actual removal is deferred to a v1alpha2 cut** — an explicit, versioned API migration rather than an in-place break (per the Kubernetes deprecation-policy discussion around #209).

## Verification
- No behavior change (comment + samples/docs only). `make test-e2e` green (5/5 on Kind); suite 9/9; `make lint` 0; all four CRD copies + `api-reference.md` regenerated + drift-checked.

Supersedes the constellation-removal part of #209 (which removed the field in place). Completes the 4-PR split (A #210, B #211, C #212, D).