### PR TITLE
feat(controller): WO-20 event & GitOps hygiene — emit after status, gate on transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`RefreshIntervalClamped` condition on `SatelliteEphemeris`.** Surfaces whether
+  `spec.source.refreshInterval` was clamped into the supported `[2h, 24h]` range:
+  `True` (reason `BelowMinimum`/`AboveMaximum`) when clamped, `False`
+  (`WithinBounds`) when the configured interval is used as-is. The controller always
+  sets it explicitly, so an absent condition means "not yet reconciled" (Unknown),
+  distinct from a `False`.
+
 ### Changed
 
+- **Controller event hygiene.** Success and state-transition Events are emitted
+  after the reconcile's durable status write, and failure Warnings are episode-gated
+  on a condition's status/reason/observedGeneration rather than fired every reconcile,
+  so a stuck or churning reconcile no longer floods the Event stream. (One documented
+  exception: `RefreshIntervalClamped` is emitted pre-persist because it is a
+  deterministic function of the spec, and may therefore duplicate after a status
+  conflict.) A controller never writes a CR's `.spec` (only `.status` and finalizers);
+  GitOps posture is documented in [`docs/gitops.md`](docs/gitops.md).
 - **Validation tightening (may reject previously-accepted values).** Every
   free-form spec string now carries a `maxLength` and every unbounded list a
   `maxItems`, so an over-long or unbounded value is refused at admission instead
@@ -39,6 +56,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The field remains accepted in `v1alpha1`; removal is deferred to a future
   versioned API migration (conversion + stored-object migration), tracked as a
   separate issue — a version rename alone does not safely drop the data.
+
+### Fixed
+
+- **`ntn_operators_ephemeris_push_errors_total` now counts every push failure**,
+  not once per failure episode. The shipped `NTNEphemerisPushFailing` alert is
+  `increase(...[15m]) > 0 for 15m`, which only keeps firing while the counter keeps
+  advancing; counting once per episode let the alert resolve mid-outage while a
+  transient gNB push kept failing (and tight-requeuing) every minute. This matches
+  the metric's name/Help and `ntn_operators_config_apply_errors_total`. The
+  `EphemerisPushFailed` Kubernetes Event remains episode-gated. (Permanent,
+  non-requeuing reasons still increment once; the durable `EphemerisPushed=False`
+  condition covers those, with a readiness gauge as a recommended follow-up.)
 
 ## [0.6.0] - 2026-07-09
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ Import `config/grafana/ntn-operators-dashboard.json` into your Grafana instance 
 
 See [docs/api-reference.md](docs/api-reference.md) for the complete CRD field reference.
 
+## GitOps (Argo CD / Flux)
+
+The operators coexist cleanly with Argo CD and Flux: they never write `.spec`, and
+derived state lives in `.status`. See [docs/gitops.md](docs/gitops.md) for
+drift-detection setup (server-side diff/apply) and the ownership boundary for
+operator-generated artifacts (provider ConfigMaps, runtime gNB pushes).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -219,6 +219,13 @@ const (
 	// derived from stale elements and drifting (SGP4 in-track error grows with
 	// age from the element epoch). False means all propagated epochs are fresh.
 	ConditionEphemerisEpochStale = "EphemerisEpochStale"
+	// ConditionRefreshIntervalClamped is True when spec.source.refreshInterval was
+	// outside [2h, 24h] and the controller clamped it (Reason BelowMinimum /
+	// AboveMaximum). False (Reason WithinBounds) means the controller evaluated the
+	// interval and used it as-is. Absent means not yet reconciled (Unknown) — the
+	// controller always sets it explicitly, so False and absent are distinct. It lets
+	// the clamp be surfaced once per episode instead of a Warning every reconcile.
+	ConditionRefreshIntervalClamped = "RefreshIntervalClamped"
 )
 
 // +kubebuilder:object:root=true

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -1,0 +1,87 @@
+# GitOps compatibility
+
+The NTN operators are designed to coexist cleanly with GitOps controllers
+(Argo CD, Flux). This note explains why and how to keep drift detection quiet.
+
+## The operator never writes to `.spec`
+
+Each reconciler treats `.spec` as user (Git) intent and never mutates it. The
+only writes to a CR object other than its `/status` subresource are finalizer
+add/remove operations on `.metadata`. When the Git manifest does not declare those
+controller-owned finalizers, a normal server-side-apply / three-way-merge sync
+neither owns nor reverts them; a `Replace`/force sync strategy, or a manifest that
+itself declares finalizers, can behave differently. Derived state on the CR is
+exposed through `.status`; separately, the operator also produces provider
+artifacts (generated ConfigMaps) and runtime gNB pushes — operator-managed outputs
+covered in [Do not GitOps-manage operator-generated artifacts](#do-not-gitops-manage-operator-generated-artifacts).
+
+Because the operator is not a second writer to any spec field, Argo CD / Flux
+never fight it for ownership of `.spec`.
+
+## Defaults are applied by the API server, not the controller
+
+Field defaults use CRD schema defaults (`+kubebuilder:default=`), which the API
+server applies on create/update and **normally persists**, so they are visible in
+`kubectl get -o yaml` and legible to GitOps rather than being an invisible
+controller side effect. (One nuance: a default introduced *after* an object was
+already stored is applied on read but not written back until the object's next
+update — so a just-added default can appear in a `get` before it is persisted.
+This affects only newly-added defaults, not steady state.) The operator itself
+does not perform controller-side spec defaulting.
+
+## Computed values live in `.status`
+
+Derived/effective configuration — the applied K_offset, the resolved ephemeris
+(ECEF) pushed to the gNB, effective cell parameters, pass windows, failover
+state — is written to `.status`, never back into `.spec`. Argo CD excludes
+`status` from diffing by default, and Flux does not manage it, so these values
+never register as drift.
+
+## Do not GitOps-manage operator-generated artifacts
+
+Manage the NTN custom resources (the CRs' `.spec`) in Git. Do **not** also commit
+or reconcile the artifacts the operator generates from them:
+
+- **Generated ConfigMaps.** `NTNCellConfig`'s OCUDU provider renders the gNB NTN
+  config (e.g. `geo_ntn.yml`) into a ConfigMap, sets a controller `OwnerReference`
+  back to the CR, and keeps its `data`/annotations in sync every reconcile. These
+  ConfigMaps are operator-owned outputs, identifiable by their controller
+  OwnerReference and the labels `app.kubernetes.io/managed-by=ntn-operators` and
+  `app.kubernetes.io/component=ocudu-ntn-config`.
+- **Runtime gNB pushes.** The SGP4→ECEF ephemeris and NTN parameters pushed to a
+  live gNB are controller side effects, not Git-managed Kubernetes objects.
+
+If the same generated ConfigMap is placed under Argo CD or Flux management, the
+GitOps controller reconciles it back to the Git copy while the operator reconciles
+it back to the CR-derived copy, and the two overwrite each other on every cycle.
+Observe these outputs through the CR's `.status`, conditions, events, and metrics
+instead of managing them in Git. In practice, simply not rendering the generated
+ConfigMap into the GitOps source is enough — a resource that exists only in the
+cluster, absent from the desired manifests, is not something Argo CD or Flux
+adopts and reconciles. If a repository render accidentally emits it, drop it at the
+source / Kustomize path level. (Live-resource exclusion mechanisms differ per tool
+— Argo CD's global `resource.exclusions` filters by apiGroup/kind, not by label,
+and Flux's label-scoped `.spec.ignore` governs drift on already-managed resources —
+so a label-based exclusion is not a portable instruction.)
+
+## Recommended: server-side diff / apply
+
+Schema defaults added by the API server can show up as a spurious diff under the
+**legacy** client-side 3-way merge. The clean, systemic fix is to let the API
+server add the same defaults to the desired manifest before comparison:
+
+- **Argo CD** — enable [Server-Side Diff](https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/)
+  (`ServerSideDiff=true`; beta since Argo CD 2.10, stable from 3.1). The dry-run
+  server-side apply makes apiserver defaults match on both sides, eliminating false diffs.
+- **Flux** — the kustomize-controller reconciles with
+  [Server-Side Apply and periodic drift correction](https://fluxcd.io/flux/components/kustomize/kustomizations/#drift-detection).
+  Fields ABSENT from the desired manifest are generally left to whichever field
+  manager owns them; fields that ARE in the desired manifest are still reconciled
+  back per SSA ownership and Flux's policy (default `Override`), so "owned by another
+  manager" is not a blanket exemption. Flux also supports field-scoped drift ignore,
+  usually preferable to ignoring a whole object.
+
+`ignoreDifferences` (Argo CD) and Flux's `kustomize.toolkit.fluxcd.io/ssa: Ignore`
+annotation are legitimate for a field another controller genuinely owns. The
+anti-pattern is a BLANKET ignore of a whole object or a large subtree, which hides
+real drift — prefer a field-scoped ignore, or the server-side diff/apply above.

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// deferredEvent is a Kubernetes Event held until after the reconcile's status
+// write persists (WO-20 / N-1), so a rolled-back Status().Update never announces
+// (and, on the retry, re-announces) a transition that did not become durable.
+type deferredEvent struct {
+	eventType string
+	reason    string
+	message   string
+}
+
+// conditionEpisodeChanged reports whether setting a condition to (newStatus,
+// newReason, generation) begins a NEW episode relative to old: the condition is
+// absent, or its Status, Reason, or ObservedGeneration differs.
+//
+// It deliberately IGNORES the condition Message. A failure whose message only
+// carries a varying detail — "dial timeout after 30.001s" vs "…30.013s" — is the
+// same episode and must not re-emit a Warning on every reconcile; the full detail
+// belongs in the structured log, not a fresh Event each cycle. (meta.SetStatusCondition
+// returns true on a Message-only change, which is why event gates use this instead
+// of that return value.)
+//
+// Callers MUST evaluate this BEFORE meta.SetStatusCondition mutates the slice: old
+// is a pointer into ns.Status.Conditions that SetStatusCondition updates in place,
+// so reading it afterward would always see the new values.
+func conditionEpisodeChanged(old *metav1.Condition, newStatus metav1.ConditionStatus, newReason string, generation int64) bool {
+	return old == nil ||
+		old.Status != newStatus ||
+		old.Reason != newReason ||
+		old.ObservedGeneration != generation
+}

--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -127,21 +127,23 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	r.reconcileHealth(ctx, gs, node, err)
 
 	// Step 4: Check firmware OTA (skip when node lookup failed to avoid
-	// clearing firmware status on transient API errors).
+	// clearing firmware status on transient API errors). Firmware events are
+	// queued and emitted post-persist (Step 8).
+	var pending []deferredEvent
 	if err == nil {
-		r.reconcileFirmware(ctx, gs, node)
+		r.reconcileFirmware(ctx, gs, node, &pending)
 	}
 
-	// Step 5: Record events for phase transitions.
+	// Step 5: Queue a phase-transition event. It is emitted post-persist (Step 8)
+	// so a rolled-back status write never announces a phase change that did not
+	// become durable. The previousPhase compare keeps it one event per transition.
 	if previousPhase != gs.Status.Phase {
-		eventType := "Normal"
+		eventType := corev1.EventTypeNormal
 		if gs.Status.Phase == ntnv1alpha1.PhaseOffline || gs.Status.Phase == ntnv1alpha1.PhaseDegraded {
-			eventType = "Warning"
+			eventType = corev1.EventTypeWarning
 		}
-		if r.Recorder != nil {
-			r.Recorder.Eventf(gs, nil, eventType, "PhaseChanged", "PhaseChanged",
-				"Phase transitioned from %s to %s", previousPhase, gs.Status.Phase)
-		}
+		pending = append(pending, deferredEvent{eventType, "PhaseChanged",
+			fmt.Sprintf("Phase transitioned from %s to %s", previousPhase, gs.Status.Phase)})
 	}
 
 	// Step 6: Update health metrics (keyed by namespace+station — see #183; the
@@ -169,6 +171,15 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	// Step 7: Update status.
 	if err := r.Status().Update(ctx, gs); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Step 8: Emit queued events only after the status persisted (WO-20 / N-1): a
+	// discarded status write must not announce a phase/firmware transition it never
+	// recorded, then re-announce it on the retry.
+	if r.Recorder != nil {
+		for _, e := range pending {
+			r.Recorder.Eventf(gs, nil, e.eventType, e.reason, e.reason, "%s", e.message)
+		}
 	}
 
 	log.Info("Reconciled ground station", "phase", gs.Status.Phase)
@@ -388,6 +399,7 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 	ctx context.Context,
 	gs *ntnv1alpha1.GroundStationLifecycle,
 	node *corev1.Node,
+	pending *[]deferredEvent,
 ) {
 	log := logf.FromContext(ctx)
 	if gs.Spec.Firmware == nil {
@@ -448,10 +460,8 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 			})
 			gs.Status.Phase = ntnv1alpha1.PhaseDegraded
 			gs.Status.FirmwareUpdateStarted = nil
-			if r.Recorder != nil {
-				r.Recorder.Eventf(gs, nil, "Warning", "FirmwareUpdateTimedOut", "FirmwareUpdateTimedOut",
-					"Firmware update started at %s timed out after 30m", startedAt)
-			}
+			*pending = append(*pending, deferredEvent{corev1.EventTypeWarning, "FirmwareUpdateTimedOut",
+				fmt.Sprintf("Firmware update started at %s timed out after 30m", startedAt)})
 			return
 		}
 	}
@@ -487,10 +497,8 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 				ObservedGeneration: gs.Generation,
 			})
 			gs.Status.Phase = ntnv1alpha1.PhaseRunning
-			if r.Recorder != nil {
-				r.Recorder.Eventf(gs, nil, "Normal", "FirmwareUpdated", "FirmwareUpdated",
-					"Firmware updated to %s", availableVersion)
-			}
+			*pending = append(*pending, deferredEvent{corev1.EventTypeNormal, "FirmwareUpdated",
+				fmt.Sprintf("Firmware updated to %s", availableVersion)})
 			return
 		}
 		// Node agent hasn't reported completion yet — stay in Updating.
@@ -519,10 +527,8 @@ func (r *GroundStationLifecycleReconciler) reconcileFirmware(
 		now := r.now()
 		gs.Status.Phase = ntnv1alpha1.PhaseUpdating
 		gs.Status.FirmwareUpdateStarted = &metav1.Time{Time: now}
-		if r.Recorder != nil {
-			r.Recorder.Eventf(gs, nil, "Normal", "FirmwareUpdateStarted", "FirmwareUpdateStarted",
-				"Starting firmware update from %s to %s", currentVersion, availableVersion)
-		}
+		*pending = append(*pending, deferredEvent{corev1.EventTypeNormal, "FirmwareUpdateStarted",
+			fmt.Sprintf("Starting firmware update from %s to %s", currentVersion, availableVersion)})
 	}
 }
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -113,18 +113,6 @@ func ephemerisPushConditionReason(err error) string {
 	return ephemerisReasonPushFailed
 }
 
-func ephemerisPushConditionChanged(
-	prev *metav1.Condition,
-	reason, message string,
-	generation int64,
-) bool {
-	return prev == nil ||
-		prev.Status != metav1.ConditionFalse ||
-		prev.Reason != reason ||
-		prev.Message != message ||
-		prev.ObservedGeneration != generation
-}
-
 func ephemerisPushShouldRequeue(reason string) bool {
 	switch reason {
 	case ephemerisReasonRefNotFound,
@@ -151,6 +139,27 @@ func ephemerisPushShouldRequeue(reason string) bool {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+
+// emitConfigApplied records the ConfigApplied Normal event. It is invoked on every
+// reconcile path that persists a ConfigApplied=True transition (the
+// ephemeris-push-failure early return as well as the full-success path), so the
+// event is never lost when a status write other than the last one carries the
+// transition. Callers gate it on the transition (configApplyChanged).
+func (r *NTNCellConfigReconciler) emitConfigApplied(cc *ntnv1alpha1.NTNCellConfig, spec *ntnv1alpha1.NTNCellConfigSpec) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(cc, nil, corev1.EventTypeNormal, "ConfigApplied", "ConfigApplied",
+		"Applied NTN config (koffset=%d) via %s", spec.NTN.CellSpecificKoffset, spec.Provider.Type)
+	// A satSwitchWithResync on the ConfigMap path (no remoteControl+cellID) cannot be
+	// delivered (its k_mac has no bootstrap-YAML surface, issue #52). Surface it here,
+	// gated on the same ConfigApplied episode as its caller (configApplyChanged), so it
+	// warns once per spec rather than on every (minutely) push-failure requeue.
+	if spec.NTN.SatSwitchWithResync != nil && (spec.Provider.RemoteControl == nil || spec.CellID == nil) {
+		r.Recorder.Eventf(cc, nil, corev1.EventTypeWarning, "SatSwitchIgnored", "SatSwitchIgnored",
+			"%s", "satSwitchWithResync (incl. k_mac) requires remoteControl+cellID; ignored on the ConfigMap path")
+	}
+}
 
 // Reconcile applies NTN cell configuration to the specified provider backend.
 func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -234,7 +243,13 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if errors.Is(err, provider.ErrConfigMapNotOwned) {
 			reason = "OwnershipConflict"
 		}
-		// Preserve existing ConfigMapRef for best-effort finalizer cleanup.
+		// Preserve existing ConfigMapRef for best-effort finalizer cleanup. Gate the
+		// Warning on a real episode (Status/Reason/Generation change, IGNORING the
+		// error Message) so a persistent failure whose message merely varies does not
+		// re-emit on every (minutely) requeue.
+		applyFailEpisode := conditionEpisodeChanged(
+			meta.FindStatusCondition(cc.Status.Conditions, ntnv1alpha1.ConditionConfigApplied),
+			metav1.ConditionFalse, reason, cc.Generation)
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -245,8 +260,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Status().Update(ctx, cc); err != nil {
 			return ctrl.Result{}, err
 		}
-		if r.Recorder != nil {
-			r.Recorder.Eventf(cc, nil, "Warning", reason, reason, "%s", err.Error())
+		if applyFailEpisode && r.Recorder != nil {
+			r.Recorder.Eventf(cc, nil, corev1.EventTypeWarning, reason, reason, "%s", err.Error())
 		}
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
@@ -272,8 +287,19 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	cc.Status.AppliedKoffset = status.AppliedKoffset
 	cc.Status.ConfigMapRef = status.ConfigMapRef
 
-	// Step 7: Set success condition.
-	meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+	// Step 7: Set success condition. Capture whether it actually changed (status/
+	// reason/generation, or a new object) so the ConfigApplied event fires once per
+	// change, not on every reconcile. The events.k8s.io/v1 recorder this operator uses
+	// correlates events by type, reason, action, reporting identity, AND the full
+	// regarding ObjectReference — which carries resourceVersion (client-go
+	// reference.GetReference). Because this event is emitted after a Status().Update
+	// that bumps the object's resourceVersion, a per-reconcile Normal event would NOT
+	// fold into one EventSeries; each reconcile would mint a distinct Event object.
+	// Gating on a real change therefore avoids both redundant Event objects and
+	// needless broadcaster/series churn, and keeps the human-relevant history legible.
+	// (The message here is constant, so meta.SetStatusCondition's return is a fine
+	// gate; failure events whose message varies use conditionEpisodeChanged instead.)
+	configApplyChanged := meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionConfigApplied,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Applied",
@@ -293,7 +319,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			reason := ephemerisPushConditionReason(pushErr)
 			message := pushErr.Error()
 			prevEphemerisCondition := meta.FindStatusCondition(cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
-			conditionChanged := ephemerisPushConditionChanged(prevEphemerisCondition, reason, message, cc.Generation)
+			conditionChanged := conditionEpisodeChanged(prevEphemerisCondition, metav1.ConditionFalse, reason, cc.Generation)
 
 			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 				Type:               ntnv1alpha1.ConditionEphemerisPushed,
@@ -305,16 +331,31 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := r.Status().Update(ctx, cc); err != nil {
 				return ctrl.Result{}, err
 			}
-			if conditionChanged {
-				// Count distinct push-failure episodes by reason (I-19). Gated on
-				// conditionChanged like the event, so a steady non-ready state
-				// (e.g. PayloadMissing) is counted once per entry, not per reconcile.
-				ntnmetrics.EphemerisPushErrorsTotal.With(prometheus.Labels{
-					"namespace": cc.Namespace, "config": cc.Name, "reason": reason,
-				}).Inc()
-				if r.Recorder != nil {
-					r.Recorder.Eventf(cc, nil, "Warning", "EphemerisPushFailed", "EphemerisPushFailed", "%s", message)
-				}
+			// This persist path durably records the ConfigApplied=True transition, so
+			// emit its event here too — the config WAS applied; the push is a separate
+			// concern reported below. Without this, a first apply whose ephemeris push
+			// fails would swallow ConfigApplied forever: the success-path emit below is
+			// skipped by this branch's early return, and later reconciles see no
+			// transition (findings: WO-20 adversarial review).
+			if configApplyChanged {
+				r.emitConfigApplied(cc, spec)
+			}
+			// Count EVERY real push failure by reason (I-19), NOT once per episode:
+			// _errors_total is a failure counter, and the shipped NTNEphemerisPushFailing
+			// alert is increase(...[15m]) > 0 for 15m — which only stays firing while the
+			// series keeps advancing. A transient outage tight-requeues every minute, so
+			// per-failure counting keeps increase() > 0 across the outage; an episode gate
+			// would increment once and let the alert resolve mid-outage. This mirrors
+			// ConfigApplyErrorsTotal (counted per failure above). (Permanent reasons that
+			// do not requeue still increment only once — a durable EphemerisPushed=False
+			// condition covers those; a readiness gauge is a recommended follow-up.)
+			ntnmetrics.EphemerisPushErrorsTotal.With(prometheus.Labels{
+				"namespace": cc.Namespace, "config": cc.Name, "reason": reason,
+			}).Inc()
+			// The Event stays episode-gated (once per outage) to keep the Event stream
+			// legible; the counter above carries the per-failure signal.
+			if conditionChanged && r.Recorder != nil {
+				r.Recorder.Eventf(cc, nil, corev1.EventTypeWarning, "EphemerisPushFailed", "EphemerisPushFailed", "%s", message)
 			}
 			if !ephemerisPushShouldRequeue(reason) {
 				return ctrl.Result{}, nil
@@ -336,9 +377,8 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if r.Recorder != nil {
-		r.Recorder.Eventf(cc, nil, "Normal", "ConfigApplied", "ConfigApplied",
-			"Applied NTN config (koffset=%d) via %s", spec.NTN.CellSpecificKoffset, spec.Provider.Type)
+	if configApplyChanged {
+		r.emitConfigApplied(cc, spec)
 	}
 
 	log.Info("NTN cell configuration applied successfully")
@@ -460,13 +500,13 @@ func (r *NTNCellConfigReconciler) pushEphemerisUpdateIfNeeded(
 	// that observable instead of silently dropping it — a cell that sets a switch
 	// without remoteControl+cellID is misconfigured.
 	if spec.NTN.SatSwitchWithResync != nil {
-		logf.FromContext(ctx).Info(
+		// The SatSwitchIgnored Warning is emitted post-persist, once per ConfigApplied
+		// episode, in emitConfigApplied — NOT here. Emitting inline re-fired it on every
+		// (minutely) push-failure requeue, since this path is re-entered whenever the
+		// push is not up to date, which it never is while the push keeps failing.
+		logf.FromContext(ctx).V(1).Info(
 			"satSwitchWithResync is set but ignored: it requires spec.provider.remoteControl and spec.cellID (runtime push); the ConfigMap path cannot deliver it",
 			"cell", cc.Name)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(cc, nil, "Warning", "SatSwitchIgnored", "SatSwitchIgnored",
-				"%s", "satSwitchWithResync (incl. k_mac) requires remoteControl+cellID; ignored on the ConfigMap path")
-		}
 	}
 
 	// ConfigMap bootstrap path (backward compatible): push the CR's static

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -19,10 +19,13 @@ package controller
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -35,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
 	"github.com/thc1006/ntn-operators/pkg/provider"
 	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
 )
@@ -578,6 +582,120 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(ephCond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(ephCond.Reason).To(Equal("ProviderPushFailed"))
 			Expect(ephCond.Message).To(ContainSubstring("runtime push failed"))
+
+			// The ConfigApplied event must still fire on this apply-succeeds-but-push-
+			// fails path: the config WAS applied and its transition is durably persisted
+			// here, so the event cannot be lost to the early return. It is emitted before
+			// EphemerisPushFailed, so it is the first buffered event.
+			Expect(reconciler.Recorder.(*events.FakeRecorder).Events).
+				To(Receive(ContainSubstring("ConfigApplied")))
+		})
+
+		It("emits SatSwitchIgnored once per spec even while the push keeps failing", func() {
+			createReferencedEphemeris()
+			kmac := 200
+			// ConfigMap bootstrap path (no remoteControl+cellID) with a satSwitch that
+			// cannot be delivered there, and a provider whose push always fails so the
+			// reconcile re-enters the not-up-to-date path every requeue.
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: cellName, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF:       &ntnv1alpha1.EphemerisECEF{PosX: 20922195, PosY: 1967783, PosZ: 19770302},
+						PayloadType:         "transparent",
+						SatSwitchWithResync: &ntnv1alpha1.SatSwitchWithResync{
+							NTNConfig: ntnv1alpha1.SatSwitchNTNConfig{
+								EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 6000000, PosY: 1, PosZ: 1},
+								KMac:          &kmac,
+							},
+						},
+					},
+					EphemerisRef: ephName,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+
+			mock := &provider.MockProvider{EphemerisErr: errors.New("runtime push failed")}
+			reconciler := newReconciler(mock)
+			// finalizer add, then apply (push fails), then two more failing requeues.
+			for range 4 {
+				_, _ = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			}
+
+			rec := reconciler.Recorder.(*events.FakeRecorder)
+			satSwitch, pushFailed := 0, 0
+			for drained := false; !drained; {
+				select {
+				case ev := <-rec.Events:
+					if strings.Contains(ev, "SatSwitchIgnored") {
+						satSwitch++
+					}
+					if strings.Contains(ev, "EphemerisPushFailed") {
+						pushFailed++
+					}
+				default:
+					drained = true
+				}
+			}
+			Expect(satSwitch).To(Equal(1), "SatSwitchIgnored must fire once per spec, not on every push-failure requeue")
+			Expect(pushFailed).To(Equal(1), "EphemerisPushFailed must be episode-gated across the failing requeues")
+		})
+
+		It("counts every ephemeris push failure while emitting the Warning once per episode", func() {
+			createReferencedEphemeris()
+			// A runtime push that always fails with a transient (requeuing) reason. The
+			// COUNTER must advance on every failure so the shipped NTNEphemerisPushFailing
+			// alert — increase(ephemeris_push_errors_total[15m]) > 0 for 15m — keeps firing
+			// through an outage that tight-requeues each minute; an episode-gated counter
+			// would increment once and let the alert resolve mid-outage. The EVENT stays
+			// episode-gated. Mirrors ConfigApplyErrorsTotal's per-failure counting.
+			cr := &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: cellName, Namespace: namespace},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: namespace},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF:       &ntnv1alpha1.EphemerisECEF{PosX: 20922195, PosY: 1967783, PosZ: 19770302},
+						PayloadType:         "transparent",
+					},
+					EphemerisRef: ephName,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+
+			// reason is ProviderPushFailed (a raw provider error), which requeues.
+			labels := prometheus.Labels{"namespace": namespace, "config": cellName, "reason": "ProviderPushFailed"}
+			before := testutil.ToFloat64(ntnmetrics.EphemerisPushErrorsTotal.With(labels))
+
+			mock := &provider.MockProvider{EphemerisErr: errors.New("runtime push failed")}
+			reconciler := newReconciler(mock)
+			// finalizer add, then three apply-ok-but-push-fails requeues.
+			for range 4 {
+				_, _ = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			}
+
+			rec := reconciler.Recorder.(*events.FakeRecorder)
+			pushFailed := 0
+			for drained := false; !drained; {
+				select {
+				case ev := <-rec.Events:
+					if strings.Contains(ev, "EphemerisPushFailed") {
+						pushFailed++
+					}
+				default:
+					drained = true
+				}
+			}
+
+			delta := testutil.ToFloat64(ntnmetrics.EphemerisPushErrorsTotal.With(labels)) - before
+			Expect(mock.EphemerisCalls).To(BeNumerically(">=", 2),
+				"the setup must drive more than one failing push, else per-failure counting is untested")
+			Expect(delta).To(Equal(float64(mock.EphemerisCalls)),
+				"EphemerisPushErrorsTotal must advance on EVERY push failure (alert continuity), not once per episode")
+			Expect(pushFailed).To(Equal(1),
+				"EphemerisPushFailed Event must stay episode-gated across the failing requeues")
 		})
 
 		It("should avoid tight requeue when ephemerisRef does not exist", func() {

--- a/internal/controller/ntncellconfig_marker_test.go
+++ b/internal/controller/ntncellconfig_marker_test.go
@@ -75,34 +75,52 @@ func TestEphemerisPushConditionReason(t *testing.T) {
 	})
 }
 
-func TestEphemerisPushConditionChanged(t *testing.T) {
-	t.Run("nil previous condition is treated as changed", func(t *testing.T) {
-		if !ephemerisPushConditionChanged(nil, ephemerisReasonRefNotFound, "missing", 3) {
-			t.Fatalf("expected condition to be marked changed when previous condition is nil")
+func TestConditionEpisodeChanged(t *testing.T) {
+	t.Run("nil previous condition is a new episode", func(t *testing.T) {
+		if !conditionEpisodeChanged(nil, metav1.ConditionFalse, ephemerisReasonRefNotFound, 3) {
+			t.Fatalf("expected a nil previous condition to be a new episode")
 		}
 	})
 
-	t.Run("identical previous condition is not changed", func(t *testing.T) {
+	t.Run("identical status/reason/generation is the same episode", func(t *testing.T) {
 		prev := &metav1.Condition{
-			Status:             metav1.ConditionFalse,
-			Reason:             ephemerisReasonRefNotFound,
-			Message:            "missing",
-			ObservedGeneration: 3,
+			Status: metav1.ConditionFalse, Reason: ephemerisReasonRefNotFound, Message: "missing", ObservedGeneration: 3,
 		}
-		if ephemerisPushConditionChanged(prev, ephemerisReasonRefNotFound, "missing", 3) {
-			t.Fatalf("expected unchanged condition to be recognized as unchanged")
+		if conditionEpisodeChanged(prev, metav1.ConditionFalse, ephemerisReasonRefNotFound, 3) {
+			t.Fatalf("expected identical status/reason/generation to be the same episode")
 		}
 	})
 
-	t.Run("generation bump is treated as changed", func(t *testing.T) {
+	t.Run("message-only change is the SAME episode", func(t *testing.T) {
+		// Same status/reason/generation, only the varying error message differs — must
+		// NOT start a new episode, or a flapping message would re-emit every reconcile.
 		prev := &metav1.Condition{
-			Status:             metav1.ConditionFalse,
-			Reason:             ephemerisReasonRefNotFound,
-			Message:            "missing",
-			ObservedGeneration: 3,
+			Status: metav1.ConditionFalse, Reason: ephemerisReasonRefNotFound,
+			Message: "dial timeout after 30.001s", ObservedGeneration: 3,
 		}
-		if !ephemerisPushConditionChanged(prev, ephemerisReasonRefNotFound, "missing", 4) {
-			t.Fatalf("expected generation change to be treated as condition change")
+		if conditionEpisodeChanged(prev, metav1.ConditionFalse, ephemerisReasonRefNotFound, 3) {
+			t.Fatalf("a message-only change must not be a new episode")
+		}
+	})
+
+	t.Run("status change is a new episode", func(t *testing.T) {
+		prev := &metav1.Condition{Status: metav1.ConditionTrue, Reason: ephemerisReasonRefNotFound, ObservedGeneration: 3}
+		if !conditionEpisodeChanged(prev, metav1.ConditionFalse, ephemerisReasonRefNotFound, 3) {
+			t.Fatalf("expected a status change to be a new episode")
+		}
+	})
+
+	t.Run("reason change is a new episode", func(t *testing.T) {
+		prev := &metav1.Condition{Status: metav1.ConditionFalse, Reason: ephemerisReasonRefNotFound, ObservedGeneration: 3}
+		if !conditionEpisodeChanged(prev, metav1.ConditionFalse, ephemerisReasonPayloadMissing, 3) {
+			t.Fatalf("expected a reason change to be a new episode")
+		}
+	})
+
+	t.Run("generation bump is a new episode", func(t *testing.T) {
+		prev := &metav1.Condition{Status: metav1.ConditionFalse, Reason: ephemerisReasonRefNotFound, ObservedGeneration: 3}
+		if !conditionEpisodeChanged(prev, metav1.ConditionFalse, ephemerisReasonRefNotFound, 4) {
+			t.Fatalf("expected a generation bump to be a new episode")
 		}
 	})
 }

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,7 +193,11 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// is replaced by EvaluateSafeHold, which holds the current path but still honors
 	// the orbital signal from Step 3) — findings.md B-4 / I-8. readPathQuality never
 	// early-returns on a metrics failure, so Step 3's orbital check always runs.
-	metrics, qualityReliable := r.readPathQuality(ctx, ns, now)
+	// Events queued by the quality/trigger helpers are emitted only after the status
+	// write persists (WO-20 / N-1), so a rolled-back Status().Update never announces
+	// (then re-announces on retry) a transition that did not become durable.
+	var pending []deferredEvent
+	metrics, qualityReliable := r.readPathQuality(ctx, ns, now, &pending)
 
 	// Step 3: Check satellite availability via SatelliteEphemeris. satelliteKnown is
 	// false on a transient ephemeris read error — availability is unknown and the
@@ -226,7 +231,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// I-10: surface any trigger whose metric has no configured source — it is
 		// armed-but-dead (never fires against the healthy placeholder). Only
 		// meaningful once metrics were actually read (qualityReliable).
-		r.reportInertTriggers(ns, slice.InertTriggers(ns.Spec.FailoverPolicy.Triggers, metrics))
+		r.reportInertTriggers(ns, slice.InertTriggers(ns.Spec.FailoverPolicy.Triggers, metrics), &pending)
 	}
 
 	// Step 4: Evaluate the failover decision. With reliable metrics the full
@@ -333,16 +338,8 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			"from_path": previousPath, "to_path": string(result.TargetPath),
 		}
 		log.Info("Failover triggered", "from", previousPath, "to", result.TargetPath, "reason", result.Reason)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(ns, nil, "Warning", "FailoverTriggered", "FailoverTriggered",
-				"Failover from %s to %s: %s", previousPath, result.TargetPath, result.Reason)
-		}
 	case slice.DecisionSwitchback:
 		log.Info("Switchback", "from", previousPath, "to", result.TargetPath, "reason", result.Reason)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(ns, nil, "Normal", "Switchback", "Switchback",
-				"Switched back from %s to %s: %s", previousPath, result.TargetPath, result.Reason)
-		}
 	case slice.DecisionStay:
 		// No action needed.
 	}
@@ -388,6 +385,28 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// status.FailoverCount.
 	if failoverLabels != nil {
 		ntnmetrics.FailoverTotal.With(failoverLabels).Inc()
+	}
+
+	// Emit the decision event only after the status write persisted (same discipline
+	// as the FailoverTotal counter above): a conflicting/stale reconcile that
+	// discards its status update must not announce a failover/switchback it never
+	// recorded, then re-announce it on retry. The Failover/Switchback decision is
+	// itself one-per-transition (steady reconciles return Stay), so it needs no extra
+	// condition gate.
+	if r.Recorder != nil {
+		switch result.Decision {
+		case slice.DecisionFailover:
+			r.Recorder.Eventf(ns, nil, corev1.EventTypeWarning, "FailoverTriggered", "FailoverTriggered",
+				"Failover from %s to %s: %s", previousPath, result.TargetPath, result.Reason)
+		case slice.DecisionSwitchback:
+			r.Recorder.Eventf(ns, nil, corev1.EventTypeNormal, "Switchback", "Switchback",
+				"Switched back from %s to %s: %s", previousPath, result.TargetPath, result.Reason)
+		}
+		// Flush the quality/trigger events queued earlier this reconcile, also only
+		// after the status persisted (WO-20 / N-1).
+		for _, e := range pending {
+			r.Recorder.Eventf(ns, nil, e.eventType, e.reason, e.reason, "%s", e.message)
+		}
 	}
 
 	return ctrl.Result{RequeueAfter: sliceRequeueInterval}, nil
@@ -463,7 +482,7 @@ func (r *NTNSliceReconciler) applyBillingStatus(ns *ntnv1alpha1.NTNSlice, active
 // the degraded conditions and returns qualityReliable=false so the caller fails
 // static (findings.md B-4/I-8). It mutates conditions on ns in memory; the caller
 // persists them once at the end of the reconcile.
-func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time) (slice.Metrics, bool) {
+func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time, pending *[]deferredEvent) (slice.Metrics, bool) {
 	log := logf.FromContext(ctx)
 
 	reader, err := r.readerProvider().For(ns)
@@ -490,8 +509,12 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 	}
 
 	// Fresh read: record freshness. The stale Event is emitted only on the
-	// transition into stale (one event per outage, not one per interval).
-	prevStale := meta.FindStatusCondition(ns.Status.Conditions, ntnv1alpha1.ConditionMetricsStale)
+	// transition into stale (one event per outage, not one per interval). Snapshot
+	// the prior state as a VALUE before mutating — meta.FindStatusCondition returns a
+	// pointer INTO the slice that SetStatusCondition then mutates in place, so a
+	// pointer read after the write would always see True and miss every False->True
+	// (fresh->stale) transition.
+	wasStale := meta.IsStatusConditionTrue(ns.Status.Conditions, ntnv1alpha1.ConditionMetricsStale)
 	if !readResult.Stale {
 		meta.SetStatusCondition(&ns.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionMetricsStale,
@@ -513,9 +536,9 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		Message:            fmt.Sprintf("Using stale metrics last observed at %s (age %s)", readResult.LastFreshAt.Format(time.RFC3339), age.Round(time.Second)),
 		ObservedGeneration: ns.Generation,
 	})
-	if r.Recorder != nil && (prevStale == nil || prevStale.Status != metav1.ConditionTrue) {
-		r.Recorder.Eventf(ns, nil, "Warning", "MetricsStale", "MetricsStale",
-			"Using stale metrics last observed at %s", readResult.LastFreshAt.Format(time.RFC3339))
+	if !wasStale {
+		*pending = append(*pending, deferredEvent{corev1.EventTypeWarning, "MetricsStale",
+			fmt.Sprintf("Using stale metrics last observed at %s", readResult.LastFreshAt.Format(time.RFC3339))})
 	}
 	if age <= metricsMaxStaleness {
 		// Stale but within the freshness bound — still usable for a decision.
@@ -562,12 +585,18 @@ func (r *NTNSliceReconciler) setMetricsDegraded(ns *ntnv1alpha1.NTNSlice, reason
 	})
 }
 
-// reportInertTriggers sets the TriggersReady condition and, only on the first
-// transition into the not-ready state, emits a Warning event listing the inert
-// triggers — those whose metric has no configured source and can never fire
-// (findings.md I-10). True/AllTriggersSourced otherwise. The transition gate keeps
-// the event stream quiet across steady reconciles.
-func (r *NTNSliceReconciler) reportInertTriggers(ns *ntnv1alpha1.NTNSlice, inert []string) {
+// reportInertTriggers sets the TriggersReady condition and, once per inert EPISODE,
+// emits a Warning event listing the inert triggers — those whose metric has no
+// configured source and can never fire (findings.md I-10). True/AllTriggersSourced
+// otherwise. The episode gate keeps the event stream quiet across steady reconciles.
+//
+// The gate is conditionEpisodeChanged (Status/Reason/Generation), not a bare
+// into-False transition, so a NEW spec generation whose inert set changed — still
+// False/InertTriggers but a higher generation, e.g. one inert trigger swapped for
+// another — re-warns once, matching the generation-aware failure-event policy the
+// other conditions use. The message (the inert-trigger list) is deliberately outside
+// the gate: it varies per spec but does not by itself begin a new episode.
+func (r *NTNSliceReconciler) reportInertTriggers(ns *ntnv1alpha1.NTNSlice, inert []string, pending *[]deferredEvent) {
 	if len(inert) == 0 {
 		meta.SetStatusCondition(&ns.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionTriggersReady,
@@ -578,8 +607,10 @@ func (r *NTNSliceReconciler) reportInertTriggers(ns *ntnv1alpha1.NTNSlice, inert
 		})
 		return
 	}
-	firstTransition := !meta.IsStatusConditionPresentAndEqual(
-		ns.Status.Conditions, ntnv1alpha1.ConditionTriggersReady, metav1.ConditionFalse)
+	// Evaluate the episode BEFORE SetStatusCondition mutates the slice element in place.
+	episode := conditionEpisodeChanged(
+		meta.FindStatusCondition(ns.Status.Conditions, ntnv1alpha1.ConditionTriggersReady),
+		metav1.ConditionFalse, "InertTriggers", ns.Generation)
 	msg := fmt.Sprintf("failover triggers reference metrics with no configured source and will never fire: %s",
 		strings.Join(inert, "; "))
 	meta.SetStatusCondition(&ns.Status.Conditions, metav1.Condition{
@@ -589,8 +620,8 @@ func (r *NTNSliceReconciler) reportInertTriggers(ns *ntnv1alpha1.NTNSlice, inert
 		Message:            msg,
 		ObservedGeneration: ns.Generation,
 	})
-	if firstTransition && r.Recorder != nil {
-		r.Recorder.Eventf(ns, nil, "Warning", "InertTriggers", "InertTriggers", "%s", msg)
+	if episode {
+		*pending = append(*pending, deferredEvent{corev1.EventTypeWarning, "InertTriggers", msg})
 	}
 }
 

--- a/internal/controller/ntnslice_failover_metric_test.go
+++ b/internal/controller/ntnslice_failover_metric_test.go
@@ -13,7 +13,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +97,12 @@ func TestReconcile_FailoverCounterNotIncrementedOnStatusConflict(t *testing.T) {
 	}
 
 	sch := makeScheme(t)
+	// Capture whether the reconcile actually computed a failover in the status it
+	// tried to persist (FailoverCount bumped from 0), so the "counter unchanged"
+	// assertion below is not vacuous. The FailoverTriggered event is now emitted
+	// only AFTER a successful status write, so it is (correctly) absent on this
+	// conflict path and can no longer serve as that proxy.
+	var triedFailover bool
 	cli := fake.NewClientBuilder().
 		WithScheme(sch).
 		WithObjects(slice, eph).
@@ -105,7 +110,10 @@ func TestReconcile_FailoverCounterNotIncrementedOnStatusConflict(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			// Simulate the fresher reconcile having already advanced the
 			// resourceVersion: this stale reconcile's status write conflicts.
-			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				if ns, ok := obj.(*ntnv1alpha1.NTNSlice); ok && ns.Status.FailoverCount > 0 {
+					triedFailover = true
+				}
 				return apierrors.NewConflict(
 					schema.GroupResource{Group: "ntn.operators.dev", Resource: "ntnslices"},
 					sliceName, errors.New("stale revision"))
@@ -137,20 +145,22 @@ func TestReconcile_FailoverCounterNotIncrementedOnStatusConflict(t *testing.T) {
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("expected a Conflict error, got: %v", err)
 	}
-	// Positive control: FailoverTriggered is emitted in the DecisionFailover
-	// branch, before the (discarded) status write. Its presence proves the
-	// reconcile actually decided to fail over — otherwise "counter unchanged"
-	// would pass vacuously even if the setup never reached a failover.
-	select {
-	case ev := <-recorder.Events:
-		if !strings.Contains(ev, "FailoverTriggered") {
-			t.Fatalf("expected a FailoverTriggered event, got: %q", ev)
-		}
-	default:
-		t.Fatal("no event emitted: the reconcile never reached the failover decision, so the counter assertion would be vacuous")
+	// Positive control: the reconcile actually decided to fail over (it bumped
+	// FailoverCount in the status it attempted to persist) — otherwise "counter
+	// unchanged" would pass vacuously even if the setup never reached a failover.
+	if !triedFailover {
+		t.Fatal("the reconcile never computed a failover decision, so the counter assertion would be vacuous")
 	}
 	// The failover was never persisted, so the counter must not have moved.
 	if got := testutil.ToFloat64(ntnmetrics.FailoverTotal.With(labels)); got != before {
 		t.Errorf("FailoverTotal moved on a discarded failover: before=%v after=%v (want unchanged)", before, got)
+	}
+	// Events are emitted only AFTER a successful status write, so a discarded
+	// (conflicted) failover must announce nothing. This guards against re-introducing
+	// a pre-persist FailoverTriggered emit that the counter check alone would miss.
+	select {
+	case ev := <-recorder.Events:
+		t.Fatalf("no event may fire when the failover status write conflicts; got %q", ev)
+	default:
 	}
 }

--- a/internal/controller/ntnslice_inert_event_test.go
+++ b/internal/controller/ntnslice_inert_event_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestReconcile_InertTriggers_EpisodePerGeneration guards that the InertTriggers
+// Warning follows the generation-aware episode policy the other failure events use,
+// not a bare into-False transition. A spec that swaps one inert trigger for another
+// bumps the generation while the condition stays False/InertTriggers; the operator
+// must re-warn once for that new episode. The sequence:
+//
+//	gen1 inert (latency)     -> 1 event, False/InertTriggers, ObservedGeneration=1
+//	same gen, reconcile      -> 0 events (steady state)
+//	gen2 inert (packetLoss)  -> 1 new event, ObservedGeneration=2
+func TestReconcile_InertTriggers_EpisodePerGeneration(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", Generation: 1},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"latency > 200"}, // inert: latency has no source below
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(nsObj, eph).
+		WithStatusSubresource(nsObj, eph).Build()
+
+	// FRESH metrics (so the engine runs), but BOTH latency and packetLoss are missing
+	// (no configured source) — so whichever of the two the spec references is inert.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{
+			RSRP: -80, LatencyMs: 20, PacketLossPercent: 0.1,
+			LatencyMissing: true, PacketLossMissing: true,
+		},
+		Stale:       false,
+		LastFreshAt: fixedNow,
+	}}
+	rec := events.NewFakeRecorder(20)
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch, Recorder: rec,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+	key := client.ObjectKeyFromObject(nsObj)
+
+	reconcileAndCountInert := func() int {
+		if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		n := 0
+		for drained := false; !drained; {
+			select {
+			case ev := <-rec.Events:
+				if strings.Contains(ev, "InertTriggers") {
+					n++
+				}
+			default:
+				drained = true
+			}
+		}
+		return n
+	}
+	condOG := func() (metav1.ConditionStatus, string, int64) {
+		u := &ntnv1alpha1.NTNSlice{}
+		if err := cli.Get(context.Background(), key, u); err != nil {
+			t.Fatal(err)
+		}
+		c := meta.FindStatusCondition(u.Status.Conditions, ntnv1alpha1.ConditionTriggersReady)
+		if c == nil {
+			t.Fatal("TriggersReady condition missing")
+		}
+		return c.Status, c.Reason, c.ObservedGeneration
+	}
+	swapTrigger := func(expr string, gen int64) {
+		u := &ntnv1alpha1.NTNSlice{}
+		if err := cli.Get(context.Background(), key, u); err != nil {
+			t.Fatal(err)
+		}
+		u.Spec.FailoverPolicy.Triggers = []string{expr}
+		u.Generation = gen
+		if err := cli.Update(context.Background(), u); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 1) gen1 inert latency -> one event, False/InertTriggers, OG=1.
+	if n := reconcileAndCountInert(); n != 1 {
+		t.Fatalf("gen1 inert: want 1 InertTriggers event, got %d", n)
+	}
+	if s, reason, og := condOG(); s != metav1.ConditionFalse || reason != "InertTriggers" || og != 1 {
+		t.Fatalf("gen1 condition: want False/InertTriggers/OG=1, got %s/%s/%d", s, reason, og)
+	}
+	// 2) same generation, same inert set -> steady state, no new event.
+	if n := reconcileAndCountInert(); n != 0 {
+		t.Fatalf("steady state: want 0 events, got %d", n)
+	}
+	// 3) gen2 swaps latency for packetLoss (still inert, still False/InertTriggers,
+	// but a new generation) -> exactly one new event.
+	swapTrigger("packetLoss > 5", 2)
+	if n := reconcileAndCountInert(); n != 1 {
+		t.Fatalf("gen2 new inert episode: want 1 event, got %d", n)
+	}
+	if s, reason, og := condOG(); s != metav1.ConditionFalse || reason != "InertTriggers" || og != 2 {
+		t.Fatalf("gen2 condition: want False/InertTriggers/OG=2, got %s/%s/%d", s, reason, og)
+	}
+}

--- a/internal/controller/ntnslice_metricsstale_event_test.go
+++ b/internal/controller/ntnslice_metricsstale_event_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// stalingReader returns a fresh Result on the first Read and a stale-but-usable
+// Result on every later Read, driving a single slice through a fresh->stale
+// transition across two reconciles.
+type stalingReader struct {
+	calls int
+	fresh slicemetrics.Result
+	stale slicemetrics.Result
+}
+
+func (r *stalingReader) Read(_ context.Context, _ *ntnv1alpha1.NTNSlice) (slicemetrics.Result, error) {
+	r.calls++
+	if r.calls == 1 {
+		return r.fresh, nil
+	}
+	return r.stale, nil
+}
+
+// TestReconcile_MetricsStaleEvent_FiresOnFreshToStaleTransition guards the
+// MetricsStale Warning against a pointer-aliasing bug: meta.FindStatusCondition
+// returns a pointer INTO the conditions slice, which meta.SetStatusCondition then
+// mutates in place, so a gate that reads that pointer AFTER the write always sees
+// True and misses every False->True transition (it would fire only on the very
+// first, absent->True, outage). The controller snapshots the prior state as a
+// value instead. Here the first (fresh) read persists MetricsStale=False, so the
+// second (stale-but-usable) read is a genuine False->True transition that MUST
+// emit exactly one MetricsStale Warning.
+func TestReconcile_MetricsStaleEvent_FiresOnFreshToStaleTransition(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{Triggers: []string{"rsrp < -100"}},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(nsObj, eph).
+		WithStatusSubresource(nsObj, eph).
+		Build()
+
+	// Active pass window so satellite availability is known (keeps the reconcile on
+	// the normal quality path rather than an ephemeris-unknown hold).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+
+	rec := events.NewFakeRecorder(20)
+	rdr := &stalingReader{
+		// Healthy RSRP (-80 does not trip "rsrp < -100"), so metrics staleness — not a
+		// failover — is what this test exercises.
+		fresh: slicemetrics.Result{Metrics: slice.Metrics{RSRP: -80}, Stale: false, LastFreshAt: fixedNow},
+		// Stale but only 10s old — WITHIN metricsMaxStaleness — so it takes the
+		// MetricsStale=True (usable) branch, not the fail-static branch.
+		stale: slicemetrics.Result{Metrics: slice.Metrics{RSRP: -80}, Stale: true, LastFreshAt: fixedNow.Add(-10 * time.Second)},
+	}
+	r := &NTNSliceReconciler{
+		Client:         cli,
+		Scheme:         sch,
+		Recorder:       rec,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: rdr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	// 1: fresh -> MetricsStale=False (no event). 2: fresh->stale transition -> one
+	// event. 3: stale->stale steady state -> no NEW event (episode gate).
+	for i, phase := range []string{"fresh", "fresh->stale", "steady-stale"} {
+		if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile %d (%s): %v", i+1, phase, err)
+		}
+	}
+
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if c := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionMetricsStale); c == nil || c.Status != metav1.ConditionTrue {
+		t.Fatalf("MetricsStale must be True after the stale read, got %+v", c)
+	}
+
+	staleEvents := 0
+	for drained := false; !drained; {
+		select {
+		case ev := <-rec.Events:
+			if strings.Contains(ev, "MetricsStale") {
+				staleEvents++
+			}
+		default:
+			drained = true
+		}
+	}
+	if staleEvents != 1 {
+		t.Fatalf("MetricsStale must fire EXACTLY once across fresh->stale->stale "+
+			"(one transition, then the steady stale state emits nothing), got %d", staleEvents)
+	}
+}

--- a/internal/controller/satelliteephemeris_clamp_event_test.go
+++ b/internal/controller/satelliteephemeris_clamp_event_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// TestReconcile_RefreshIntervalClamped_EmitsOncePerEpisode guards the episode gate
+// on the clamp Warning: an out-of-bounds refreshInterval reschedules on the ~3-minute
+// propagation cadence, so without a gate the Warning would fire ~480 times/day. It
+// must warn ONCE per episode (per spec) instead. The clamp is evaluated in Step 2
+// before the fetch, so it fires regardless of the fetch outcome; a fetch error here
+// just exercises that the RefreshIntervalClamped condition still persists (via
+// handleFetchError's status write), which is what makes the second reconcile a no-op.
+func TestReconcile_RefreshIntervalClamped_EmitsOncePerEpisode(t *testing.T) {
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default"},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type:            "CelesTrak",
+				URL:             "https://celestrak.org/x",
+				RefreshInterval: metav1.Duration{Duration: 1 * time.Hour}, // below the 2h minimum
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+
+	rec := events.NewFakeRecorder(20)
+	r := &SatelliteEphemerisReconciler{
+		Client:   cli,
+		Scheme:   sch,
+		Recorder: rec,
+		Fetcher:  &mockGPFetcher{err: errors.New("simulated GP source outage")},
+	}
+
+	key := client.ObjectKeyFromObject(eph)
+	for range 2 {
+		// The fetch error surfaces as a reconcile error; irrelevant to the clamp
+		// assertion (which fires in Step 2, before the fetch).
+		_, _ = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	}
+
+	clampEvents := 0
+	for drained := false; !drained; {
+		select {
+		case ev := <-rec.Events:
+			if strings.Contains(ev, "RefreshIntervalClamped") {
+				clampEvents++
+			}
+		default:
+			drained = true
+		}
+	}
+	if clampEvents != 1 {
+		t.Fatalf("expected exactly ONE RefreshIntervalClamped event across two reconciles, got %d", clampEvents)
+	}
+
+	updated := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	c := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionRefreshIntervalClamped)
+	if c == nil || c.Status != metav1.ConditionTrue || c.Reason != "BelowMinimum" {
+		t.Fatalf("RefreshIntervalClamped condition must be True/BelowMinimum, got %+v", c)
+	}
+}
+
+// TestReconcile_RefreshIntervalClamped_RecoveryContract checks the condition
+// contract — True/BelowMinimum when clamped, False/WithinBounds (NEVER absent) when
+// valid, so a consumer can tell "evaluated, no clamp" from "not yet reconciled" — and
+// the episode transitions across invalid -> valid -> invalid spec edits (one event
+// each clamp, none on recovery).
+func TestReconcile_RefreshIntervalClamped_RecoveryContract(t *testing.T) {
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/x",
+				RefreshInterval: metav1.Duration{Duration: 1 * time.Hour}, // invalid (< 2h)
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	rec := events.NewFakeRecorder(20)
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: rec, Fetcher: &mockGPFetcher{err: errors.New("outage")}}
+	key := client.ObjectKeyFromObject(eph)
+
+	reconcileAndCountClampEvents := func() int {
+		_, _ = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+		n := 0
+		for drained := false; !drained; {
+			select {
+			case ev := <-rec.Events:
+				if strings.Contains(ev, "RefreshIntervalClamped") {
+					n++
+				}
+			default:
+				drained = true
+			}
+		}
+		return n
+	}
+	cond := func() *metav1.Condition {
+		u := &ntnv1alpha1.SatelliteEphemeris{}
+		if err := cli.Get(context.Background(), key, u); err != nil {
+			t.Fatal(err)
+		}
+		return meta.FindStatusCondition(u.Status.Conditions, ntnv1alpha1.ConditionRefreshIntervalClamped)
+	}
+	setInterval := func(d time.Duration, gen int64) {
+		u := &ntnv1alpha1.SatelliteEphemeris{}
+		if err := cli.Get(context.Background(), key, u); err != nil {
+			t.Fatal(err)
+		}
+		u.Spec.Source.RefreshInterval = metav1.Duration{Duration: d}
+		u.Generation = gen
+		if err := cli.Update(context.Background(), u); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 1) invalid -> True/BelowMinimum + one event.
+	if n := reconcileAndCountClampEvents(); n != 1 {
+		t.Fatalf("initial clamp: want 1 event, got %d", n)
+	}
+	if c := cond(); c == nil || c.Status != metav1.ConditionTrue || c.Reason != "BelowMinimum" {
+		t.Fatalf("clamped state must be True/BelowMinimum, got %+v", c)
+	}
+	// 2) valid -> False/WithinBounds (NOT absent) + zero events.
+	setInterval(4*time.Hour, 2)
+	if n := reconcileAndCountClampEvents(); n != 0 {
+		t.Fatalf("recovery: want 0 events, got %d", n)
+	}
+	if c := cond(); c == nil || c.Status != metav1.ConditionFalse || c.Reason != "WithinBounds" {
+		t.Fatalf("valid interval must record False/WithinBounds (never absent), got %+v", c)
+	}
+	// 3) invalid again -> True + a second event (the recovery made this a real transition).
+	setInterval(1*time.Hour, 3)
+	if n := reconcileAndCountClampEvents(); n != 1 {
+		t.Fatalf("re-clamp: want 1 event, got %d", n)
+	}
+	if c := cond(); c == nil || c.Status != metav1.ConditionTrue {
+		t.Fatalf("re-clamp: want True, got %+v", c)
+	}
+}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -89,6 +89,69 @@ type SatelliteEphemerisReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
+// clampRefreshInterval clamps spec.source.refreshInterval into [minRefreshInterval,
+// maxRefreshInterval] and records the RefreshIntervalClamped condition — True with
+// reason BelowMinimum/AboveMaximum when clamped, and False/WithinBounds (NOT absent)
+// when the configured interval is used as-is, so False is distinguishable from the
+// not-yet-reconciled Unknown per the Kubernetes condition contract. The clamp Warning
+// is emitted inline (pre-persist) and episode-gated, so it fires once per spec across
+// NORMAL reconciles instead of on every ~3-minute reconcile. Inline emission is
+// deliberate: the clamp is a deterministic function of the spec, so the Warning is
+// never fabricated and is not lost on an early-return fetch-error path. The one edge
+// it does NOT cover is a status-update CONFLICT that discards the reconcile — the prior
+// condition then does not persist, so the next reconcile re-detects the episode and
+// re-emits; that is rare and benign for a spec-validation Warning, and is the accepted
+// trade-off against threading a deferred note through every status-write path.
+func (r *SatelliteEphemerisReconciler) clampRefreshInterval(ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris) time.Duration {
+	effectiveInterval := eph.Spec.Source.RefreshInterval.Duration
+	var clampReason, clampMsg string
+	switch {
+	case effectiveInterval < minRefreshInterval:
+		effectiveInterval = minRefreshInterval
+		clampReason = "BelowMinimum"
+		clampMsg = fmt.Sprintf("refreshInterval %s is below minimum 2h; using 2h", eph.Spec.Source.RefreshInterval.Duration)
+	case effectiveInterval > maxRefreshInterval:
+		effectiveInterval = maxRefreshInterval
+		clampReason = "AboveMaximum"
+		clampMsg = fmt.Sprintf("refreshInterval %s exceeds maximum 24h; using 24h to keep the element set fresh", eph.Spec.Source.RefreshInterval.Duration)
+	}
+	if clampReason == "" {
+		// Within bounds: record an explicit False (not absent) so a consumer can tell
+		// "evaluated, no clamp needed" from "not yet reconciled" (absent = Unknown).
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionRefreshIntervalClamped,
+			Status:             metav1.ConditionFalse,
+			Reason:             "WithinBounds",
+			Message:            "Configured refreshInterval is within the supported range [2h, 24h]",
+			ObservedGeneration: eph.Generation,
+		})
+		return effectiveInterval
+	}
+	clampEpisode := conditionEpisodeChanged(
+		meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionRefreshIntervalClamped),
+		metav1.ConditionTrue, clampReason, eph.Generation)
+	// Log at Info once per clamp episode; drop to V(1) across steady-state reconciles
+	// so a persistently out-of-bounds spec does not print the same line every ~3
+	// minutes, mirroring the event hygiene this WO enforces.
+	clampLog := logf.FromContext(ctx)
+	if !clampEpisode {
+		clampLog = clampLog.V(1)
+	}
+	clampLog.Info("RefreshInterval clamped", "reason", clampReason,
+		"configured", eph.Spec.Source.RefreshInterval.Duration, "effective", effectiveInterval)
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionRefreshIntervalClamped,
+		Status:             metav1.ConditionTrue,
+		Reason:             clampReason,
+		Message:            clampMsg,
+		ObservedGeneration: eph.Generation,
+	})
+	if clampEpisode && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "RefreshIntervalClamped", clampReason, "%s", clampMsg)
+	}
+	return effectiveInterval
+}
+
 // Reconcile fetches GP data, computes pass predictions, and updates status.
 func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -119,23 +182,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// re-propagate a 30-day-old element set as if fresh, and LEO SGP4 error grows
 	// ~1–3 km/day from the element epoch (findings.md I-17). metav1.Duration
 	// serialises as a string, so both bounds are enforced here rather than via CEL.
-	effectiveInterval := eph.Spec.Source.RefreshInterval.Duration
-	switch {
-	case effectiveInterval < minRefreshInterval:
-		log.Info("RefreshInterval below minimum, clamping", "configured", effectiveInterval, "effective", minRefreshInterval)
-		effectiveInterval = minRefreshInterval
-		if r.Recorder != nil {
-			r.Recorder.Eventf(eph, nil, "Warning", "RefreshIntervalClamped", "RefreshIntervalClamped",
-				"refreshInterval %s is below minimum 2h; using 2h", eph.Spec.Source.RefreshInterval.Duration)
-		}
-	case effectiveInterval > maxRefreshInterval:
-		log.Info("RefreshInterval above maximum, clamping", "configured", effectiveInterval, "effective", maxRefreshInterval)
-		effectiveInterval = maxRefreshInterval
-		if r.Recorder != nil {
-			r.Recorder.Eventf(eph, nil, "Warning", "RefreshIntervalClamped", "RefreshIntervalClamped",
-				"refreshInterval %s exceeds maximum 24h; using 24h to keep the element set fresh", eph.Spec.Source.RefreshInterval.Duration)
-		}
-	}
+	effectiveInterval := r.clampRefreshInterval(ctx, eph)
 
 	// Step 3: Select fetcher and load credentials if needed.
 	fetcher, fetcherErr := r.fetcherForSource(ctx, eph)
@@ -184,6 +231,13 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	eph.Status.SatelliteCount = result.SatelliteCount
 	eph.Status.LastUpdated = &metav1.Time{Time: result.FetchedAt}
 	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
+
+	// Snapshot (before the switch mutates it) whether serve-from-cache is a NEW
+	// episode, so its Warning fires once per outage — not on every short-cadence
+	// re-propagation that keeps serving the same stale cache.
+	serveCacheEpisode := servedCacheOnError && conditionEpisodeChanged(
+		meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched),
+		metav1.ConditionFalse, "FetchFailedServingCache", eph.Generation)
 
 	switch {
 	case servedCacheOnError:
@@ -280,26 +334,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ntnmetrics.GPDeepSpaceRejectedCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(len(trackedDeepSpace)))
 
 	// Step 7: Compute pass predictions if configured; clear stale data if disabled.
-	if eph.Spec.PassPrediction != nil && len(eph.Spec.PassPrediction.GroundStations) > 0 {
-		if err := r.predictPasses(ctx, eph, result); err != nil {
-			log.Error(err, "pass prediction failed")
-			eph.Status.NextPassWindows = nil // clear stale pass data
-			meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
-				Type:               ntnv1alpha1.ConditionPassesPredicted,
-				Status:             metav1.ConditionFalse,
-				Reason:             "PredictionFailed",
-				Message:            err.Error(),
-				ObservedGeneration: eph.Generation,
-			})
-			if r.Recorder != nil {
-				r.Recorder.Eventf(eph, nil, "Warning", "PredictionFailed", "PredictionFailed", "%s", err.Error())
-			}
-		}
-	} else {
-		// Pass prediction not configured; clear stale pass windows and condition.
-		eph.Status.NextPassWindows = nil
-		meta.RemoveStatusCondition(&eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
-	}
+	passNote, passFailNote := r.handlePassPrediction(ctx, eph, result)
 
 	// Step 7b: Propagate tracked satellites to a NEAR-now epoch for the runtime
 	// ephemeris push (#176). The epoch is only a small lead ahead of now — enough
@@ -323,14 +358,25 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// suppresses a spurious event on a terminating object, whose Status().Update
 	// fails NotFound above. (findings.md B-5; deep-review C-#4)
 	if orbitRegimeEvent != "" && r.Recorder != nil {
-		r.Recorder.Eventf(eph, nil, "Warning", "UnsupportedOrbitRegime", "OrbitRegimeGuard", "%s", orbitRegimeEvent)
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "UnsupportedOrbitRegime", "OrbitRegimeGuard", "%s", orbitRegimeEvent)
 	}
 
 	// Same post-persist, transition-gated discipline: emit the StatesTruncated
 	// Warning only when propagateStates reported a fresh entry into the truncated
 	// state, so the ~3-minute re-propagation cadence never re-fires it.
 	if truncEvent != "" && r.Recorder != nil {
-		r.Recorder.Eventf(eph, nil, "Warning", "StatesTruncated", "StatesTruncated", "%s", truncEvent)
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "StatesTruncated", "StatesTruncated", "%s", truncEvent)
+	}
+
+	// Pass-prediction events, same post-persist + transition-gated discipline (#188):
+	// the notes are non-empty only when the PassesPredicted condition changed, so the
+	// ~3-minute cache re-propagation never re-emits an identical pass event, and a
+	// rolled-back status update fires neither.
+	if passNote != "" && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeNormal, "PassesPredicted", "PassesPredicted", "%s", passNote)
+	}
+	if passFailNote != "" && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "PredictionFailed", "PredictionFailed", "%s", passFailNote)
 	}
 
 	// Emit the "fetched" event only on a real successful fetch — not on the
@@ -339,13 +385,13 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Warning so an operator sees SIB19 is running on stale cache (I-18).
 	switch {
 	case servedCacheOnError:
-		if r.Recorder != nil {
-			r.Recorder.Eventf(eph, nil, "Warning", "FetchFailedServingCache", "FetchFailedServingCache",
+		if serveCacheEpisode && r.Recorder != nil {
+			r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "FetchFailedServingCache", "FetchFailedServingCache",
 				"GP fetch failed (%s); serving %d satellites from cached OMMs", cacheServeErr.Error(), result.SatelliteCount)
 		}
 	case !reusedCache:
 		if r.Recorder != nil {
-			r.Recorder.Eventf(eph, nil, "Normal", "GPDataFetched", "GPDataFetched", "Fetched %d satellites", result.SatelliteCount)
+			r.Recorder.Eventf(eph, nil, corev1.EventTypeNormal, "GPDataFetched", "GPDataFetched", "Fetched %d satellites", result.SatelliteCount)
 		}
 	}
 
@@ -605,12 +651,55 @@ func (r *SatelliteEphemerisReconciler) reportOrbitRegime(
 	return ""
 }
 
-// predictPasses resolves ground stations and computes pass windows.
+// handlePassPrediction runs pass prediction (when configured) and returns the
+// post-persist event notes: passNote (Normal, success) and passFailNote (Warning,
+// failure), each non-empty only on a real PassesPredicted-condition transition, so
+// the caller emits them at most once per change after the status write persists.
+func (r *SatelliteEphemerisReconciler) handlePassPrediction(
+	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, result ephemeris.GPFetchResult,
+) (passNote, passFailNote string) {
+	if eph.Spec.PassPrediction == nil || len(eph.Spec.PassPrediction.GroundStations) == 0 {
+		// Pass prediction not configured; clear stale pass windows and condition.
+		eph.Status.NextPassWindows = nil
+		meta.RemoveStatusCondition(&eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
+		return "", ""
+	}
+	note, err := r.predictPasses(ctx, eph, result)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "pass prediction failed")
+		eph.Status.NextPassWindows = nil // clear stale pass data
+		// Gate on the failure EPISODE (Status/Reason/Generation, ignoring the varying
+		// error Message) and defer the event to after the status persists (like
+		// reportOrbitRegime), so a rolled-back status update does not fire — and a
+		// message-only change does not re-fire — a PredictionFailed event.
+		failEpisode := conditionEpisodeChanged(
+			meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted),
+			metav1.ConditionFalse, "PredictionFailed", eph.Generation)
+		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionPassesPredicted,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PredictionFailed",
+			Message:            err.Error(),
+			ObservedGeneration: eph.Generation,
+		})
+		if failEpisode {
+			return "", err.Error()
+		}
+		return "", ""
+	}
+	return note, ""
+}
+
+// predictPasses resolves ground stations and computes pass windows. It sets the
+// PassesPredicted condition and RETURNS the Normal-event note the caller must emit
+// only AFTER a successful Status().Update; the note is non-empty ONLY when the
+// condition actually transitioned, so the ~3-minute cache re-propagation cadence
+// does not re-fire an identical PassesPredicted event (#179/#188).
 func (r *SatelliteEphemerisReconciler) predictPasses(
 	ctx context.Context,
 	eph *ntnv1alpha1.SatelliteEphemeris,
 	fetchResult ephemeris.GPFetchResult,
-) error {
+) (string, error) {
 	log := logf.FromContext(ctx)
 	pp := eph.Spec.PassPrediction
 
@@ -619,21 +708,21 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	for _, gsName := range pp.GroundStations {
 		gs := &ntnv1alpha1.GroundStationLifecycle{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: gsName}, gs); err != nil {
-			return fmt.Errorf("ground station %q not found: %w", gsName, err)
+			return "", fmt.Errorf("ground station %q not found: %w", gsName, err)
 		}
 		lat, err := ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Lat)
 		if err != nil {
-			return fmt.Errorf("invalid latitude for %q: %w", gsName, err)
+			return "", fmt.Errorf("invalid latitude for %q: %w", gsName, err)
 		}
 		lon, err := ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Lon)
 		if err != nil {
-			return fmt.Errorf("invalid longitude for %q: %w", gsName, err)
+			return "", fmt.Errorf("invalid longitude for %q: %w", gsName, err)
 		}
 		alt := 0.0
 		if gs.Spec.Deployment.Location.Alt != "" {
 			alt, err = ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Alt)
 			if err != nil {
-				return fmt.Errorf("invalid altitude for %q: %w", gsName, err)
+				return "", fmt.Errorf("invalid altitude for %q: %w", gsName, err)
 			}
 		}
 		stations = append(stations, ephemeris.GroundStation{
@@ -647,7 +736,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// Parse minElevation.
 	minEl, err := ephemeris.ParseElevation(pp.MinElevation)
 	if err != nil {
-		return fmt.Errorf("invalid minElevation: %w", err)
+		return "", fmt.Errorf("invalid minElevation: %w", err)
 	}
 
 	// Parse horizon.
@@ -665,7 +754,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// Run pass prediction.
 	passes, err := ephemeris.PredictPasses(fetchResult.OMMs, stations, minEl, horizon, noradFilter, fetchResult.FetchedAt)
 	if err != nil {
-		return fmt.Errorf("computing passes: %w", err)
+		return "", fmt.Errorf("computing passes: %w", err)
 	}
 
 	// Convert to CRD PassWindow format.
@@ -683,19 +772,18 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 
 	log.Info("Pass prediction completed", "passCount", len(windows), "stationCount", len(stations))
 
-	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+	msg := fmt.Sprintf("Computed %d passes over %d ground stations", len(windows), len(stations))
+	changed := meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionPassesPredicted,
 		Status:             metav1.ConditionTrue,
 		Reason:             "PredictionSucceeded",
-		Message:            fmt.Sprintf("Computed %d passes over %d ground stations", len(windows), len(stations)),
+		Message:            msg,
 		ObservedGeneration: eph.Generation,
 	})
-
-	if r.Recorder != nil {
-		r.Recorder.Eventf(eph, nil, "Normal", "PassesPredicted", "PassesPredicted", "Computed %d passes over %d ground stations", len(windows), len(stations))
+	if changed {
+		return msg, nil
 	}
-
-	return nil
+	return "", nil
 }
 
 // publicHTTPSource reports whether raw is a cleartext http:// URL whose host
@@ -735,6 +823,9 @@ func (r *SatelliteEphemerisReconciler) handleInsecureURL(
 	msg := fmt.Sprintf(
 		"cleartext http source resolves to public IP %s; use https to prevent forged OMM injection into SIB19",
 		ip)
+	insecureEpisode := conditionEpisodeChanged(
+		meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched),
+		metav1.ConditionFalse, "InsecureURL", eph.Generation)
 	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionGPDataFetched,
 		Status:             metav1.ConditionFalse,
@@ -745,8 +836,10 @@ func (r *SatelliteEphemerisReconciler) handleInsecureURL(
 	if err := r.Status().Update(ctx, eph); err != nil {
 		return ctrl.Result{}, err
 	}
-	if r.Recorder != nil {
-		r.Recorder.Eventf(eph, nil, "Warning", "InsecureURL", "InsecureURL", "%s", msg)
+	// Gate on the episode so a permanently-insecure source emits one Warning per
+	// episode, not one per (minutely) requeue.
+	if insecureEpisode && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "InsecureURL", "InsecureURL", "%s", msg)
 	}
 	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
@@ -759,6 +852,14 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 	effectiveInterval time.Duration,
 ) (ctrl.Result, error) {
 	reason, requeueAfter, returnAsError := classifyFetchError(fetchErr, effectiveInterval)
+
+	// Gate the Warning on the fetch-failure EPISODE (Status/Reason/Generation,
+	// ignoring the varying error Message) so a persistent outage — whose message
+	// flaps between e.g. "timeout after 30.001s" and "…30.013s" — emits one Warning
+	// per episode, not one per requeue.
+	fetchEpisode := conditionEpisodeChanged(
+		meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched),
+		metav1.ConditionFalse, reason, eph.Generation)
 
 	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionGPDataFetched,
@@ -784,8 +885,8 @@ func (r *SatelliteEphemerisReconciler) handleFetchError(
 		return ctrl.Result{}, err
 	}
 
-	if r.Recorder != nil {
-		r.Recorder.Eventf(eph, nil, "Warning", reason, reason, "%s", fetchErr.Error())
+	if fetchEpisode && r.Recorder != nil {
+		r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, reason, reason, "%s", fetchErr.Error())
 	}
 
 	if returnAsError {


### PR DESCRIPTION
## Summary

Tightens Kubernetes Event emission across the four reconcilers to two rules:

1. **Emit success/transition events only AFTER a successful `Status().Update`.** Events are best-effort and non-durable; `.status` is the source of truth and its writes use optimistic concurrency (they conflict and retry). An event fired before a status write that then rolls back asserts state that never became durable, and re-fires on the retry. (Failure Warning events still accompany the error return.)
2. **Gate events on a real EPISODE, not on every reconcile.** This operator uses the `events.k8s.io/v1` recorder (`mgr.GetEventRecorder`). Its correlation key (`getKey`) is type + reason + action + reporting identity + the **full regarding `ObjectReference`** + related — and `reference.GetReference` populates that reference's `resourceVersion` (client-go v0.36.2). Because these events are emitted *after* a `Status().Update` that bumps the object's `resourceVersion`, a per-reconcile event would **not** fold into one `EventSeries`; each reconcile would mint a distinct `Event` object. Gating therefore avoids both redundant Event objects and needless broadcaster/series churn — it is more necessary here, not less. Success/transition events gate on the `meta.SetStatusCondition` change; **message-varying failure paths gate on `conditionEpisodeChanged` (Status/Reason/Generation, IGNORING the Message)** so a persistent failure whose error string merely varies — `"timeout after 30.001s"` vs `"…30.013s"` — does not emit a fresh Warning every reconcile. (A few condition-specific transitions use narrower gates that fit their contract — e.g. `MetricsStale` snapshots the prior value across a fresh→stale flip, `RefreshIntervalClamped` is pre-persist — so this is not a single uniform helper across all four controllers.) Event gating is orthogonal to **metric** counting: `_errors_total` counters advance on every real failure regardless of the event gate, so rate/`increase()` alerts stay accurate (see the ntncellconfig note below).

(**N-5**) The controllers never write a CR's `.spec` (only `.status` + finalizers), so Argo CD / Flux never fight them for spec ownership. Derived state lands in `.status`; separately, the operator produces two *operator-owned outputs* — the provider-generated gNB ConfigMap (owner-referenced, labelled `app.kubernetes.io/managed-by=ntn-operators`) and runtime gNB pushes — which must **not** also be GitOps-managed. `docs/gitops.md` documents the ownership boundary and the server-side-diff/apply guidance; `README.md` links to it.

## Changes

- **New `conditionEpisodeChanged` helper** (in `internal/controller/events.go`, alongside the shared `deferredEvent` type): gates on a real episode and drops the message-only churn. Replaces the old `ephemerisPushConditionChanged` (which compared Message).
- **ntncellconfig** — `ConfigApplied` fires on every path that persists the `ConfigApplied=True` transition (push-failure early-return *and* success); `ApplyFailed`/`OwnershipConflict` and `EphemerisPushFailed` are episode-gated. **`SatSwitchIgnored`** moved out of `pushEphemerisUpdateIfNeeded` (where it rode the every-minute push-retry loop and re-warned on each persistent push failure) into `emitConfigApplied`, gated on the `configApplyChanged` episode — so it warns once per config episode, alongside the applied event.
- **ntncellconfig metric (observability fix)** — **`EphemerisPushErrorsTotal` now counts every push failure**, not once per episode. The shipped `NTNEphemerisPushFailing` alert is `increase(ntn_operators_ephemeris_push_errors_total[15m]) > 0` `for: 15m`, which only stays firing while the counter keeps advancing; the previous episode-gated `.Inc()` incremented once at outage start and let the alert resolve mid-outage while a transient gNB push kept failing (and tight-requeuing) every minute. The counter is now unconditional (mirroring `ConfigApplyErrorsTotal`) while the `EphemerisPushFailed` **Event** stays episode-gated. Permanent, non-requeuing reasons still increment once — the durable `EphemerisPushed=False` condition covers those, with a readiness gauge (`ephemeris_push_ready` 0|1, alertable regardless of requeue) as a recommended follow-up.
- **ntnslice** — `FailoverTriggered`/`Switchback` moved post-persist; `MetricsStale`/`InertTriggers` deferred via the `deferredEvent` accumulator; the **MetricsStale pointer-aliasing** bug fixed (snapshot the prior state as a value, not a slice-element pointer `SetStatusCondition` mutates in place). `InertTriggers` now gates on `conditionEpisodeChanged` (generation-aware) rather than a bare into-`False` transition, so swapping one inert trigger for another (new generation, still `False`/`InertTriggers`) re-warns once — consistent with the other failure-event gates.
- **satelliteephemeris** — `PassesPredicted`/`PredictionFailed` post-persist + gated (closes the pass-**event** churn on the ~3-minute cache re-propagation; the recompute churn of #188 is separate). `InsecureURL`, `FetchFailedServingCache`, and the fetch-error Warning are now episode-gated. **`RefreshIntervalClamped`** gains a durable condition and fires **one Warning per persisted clamp episode** during normal reconciles instead of on every ~3-minute reconcile; the clamp event is emitted pre-persist by design (the clamp is a deterministic function of the spec), so a status-update *conflict* that discards the reconcile can cause a duplicate warning on the retry — an accepted trade-off documented in the helper. The condition now records **`False`/`WithinBounds`** when the interval is valid (previously it was *removed*, which is indistinguishable from "not yet reconciled") so a consumer can tell "evaluated, no clamp" from Unknown; the episode gate makes invalid→valid→invalid a clean transition sequence. The steady-state clamp *log* also drops to `V(1)` off-episode.
- **groundstation** — `PhaseChanged` + the three firmware events deferred via the accumulator, flushed after the single status write.
- `"Warning"`/`"Normal"` literals → `corev1.EventType*`.

## Tests

- `TestConditionEpisodeChanged` — including the load-bearing case that a **message-only** condition change is the SAME episode (no re-emit).
- `TestReconcile_MetricsStaleEvent_FiresOnFreshToStaleTransition` — asserts **exactly one** event across fresh→stale→stale (transition once, steady state silent); revert-proven against the aliasing bug.
- `TestReconcile_RefreshIntervalClamped_EmitsOncePerEpisode` — asserts one clamp Warning across two reconciles.
- `TestReconcile_RefreshIntervalClamped_RecoveryContract` — locks the condition contract (True/BelowMinimum when clamped, **False/WithinBounds — never absent — when valid**) across an invalid→valid→invalid spec-edit sequence: one event per clamp, none on recovery.
- `TestReconcile_FailoverCounterNotIncrementedOnStatusConflict` — proxy changed from "an event was emitted" to "the status write attempted a failover" (now that events are post-persist), plus an assertion that **no** event fires when the failover status write conflicts — guarding against re-introducing a pre-persist emit.
- ntncellconfig Ginkgo spec *"emits SatSwitchIgnored once per spec even while the push keeps failing"* — across four reconciles against a failing push provider, `SatSwitchIgnored` fires exactly once (episode-gated) while `EphemerisPushFailed` also stays at one, proving the warning no longer rides the push-retry loop.
- `TestReconcile_InertTriggers_EpisodePerGeneration` — one Warning on gen1 (inert `latency`), **zero** on a steady-state re-reconcile, and one **new** Warning after gen2 swaps in a different inert trigger (`packetLoss`) — proving the generation-aware episode gate.
- ntncellconfig Ginkgo spec *"counts every ephemeris push failure while emitting the Warning once per episode"* — across four reconciles against an always-failing push, `EphemerisPushErrorsTotal` advances once **per push attempt** (asserted equal to `mock.EphemerisCalls`, ≥ 2) while the `EphemerisPushFailed` Event fires exactly once — locking the metric/event separation so the outage alert stays continuous.

## Verification

`make test` (envtest), `make test-e2e` (local Kind), `golangci-lint` (**0**), `gofmt`, `go test -race` — all green. Multiple independent adversarial-review rounds converged. The recorder rationale was verified against the client-go v0.36.2 source (`getKey` keys on the full regarding `ObjectReference`, and `GetReference` carries `resourceVersion`), so the event-hygiene design description is now precise rather than approximate.

`CHANGELOG.md` records the new `RefreshIntervalClamped` condition (Added), the event-hygiene behavior change (Changed), and the `EphemerisPushErrorsTotal` per-failure counting fix (Fixed).

Scope note — reviewer-found items folded across revisions: (1) `SatSwitchIgnored` had ridden the every-minute push-retry loop → now gated on the config-apply episode; (2) `RefreshIntervalClamped`'s valid path removed the condition instead of recording `False` → now `False`/`WithinBounds`; (3) the recorder wording ("would fold into one series") was imprecise → corrected to the `resourceVersion`-in-`ObjectReference` reality; (4) `docs/gitops.md` overstated "everything lands in `.status`" → now documents the operator-owned ConfigMap / runtime-push ownership boundary; (5) `InertTriggers` used a bare transition gate → now generation-aware like the other failure events. **This latest revision** adds the P1 observability fix — **`EphemerisPushErrorsTotal` was episode-gated, which would let `NTNEphemerisPushFailing` resolve mid-outage; it now counts per failure** — plus three doc-precision fixes (CHANGELOG's "emit only after persist" now notes the clamp pre-persist exception; the GitOps ConfigMap-exclusion advice is now source/path-level, not a non-portable label filter; the CRD-default "stored" claim now notes read-time defaults are not persisted until the next update). All are covered by the tests above or by the doc/changelog updates.
