### PR TITLE
release: v0.7.0 — audit season (event/GitOps hygiene, validation, observability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-12
+
+The audit season: runtime-resilience, validation, event/GitOps, and observability
+hardening across all four controllers (folds the #198–#215 remediation work).
+Backward-incompatible in two ways — read the Upgrade notes before upgrading.
+
+### Upgrade notes
+
+- **Breaking: minimum Kubernetes version is now 1.31.** The
+  `provider.remoteControl.endpoint` CEL validation uses the `isIP()` library, which
+  is available only from Kubernetes 1.31; `Chart.yaml` `kubeVersion` is `>=1.31.0-0`
+  and installing on an older cluster is unsupported.
+- **Breaking: tighter spec validation may reject previously-accepted objects.** Every
+  free-form string now carries a `maxLength` and every unbounded list a `maxItems`, so
+  an object authored under ≤ 0.6.0 that exceeds a new bound is rejected on its next
+  apply/edit (unset fields are unaffected). Review long free-text and large-list fields
+  before upgrading.
+- **CRDs upgrade separately on Option A (`--set crd.enable=false`).** Run `make install`
+  at the new tag **before** `helm upgrade`, or the new operator runs against the old
+  CRD schema. See [RELEASING.md](RELEASING.md) § Rollback.
+
 ### Added
 
 - **`RefreshIntervalClamped` condition on `SatelliteEphemeris`.** Surfaces whether

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 IMAGE_TAG_BASE ?= ghcr.io/thc1006/ntn-operators
-VERSION ?= 0.6.0
+VERSION ?= 0.7.0
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 .PHONY: bundle

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Kubernetes-native management framework for Non-Terrestrial Networks (NTN). Declaratively manage satellite constellations, ground stations, NTN cell configurations, and terrestrial-satellite failover — all through standard Kubernetes CRDs.
 
-> **Latest release:** [v0.6.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.6.0) — cluster-scope NTN orchestration foundation: gNB-parseable OCUDU config, runtime NTN push (OCUDU !798) with SGP4-propagated ECEF → SIB19, SatelliteEphemeris → multi-NTNCellConfig fan-out with off-cycle epoch freshness, namespace-consistent Prometheus metrics, and Go 1.26.4 (HIGH stdlib CVE fixes). See [CHANGELOG.md](CHANGELOG.md) for the full delta.
+> **Latest release:** [v0.7.0](https://github.com/thc1006/ntn-operators/releases/tag/v0.7.0) — audit-season hardening across all four controllers: Kubernetes Event & GitOps hygiene (emit-after-persist, episode-gated), CEL validation tightening (`maxLength`/`maxItems`, hardened `remoteControl.endpoint` host checks), the new `RefreshIntervalClamped` condition, and per-failure runtime-push error counting so the outage alert stays continuous. ⚠ **Breaking:** raises the minimum Kubernetes version to **1.31** (endpoint CEL uses `isIP()`) and may reject previously-accepted over-long or unbounded spec values on next apply. See [CHANGELOG.md](CHANGELOG.md) for the full delta.
 
 ## Custom Resource Definitions
 

--- a/bundle/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/bundle/manifests/ntn-operators.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
     # / clickhouse 0.26.3 all carry this annotation).
     certified: "false"
-    containerImage: ghcr.io/thc1006/ntn-operators:v0.6.0
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.7.0
     repository: https://github.com/thc1006/ntn-operators
     # description: short tile text shown on operatorhub.io marketplace cards.
     # Hard limit is 135 chars per k8s-operatorhub/community-operators
@@ -61,9 +61,9 @@ metadata:
     description: "Kubernetes-native NTN: satellite ephemeris, ground station lifecycle, NTN cell config, terrestrial-satellite slice failover."
     # createdAt: ISO-8601 timestamp of the bundle's published release.
     # Bump on every version cut (approximate; set at release-prep time).
-    createdAt: "2026-07-09T00:00:00Z"
+    createdAt: "2026-07-12T00:00:00Z"
     support: thc1006
-  name: ntn-operators.v0.6.0
+  name: ntn-operators.v0.7.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -153,7 +153,7 @@ spec:
               spec:
                 containers:
                   - name: manager
-                    image: ghcr.io/thc1006/ntn-operators:v0.6.0
+                    image: ghcr.io/thc1006/ntn-operators:v0.7.0
                     args:
                       - --leader-elect
                       - --health-probe-bind-address=:8081
@@ -226,5 +226,5 @@ spec:
   # skipRange (not replaces): the OperatorHub community-operators semver-mode CI
   # rejects `replaces`/`skips`, so declare the upgrade edge via skipRange. This
   # range covers all prior published versions (v0.4.0 #8018, v0.5.0 #8299).
-  skipRange: "<0.6.0"
-  version: 0.6.0
+  skipRange: "<0.7.0"
+  version: 0.7.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/thc1006/ntn-operators
-  newTag: v0.6.0
+  newTag: v0.7.0

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: ntn-operators
 description: Kubernetes Operators for Non-Terrestrial Network (NTN) management — satellite ephemeris, ground station lifecycle, cell configuration, and slice failover.
 type: application
 
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 
 # The CRD validation uses the CEL IP-address library (isIP), available since
 # Kubernetes 1.31; -0 admits vendor/pre-release version strings (e.g. GKE/EKS).

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -25,7 +25,7 @@ This chart installs four Custom Resource Definitions:
 |-----|------|---------|-------------|
 | `manager.replicas` | int | `1` | Number of controller manager replicas |
 | `manager.image.repository` | string | `ghcr.io/thc1006/ntn-operators` | Manager container image |
-| `manager.image.tag` | string | `v0.6.0` | Image tag |
+| `manager.image.tag` | string | `v0.7.0` | Image tag |
 | `manager.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `manager.args` | list | `[--leader-elect]` | Extra args passed to the manager binary |
 | `manager.env` | list | `[]` | Environment variables |

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -17,7 +17,7 @@ manager:
 
   image:
     repository: ghcr.io/thc1006/ntn-operators
-    tag: v0.6.0
+    tag: v0.7.0
     pullPolicy: IfNotPresent
 
   ## Extra arguments passed to the manager binary.


### PR DESCRIPTION
## What

Release-prep for **v0.7.0**, folding the completed audit season (#198–#215) into a cut release.

## Why v0.7.0 (minor), not v0.6.1 (patch)

The merged audit season is **backward-incompatible in two ways**, so semver calls for a minor bump, not a patch:

1. **Minimum Kubernetes version raised to 1.31.** `provider.remoteControl.endpoint` CEL uses `isIP()` (K8s 1.31+); `Chart.yaml` `kubeVersion` is now `>=1.31.0-0`. Clusters < 1.31 lose support.
2. **Validation tightening may reject previously-accepted objects.** Every free-form string gained a `maxLength` and every unbounded list a `maxItems`; an object authored under ≤ 0.6.0 that exceeds a bound is rejected on its next apply.

Shipping these as a "patch" would mislead users into treating it as a safe drop-in. (The feature work earmarked for v0.7 — #162 remainder, #188 — shifts to v0.8.0.)

## Stamps bumped

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.7.0] - 2026-07-12` + Upgrade notes; fresh empty `[Unreleased]` |
| `dist/chart/Chart.yaml` | `version`/`appVersion` → `0.7.0` (`kubeVersion >=1.31.0-0` unchanged) |
| `dist/chart/values.yaml`, `config/manager/kustomization.yaml` | image tag → `v0.7.0` |
| `Makefile`, `dist/chart/README.md` | `VERSION` / values table → `0.7.0` |
| `bundle/manifests/…csv` | name/version/containerImage/image → `v0.7.0`, `skipRange "<0.7.0"`, `createdAt` (still `skipRange`, not `replaces`) |
| `README.md` | Latest-release banner → `v0.7.0` with the breaking-change note |

## Release plan (after merge)

1. `gh workflow run release.yml --ref main` **dry-run** (build + Trivy, no publish).
2. Tag `v0.7.0` → real release (ghcr image + Helm chart + SBOM + cosign + GitHub Release).
3. Separate follow-up: OperatorHub community-operators v0.7.0 bundle submission.

`release.yml` derives the published image + chart version from the git tag (it rewrites `Chart.yaml` at package time), so these in-repo stamps keep `main` internally consistent and prep the OperatorHub bundle.

## Verification

`helm lint dist/chart` clean; no stray `0.6.0` stamp remains; docs/metadata-only (no Go code changed).