### PR TITLE
feat(metrics): readiness gauges for ephemeris push & GP fetch (#216)

### DIFF
--- a/dist/chart/templates/monitoring/prometheusrule.yaml
+++ b/dist/chart/templates/monitoring/prometheusrule.yaml
@@ -46,6 +46,18 @@ spec:
           annotations:
             summary: "SatelliteEphemeris {{`{{ $labels.namespace }}/{{ $labels.ephemeris }}`}} tracks zero satellites"
             description: "The latest GP fetch produced no satellites for 30m."
+        # The GP pipeline has NEVER produced usable element data (fetcher setup /
+        # credentials failing, or every fetch erroring with no cache). Unlike
+        # gp_satellite_count == 0, this fires on a cold start that never fetched
+        # successfully — that counter's series is absent, so `== 0` never matches.
+        - alert: NTNGPFetchNotReady
+          expr: ntn_operators_gp_fetch_ready == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SatelliteEphemeris {{`{{ $labels.namespace }}/{{ $labels.ephemeris }}`}} has no usable GP data"
+            description: "No usable element set (fresh fetch, 304, or cache) has been obtained for 30m — the GP pipeline may never have come up."
     - name: ntn-operators.gnb-push
       rules:
         # Runtime NTN ephemeris push to the gNB is failing (findings.md I-19). This
@@ -58,6 +70,18 @@ spec:
           annotations:
             summary: "NTNCellConfig {{`{{ $labels.namespace }}/{{ $labels.config }}`}} ephemeris push is failing ({{`{{ $labels.reason }}`}})"
             description: "Runtime NTN ephemeris push to the gNB has failed in the last 15m."
+        # The push has been failing continuously — catches PERMANENT reasons
+        # (EphemerisRefNotFound / PayloadMissing / EphemerisStale / ProviderPushRejected)
+        # that do not requeue, so the per-failure counter above increments only once and
+        # its rate alert decays. The gauge holds 0 across the whole outage regardless.
+        - alert: NTNEphemerisPushNotReady
+          expr: ntn_operators_ephemeris_push_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NTNCellConfig {{`{{ $labels.namespace }}/{{ $labels.config }}`}} ephemeris push is not ready"
+            description: "Runtime NTN ephemeris push to the gNB has been failing for 15m (covers permanent, non-requeuing failures the rate alert misses)."
         # Static provider config apply is erroring.
         - alert: NTNConfigApplyErrors
           expr: increase(ntn_operators_config_apply_errors_total[15m]) > 0

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -24,9 +24,11 @@ Metric → alert map:
 |---|---|---|
 | `NTNEphemerisEpochStale` | `ntn_operators_ephemeris_epoch_stale_count > 0` | 15m |
 | `NTNEphemerisPushFailing` | `increase(ntn_operators_ephemeris_push_errors_total[15m]) > 0` | 15m |
+| `NTNEphemerisPushNotReady` | `ntn_operators_ephemeris_push_ready == 0` | 15m |
 | `NTNSliceFailoverFlapping` | `increase(ntn_operators_failover_total[15m]) > 4` | 5m |
 | `NTNConfigApplyErrors` | `increase(ntn_operators_config_apply_errors_total[15m]) > 0` | 15m |
 | `NTNNoSatellitesTracked` | `ntn_operators_gp_satellite_count == 0` | 30m |
+| `NTNGPFetchNotReady` | `ntn_operators_gp_fetch_ready == 0` | 30m |
 | `NTNDeepSpaceElementsRejected` | `ntn_operators_gp_deep_space_rejected_count > 0` | 15m |
 | `NTNControllerReconcileErrors` | `sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m])) > 0.1` | 15m |
 
@@ -125,6 +127,26 @@ owner (stale/missing state).
 
 ---
 
+## NTNEphemerisPushNotReady
+
+**Expr:** `ntn_operators_ephemeris_push_ready == 0` for 15m.
+
+The runtime NTN ephemeris push to the gNB has been failing continuously for 15m.
+This is the durable companion to **NTNEphemerisPushFailing**: that alert uses
+`increase(...errors_total[15m])`, which only sustains while a *transient* failure
+tight-requeues each minute. A **permanent** reason that does not requeue
+(`EphemerisRefNotFound`, `EphemerisPayloadMissing`, `EphemerisStale`,
+`ProviderPushRejected`) increments the counter once, so this gauge — held at 0 for
+the whole outage — is what fires for it.
+
+**Triage:** read the `EphemerisPushed=False` condition on the `NTNCellConfig` for
+the reason (`kubectl get ntncellconfig <config> -n "$NS" -o jsonpath='{.status.conditions}'`),
+then follow the same reason table as **NTNEphemerisPushFailing**. A gauge stuck at
+0 with no counter movement points at a permanent (config/state) cause, not a
+transient reachability blip.
+
+---
+
 ## NTNSliceFailoverFlapping
 
 **Fires when** more than 4 path switches occur in 15m. Labels: `namespace`,
@@ -197,6 +219,22 @@ its satellite path as unavailable. **Diagnose:** SatelliteEphemeris
 `GPDataFetched` / `GPDataParsed`, the source URL, and `spec.passPrediction`'s
 NORAD filter (a filter matching nothing yields zero). **Mitigate:** fix the
 source or widen the filter. **Escalate** to the ephemeris data owner.
+
+---
+
+## NTNGPFetchNotReady
+
+**Fires when** `ntn_operators_gp_fetch_ready == 0` for 30m — no usable element set
+(fresh fetch, 304, or served cache) has been obtained. **Why this and not
+NTNNoSatellitesTracked:** `gp_satellite_count == 0` cannot fire on a cold start
+that has *never* fetched successfully — the counter series is absent and PromQL
+`== 0` never matches an absent series. `gp_fetch_ready` is set to 0 on the first
+failed reconcile, so it catches a pipeline that never came up (bad credentials
+Secret, DNS/egress blocked, an insecure `http://` source refused, or the source
+persistently erroring with no cache). **Diagnose:** the SatelliteEphemeris
+`GPDataFetched` condition reason (`FetcherSetupFailed`, `InsecureURL`,
+`FetchFailed`, `AuthFailed`, `RateLimited`), then network egress / credentials /
+source URL. **Escalate** to the ephemeris data owner or the platform (egress).
 
 ---
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -311,6 +311,9 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Keep ConfigApplied semantics independent from ephemeris push status.
 	if cc.Spec.EphemerisRef == "" {
 		meta.RemoveStatusCondition(&cc.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+		// No runtime push configured: clear any readiness series from a prior spec
+		// that did configure one, so a stale 0/1 does not linger and misfire the alert.
+		ntnmetrics.EphemerisPushReady.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 	} else {
 		pushed, marker, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, spec, prov)
 		if err != nil {
@@ -352,6 +355,12 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			ntnmetrics.EphemerisPushErrorsTotal.With(prometheus.Labels{
 				"namespace": cc.Namespace, "config": cc.Name, "reason": reason,
 			}).Inc()
+			// Readiness gauge: 0 while the push is failing. Unlike the counter, this
+			// holds across a PERMANENT (non-requeuing) failure, so `push_ready == 0 for
+			// 15m` alerts even when the counter stops advancing (issue #216).
+			ntnmetrics.EphemerisPushReady.With(prometheus.Labels{
+				"namespace": cc.Namespace, "config": cc.Name,
+			}).Set(0)
 			// The Event stays episode-gated (once per outage) to keep the Event stream
 			// legible; the counter above carries the per-failure signal.
 			if conditionChanged && r.Recorder != nil {
@@ -371,6 +380,12 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				ObservedGeneration: cc.Generation,
 			})
 		}
+		// Reaching here means the push did not error (the failure branch returns
+		// early), so the runtime push is healthy — freshly pushed or already up to
+		// date. Mark ready=1 (this also clears a prior 0 once the outage recovers).
+		ntnmetrics.EphemerisPushReady.With(prometheus.Labels{
+			"namespace": cc.Namespace, "config": cc.Name,
+		}).Set(1)
 	}
 
 	if err := r.Status().Update(ctx, cc); err != nil {
@@ -398,6 +413,7 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 		// accumulate dead series across create/delete churn (idempotent).
 		ntnmetrics.ConfigApplyErrorsTotal.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		ntnmetrics.EphemerisPushErrorsTotal.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
+		ntnmetrics.EphemerisPushReady.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		if controllerutil.ContainsFinalizer(cc, finalizerName) {
 			if prov == nil {
 				// Best-effort cleanup using Status.ConfigMapRef when provider is missing.

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -698,6 +698,28 @@ var _ = Describe("NTNCellConfig Controller", func() {
 				"EphemerisPushFailed Event must stay episode-gated across the failing requeues")
 		})
 
+		It("holds ephemeris_push_ready at 0 through the outage and returns it to 1 on recovery", func() {
+			createReferencedEphemeris()
+			createCellConfig()
+			labels := prometheus.Labels{"namespace": namespace, "config": cellName}
+
+			// Push keeps failing → readiness 0. Unlike the per-failure counter, this
+			// holds even for a PERMANENT (non-requeuing) reason, so the companion
+			// `ephemeris_push_ready == 0 for 15m` alert fires where the rate alert can't.
+			failing := newReconciler(&provider.MockProvider{EphemerisErr: errors.New("runtime push failed")})
+			for range 2 {
+				_, _ = failing.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			}
+			Expect(testutil.ToFloat64(ntnmetrics.EphemerisPushReady.With(labels))).To(Equal(float64(0)),
+				"push_ready must be 0 while the runtime push is failing")
+
+			// A healthy push → readiness back to 1.
+			healthy := newReconciler(&provider.MockProvider{})
+			_, _ = healthy.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(testutil.ToFloat64(ntnmetrics.EphemerisPushReady.With(labels))).To(Equal(float64(1)),
+				"push_ready must return to 1 once the push recovers")
+		})
+
 		It("should avoid tight requeue when ephemerisRef does not exist", func() {
 			createCellConfig()
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -171,6 +171,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			ntnmetrics.GPSatelliteCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.GPDeepSpaceRejectedCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.EphemerisEpochStaleCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.GPFetchReady.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			r.ommCache.Delete(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -194,6 +195,10 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			Message:            fetcherErr.Error(),
 			ObservedGeneration: eph.Generation,
 		})
+		// No usable GP data this cycle → readiness 0. Holds across a persistent
+		// setup failure so `gp_fetch_ready == 0` alerts even on a never-fetched cold
+		// start, where `gp_satellite_count == 0` cannot (absent series).
+		ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
 		if err := r.Status().Update(ctx, eph); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -209,6 +214,10 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	now := time.Now()
 	outcome, earlyResult, earlyErr := r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
 	if earlyResult != nil {
+		// obtainOMMs only early-returns on no-usable-data outcomes: a refused insecure
+		// URL, or a fetch error with no cache to fall back on. Readiness 0 either way
+		// (served-cache and fresh/304 do NOT early-return — they reach the 1 below).
+		ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
 		return *earlyResult, earlyErr
 	}
 	result := outcome.result
@@ -231,6 +240,9 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	eph.Status.SatelliteCount = result.SatelliteCount
 	eph.Status.LastUpdated = &metav1.Time{Time: result.FetchedAt}
 	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(result.SatelliteCount))
+	// Reaching here means usable GP data was obtained (fresh fetch, 304, or served
+	// cache) — readiness 1. This also clears a prior 0 once the pipeline recovers.
+	ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(1)
 
 	// Snapshot (before the switch mutates it) whether serve-from-cache is a NEW
 	// episode, so its Warning fires once per outage — not on every short-cadence

--- a/internal/controller/satelliteephemeris_fetchready_test.go
+++ b/internal/controller/satelliteephemeris_fetchready_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+)
+
+// TestReconcile_GPFetchReady_TracksUsableData pins the F5 gap: gp_satellite_count == 0
+// cannot alert on a cold start that has NEVER fetched (the series is absent, and
+// PromQL `== 0` never matches an absent series). gp_fetch_ready is set to 0 on that
+// first failed reconcile, so `gp_fetch_ready == 0 for N` catches a pipeline that never
+// came up, and returns to 1 once a fetch (or cache serve) yields usable data.
+func TestReconcile_GPFetchReady_TracksUsableData(t *testing.T) {
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-fetchready", Namespace: "default"},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	fetcher := &mockGPFetcher{err: errors.New("connection refused")}
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10), Fetcher: fetcher,
+	}
+	key := types.NamespacedName{Name: "eph-fetchready", Namespace: "default"}
+	labels := prometheus.Labels{"namespace": "default", "ephemeris": "eph-fetchready"}
+
+	// 1) Cold start, fetch fails, no cache to fall back on → readiness 0. This is the
+	// never-fetched case gp_satellite_count == 0 cannot alert on.
+	_, _ = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	if got := testutil.ToFloat64(ntnmetrics.GPFetchReady.With(labels)); got != 0 {
+		t.Fatalf("failed cold-start fetch must set gp_fetch_ready=0, got %v", got)
+	}
+
+	// 2) The fetch recovers → usable data → readiness 1 (clears the prior 0).
+	fetcher.err = nil
+	fetcher.result = ephemeris.GPFetchResult{SatelliteCount: 1, FetchedAt: time.Now()}
+	_, _ = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	if got := testutil.ToFloat64(ntnmetrics.GPFetchReady.With(labels)); got != 1 {
+		t.Fatalf("recovered fetch must set gp_fetch_ready=1, got %v", got)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -122,6 +122,23 @@ var (
 		[]string{"namespace", "ephemeris"},
 	)
 
+	// GPFetchReady is 1 when the latest reconcile obtained usable GP data (a fresh
+	// fetch, a 304 Not Modified, or a served cache) and 0 when it could not (fetcher
+	// setup failed, the fetch errored with no cache to fall back on, or an insecure
+	// URL was refused). It is the alertable companion to GPSatelliteCount:
+	// `gp_satellite_count == 0` cannot fire on a cold start that has NEVER fetched
+	// (the series is absent, and PromQL `== 0` never matches an absent series), but
+	// this gauge is set to 0 on that first failed reconcile, so `gp_fetch_ready == 0`
+	// for N minutes catches a GP pipeline that has never come up. Same
+	// namespace+ephemeris keying and delete-on-CR-removal as GPSatelliteCount.
+	GPFetchReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ntn_operators_gp_fetch_ready",
+			Help: "1 if the latest GP reconcile obtained usable element-set data (fresh/304/cache), 0 if it failed.",
+		},
+		[]string{"namespace", "ephemeris"},
+	)
+
 	// EphemerisPushErrorsTotal counts runtime NTN-ephemeris push failures to the
 	// gNB, split by reason (findings.md I-19). ConfigApplyErrorsTotal covers only
 	// the static ConfigMap apply path, leaving the v0.6 runtime WebSocket push
@@ -132,6 +149,26 @@ var (
 			Help: "Total runtime NTN ephemeris push failures to the gNB, by reason.",
 		},
 		[]string{"namespace", "config", "reason"},
+	)
+
+	// EphemerisPushReady is 1 when the CR's runtime NTN ephemeris push to the gNB is
+	// currently healthy (pushed, already up to date, or no push failure this cycle)
+	// and 0 when the last push failed. EphemerisPushErrorsTotal is a per-failure
+	// COUNTER, so its rate alert (`increase(...[15m]) > 0`) only sustains while a
+	// TRANSIENT push keeps tight-requeuing every minute; a PERMANENT reason
+	// (EphemerisRefNotFound / EphemerisPayloadMissing / EphemerisStale /
+	// ProviderPushRejected) does not requeue and increments the counter only once, so
+	// the rate alert decays after the window. This gauge holds 0 across the whole
+	// outage regardless of requeue, so `ephemeris_push_ready == 0` for N minutes
+	// alerts on the permanent push failures the counter cannot (issue #216). Emitted
+	// only for CRs that configure a runtime push; keyed namespace+config, deleted on
+	// CR removal (and cleared when a CR stops configuring a push).
+	EphemerisPushReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ntn_operators_ephemeris_push_ready",
+			Help: "1 if the CR's runtime NTN ephemeris push to the gNB is currently healthy, 0 if the last push failed.",
+		},
+		[]string{"namespace", "config"},
 	)
 
 	// ReaderQueryDuration measures how long a single PromQL fetch made
@@ -197,7 +234,9 @@ func init() {
 		GPSatelliteCount,
 		GPDeepSpaceRejectedCount,
 		EphemerisEpochStaleCount,
+		GPFetchReady,
 		EphemerisPushErrorsTotal,
+		EphemerisPushReady,
 		ReaderQueryDuration,
 		ReaderErrorsTotal,
 		ReaderStaleUsedTotal,

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -34,7 +34,9 @@ func TestMetricsRegistered(t *testing.T) {
 	GPSatelliteCount.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
 	GPDeepSpaceRejectedCount.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
 	EphemerisEpochStaleCount.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
+	GPFetchReady.With(prometheus.Labels{"namespace": "_", "ephemeris": "_"}).Set(0)
 	EphemerisPushErrorsTotal.With(prometheus.Labels{"namespace": "_", "config": "_", "reason": "_"}).Add(0)
+	EphemerisPushReady.With(prometheus.Labels{"namespace": "_", "config": "_"}).Set(0)
 	ReaderQueryDuration.With(prometheus.Labels{"source": "_", "outcome": "_"}).Observe(0)
 	ReaderErrorsTotal.With(prometheus.Labels{"source": "_", "reason": "_"}).Add(0)
 	ReaderStaleUsedTotal.With(prometheus.Labels{"namespace": "_", "name": "_"}).Add(0)
@@ -53,7 +55,9 @@ func TestMetricsRegistered(t *testing.T) {
 		"ntn_operators_gp_satellite_count",
 		"ntn_operators_gp_deep_space_rejected_count",
 		"ntn_operators_ephemeris_epoch_stale_count",
+		"ntn_operators_gp_fetch_ready",
 		"ntn_operators_ephemeris_push_errors_total",
+		"ntn_operators_ephemeris_push_ready",
 		"ntn_operators_reader_query_duration_seconds",
 		"ntn_operators_reader_errors_total",
 		"ntn_operators_reader_stale_value_used_total",


### PR DESCRIPTION
## Summary

Two `0|1` readiness gauges that alert on failure states the existing rate/count alerts **structurally cannot** — both surfaced by the recent adversarial reviews.

## `ntn_operators_ephemeris_push_ready{namespace,config}` — closes #216

`NTNEphemerisPushFailing` is `increase(ntn_operators_ephemeris_push_errors_total[15m]) > 0` `for 15m`. That only sustains while a **transient** push tight-requeues each minute. A **permanent** reason (`EphemerisRefNotFound` / `EphemerisPayloadMissing` / `EphemerisStale` / `ProviderPushRejected`) does **not** requeue, so the per-failure counter (shipped in #215) increments once and the rate alert decays after the window. This gauge holds `0` across the whole outage regardless of requeue. New alert **`NTNEphemerisPushNotReady`** (`== 0 for 15m`).

## `ntn_operators_gp_fetch_ready{namespace,ephemeris}` — from the #202 review (F5)

`NTNNoSatellitesTracked` is `gp_satellite_count == 0`. `GPSatelliteCount` is only `Set` after a **successful** fetch, so a cold start that has **never** fetched has no series — and PromQL `== 0` never matches an absent series, so the pipeline can be dark and unalerted. This gauge is set to `0` on the first failed reconcile (fetcher setup failed, insecure URL refused, or fetch errored with no cache), so `== 0 for 30m` catches a never-came-up pipeline. New alert **`NTNGPFetchNotReady`**.

## Semantics

- Both gauges `Set(1)` on the healthy path (fresh/304/served-cache for fetch; pushed/up-to-date for push), which also **clears a prior `0` on recovery**.
- Both are `DeletePartialMatch`'d on CR deletion (finalizer), and `push_ready` is additionally cleared when a CR stops configuring a runtime push (so a stale `0/1` can't linger and misfire).
- `gp_fetch_ready` is `1` on a **served cache** (fetch failing but data usable) — the "fetch is failing" signal is the separate `GPDataFetched=False`/`FetchFailedServingCache` condition + `EphemerisEpochStale`; this gauge means "has usable data at all", which is what the cold-start gap needs.

## Not in scope (tracked / deferred)

Per the review triage, the heavier #202-F5 companion (a `gp_last_success_timestamp` for staleness) and the permanent-reason *push* readiness are both covered by the two gauges here. The broader observability follow-ups stay in #216.

## Verification

`make test` (envtest, controller cov 87.1%, metrics 100%), `golangci-lint` (**0**), `gofmt`, `helm lint`, `go test -race` — all green.

Tests: registration of both gauges; `GPFetchReady` fail→0 / recover→1; `EphemerisPushReady` outage→0 / recover→1 (envtest Ginkgo spec).