### PR TITLE
security(runtime-push): refuse handshake redirects + harden remoteControl.tls Secrets (mitigation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Runtime NTN push no longer follows redirects on the WebSocket handshake.** A
+  gNB/proxy `302` from `wss://` to a plaintext `http://` on the same host could
+  otherwise make the client re-send the `Authorization: Bearer` shared secret over
+  cleartext (`coder/websocket` follows redirects by default, and Go preserves the
+  header on a same-host redirect). The handshake now refuses redirects
+  (`CheckRedirect` → `ErrUseLastResponse`), mutation-tested against the leak.
+- **`remoteControl.tls` Secret handling hardened (partial confused-deputy mitigation).**
+  The operator reads the referenced Secret with its own cluster-wide `secrets get`, on
+  behalf of whoever authored the `NTNCellConfig`; a principal who can write the CR (but
+  not read Secrets) could otherwise point the operator at an arbitrary namespace Secret
+  and have its `token` shipped to a CR-controlled endpoint. Two gates raise the bar: the
+  Secret's **owner** must label it `ntn.operators.dev/remote-control-credential: "true"`,
+  and a `kubernetes.io/service-account-token` / `bootstrap.kubernetes.io/token` Secret is
+  refused outright. ⚠ **This is attack-surface reduction, not an authorization boundary:**
+  the label is namespace-scoped (any `NTNCellConfig` in the namespace may use a labelled
+  Secret), a `patch`-only principal could add the label to a Secret it cannot read, and
+  the type check does not stop an `Opaque` Secret from holding some other bearer token. A
+  real per-CR/endpoint authorization control (SubjectAccessReview or a grant resource) is
+  a tracked follow-up.
+- **Refused handshake redirects and other definitive HTTP handshake responses (3xx/4xx)
+  are classified as permanent**, not transient — so the runtime push does not tight-requeue
+  a redirect/auth rejection every minute.
+- **Credential-resolution failures no longer leak Secret existence/type to the CR.** The
+  `EphemerisPushed=False` condition/event now carries a uniform "credential unavailable or
+  not authorized" message; the specific cause is logged for the operator only (closes a
+  Secret existence/type oracle for a CR-writer without `secrets get`).
+
+### Upgrade notes
+
+- **Breaking (`remoteControl.tls`):** an existing remote-control credential Secret must
+  gain the label `ntn.operators.dev/remote-control-credential: "true"` (set by the
+  Secret owner), or the runtime push reports `EphemerisPushed=False` with reason
+  `RemoteControlConfigInvalid` (a permanent, non-tight-requeuing error that clears when
+  the Secret is fixed). Add the label before upgrading. Note the opt-in is
+  namespace-scoped; a per-CR grant is a future hardening.
+
 ## [0.7.0] - 2026-07-12
 
 The audit season: runtime-resilience, validation, event/GitOps, and observability

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -123,6 +123,14 @@ type RemoteControlTLS struct {
 	// shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
 	// "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
 	// replayable, so it is only ever sent over the wss:// (TLS) connection.
+	//
+	// SECURITY: the Secret's owner must opt it in for remote-control use with the label
+	// "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+	// credential (a service-account or bootstrap-token Secret) is refused. This is a
+	// mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+	// ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+	// NTNCellConfig write to principals who should not be able to use every labelled
+	// remote-control credential in that namespace.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	SecretName string `json:"secretName"`

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -886,6 +886,14 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+
+                              SECURITY: the Secret's owner must opt it in for remote-control use with the label
+                              "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+                              credential (a service-account or bootstrap-token Secret) is refused. This is a
+                              mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+                              ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+                              NTNCellConfig write to principals who should not be able to use every labelled
+                              remote-control credential in that namespace.
                             maxLength: 253
                             minLength: 1
                             type: string

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -886,6 +886,14 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+
+                              SECURITY: the Secret's owner must opt it in for remote-control use with the label
+                              "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+                              credential (a service-account or bootstrap-token Secret) is refused. This is a
+                              mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+                              ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+                              NTNCellConfig write to principals who should not be able to use every labelled
+                              remote-control credential in that namespace.
                             maxLength: 253
                             minLength: 1
                             type: string

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -889,6 +889,14 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+
+                              SECURITY: the Secret's owner must opt it in for remote-control use with the label
+                              "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+                              credential (a service-account or bootstrap-token Secret) is refused. This is a
+                              mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+                              ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+                              NTNCellConfig write to principals who should not be able to use every labelled
+                              remote-control credential in that namespace.
                             maxLength: 253
                             minLength: 1
                             type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1938,7 +1938,15 @@ trust and auth material. Recognized keys: "ca.crt" (PEM CA to verify the
 gNB/proxy server certificate — omit to use the system roots), "token" (the
 shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
 "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
-replayable, so it is only ever sent over the wss:// (TLS) connection.<br/>
+replayable, so it is only ever sent over the wss:// (TLS) connection.
+
+SECURITY: the Secret's owner must opt it in for remote-control use with the label
+"ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+credential (a service-account or bootstrap-token Secret) is refused. This is a
+mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+NTNCellConfig write to principals who should not be able to use every labelled
+remote-control credential in that namespace.<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -70,6 +70,7 @@ const (
 	ephemerisReasonProviderPushFailed   = "ProviderPushFailed"
 	ephemerisReasonProviderPushRejected = "ProviderPushRejected"
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
+	ephemerisReasonRemoteControlConfig  = "RemoteControlConfigInvalid"
 )
 
 // epochSkewMargin is how far in the future a propagated epoch must be to be worth
@@ -118,6 +119,7 @@ func ephemerisPushShouldRequeue(reason string) bool {
 	case ephemerisReasonRefNotFound,
 		ephemerisReasonPayloadMissing,
 		ephemerisReasonEphemerisStale,
+		ephemerisReasonRemoteControlConfig,
 		ephemerisReasonProviderPushRejected:
 		// These clear only on an external change — a spec edit (generation bump)
 		// or a SatelliteEphemeris refresh (new marker) — both of which re-trigger
@@ -623,7 +625,19 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
 	tlsConfig, authToken, tlsErr := r.resolveRemoteControlTLS(ctx, eph.Namespace, spec.Provider.RemoteControl)
 	if tlsErr != nil {
-		return false, marker, newEphemerisPushError(ephemerisReasonProviderPushFailed, tlsErr)
+		// A deterministic credential/config error (wrong Secret type, missing opt-in
+		// label, malformed cert) is PERMANENT — it clears only on a Secret/spec edit,
+		// which re-triggers reconcile, so classify it non-requeuing instead of hammering
+		// the apiserver every minute. A transient Secret read error stays requeuing.
+		reason := ephemerisReasonProviderPushFailed
+		if errors.Is(tlsErr, errRemoteControlCredentialInvalid) {
+			reason = ephemerisReasonRemoteControlConfig
+		}
+		// Log the specific cause for the operator; surface only a uniform message on the
+		// CR (see errRemoteControlCredentialUnavailable — avoids a Secret existence/type
+		// oracle for a principal that can write the CR but not read Secrets).
+		logf.FromContext(ctx).Error(tlsErr, "remoteControl.tls credential could not be resolved", "cell", cc.Name)
+		return false, marker, newEphemerisPushError(reason, errRemoteControlCredentialUnavailable)
 	}
 	target := provider.ResolvedRemoteControl{
 		Endpoint:  spec.Provider.RemoteControl.Endpoint,
@@ -642,13 +656,39 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	return true, marker, nil
 }
 
+const (
+	// remoteControlCredentialLabel must be set to "true" by the Secret's owner for a
+	// Secret to be usable as a remoteControl.tls credential — an opt-in that prevents
+	// a CR author from redirecting the operator's Secret read at an unrelated Secret.
+	remoteControlCredentialLabel = "ntn.operators.dev/remote-control-credential"
+	// secretTypeBootstrapToken is the k8s bootstrap-token Secret type (no corev1
+	// constant); like a service-account token it is a cluster credential, not a gNB one.
+	secretTypeBootstrapToken = "bootstrap.kubernetes.io/token"
+)
+
+// errRemoteControlCredentialInvalid tags a DETERMINISTIC remoteControl.tls config
+// failure (wrong Secret type, missing opt-in label, malformed cert material). The
+// caller classifies it as permanent — it clears only on a Secret/spec edit (which
+// re-triggers reconcile via generation or the ephemeris fan-out), so it must not
+// tight-requeue like a transient failure would.
+var errRemoteControlCredentialInvalid = errors.New("not a usable remote-control credential")
+
+// errRemoteControlCredentialUnavailable is the UNIFORM, CR-facing message for any
+// remoteControl.tls resolution failure. The specific cause (Secret missing / wrong
+// type / unlabelled / malformed cert) is logged for the operator but never surfaced
+// on the CR condition/event: it would otherwise let a principal who can write the CR
+// but not read Secrets probe Secret existence and type (an oracle).
+var errRemoteControlCredentialUnavailable = errors.New("referenced remote-control credential is unavailable or not authorized")
+
 // resolveRemoteControlTLS builds the TLS config and bearer token for the runtime
 // push from the Secret referenced by remoteControl.tls. It reads the Secret from
 // the NTNCellConfig's OWN namespace (never cross-namespace) and never logs its
-// contents. Returns (nil, "", nil) when TLS is not configured — the caller then
-// dials plaintext ws:// (N-12). Recognized Secret keys: ca.crt (PEM CA to verify
-// the server; omit ⇒ system roots), token (Bearer shared secret; optional), and
-// for mode=mtls tls.crt + tls.key (client certificate).
+// contents. The Secret must be owner-opted-in (label remoteControlCredentialLabel=
+// true) and must not be a Kubernetes API credential (service-account / bootstrap
+// token) — see the confused-deputy note below. Returns (nil, "", nil) when TLS is
+// not configured — the caller then dials plaintext ws:// (N-12). Recognized Secret
+// keys: ca.crt (PEM CA to verify the server; omit ⇒ system roots), token (Bearer
+// shared secret; optional), and for mode=mtls tls.crt + tls.key (client certificate).
 func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	ctx context.Context, namespace string, rc *ntnv1alpha1.RemoteControlRef,
 ) (*tls.Config, string, error) {
@@ -667,6 +707,26 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: t.SecretName}, secret); err != nil {
 		return nil, "", fmt.Errorf("reading remoteControl.tls secret %q: %w", t.SecretName, err)
 	}
+	// SECURITY (partial confused-deputy MITIGATION, not an authorization boundary): the
+	// operator reads this Secret with its OWN cluster-wide secrets-get, on behalf of
+	// whoever authored the NTNCellConfig — who may not be able to read Secrets. Two gates
+	// raise the bar against a CR author pointing the operator at an arbitrary Secret and
+	// shipping its contents to a CR-controlled endpoint:
+	//   (1) refuse a Kubernetes API credential — a service-account or bootstrap token
+	//       Secret stores its apiserver token under the same "token" key we read;
+	//   (2) require the Secret's owner to opt it in via a label.
+	// Known LIMITS (a real per-CR/per-endpoint SubjectAccessReview or grant resource is a
+	// tracked follow-up): the opt-in is namespace-scoped — once labelled, ANY NTNCellConfig
+	// in the namespace may use the Secret; a principal with secrets `patch` but not `get`
+	// could add the label to a Secret it cannot read; and the type check does not stop an
+	// Opaque Secret from holding some other bearer token.
+	switch secret.Type {
+	case corev1.SecretTypeServiceAccountToken, secretTypeBootstrapToken:
+		return nil, "", fmt.Errorf("remoteControl.tls secret %q has type %q — a Kubernetes API credential must not be used as a gNB remote-control secret: %w", t.SecretName, secret.Type, errRemoteControlCredentialInvalid)
+	}
+	if secret.Labels[remoteControlCredentialLabel] != "true" {
+		return nil, "", fmt.Errorf("remoteControl.tls secret %q must be labelled %s=true by its owner to be usable as a remote-control credential: %w", t.SecretName, remoteControlCredentialLabel, errRemoteControlCredentialInvalid)
+	}
 
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 	// ServerName verified against the certificate SANs: explicit override, else the
@@ -680,7 +740,7 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if ca := secret.Data["ca.crt"]; len(ca) > 0 {
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(ca) {
-			return nil, "", fmt.Errorf("remoteControl.tls secret %q: ca.crt is not valid PEM", t.SecretName)
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: ca.crt is not valid PEM: %w", t.SecretName, errRemoteControlCredentialInvalid)
 		}
 		cfg.RootCAs = pool
 	}
@@ -688,11 +748,11 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if t.Mode == "mtls" {
 		crt, key := secret.Data["tls.crt"], secret.Data["tls.key"]
 		if len(crt) == 0 || len(key) == 0 {
-			return nil, "", fmt.Errorf("remoteControl.tls mode=mtls requires tls.crt and tls.key in secret %q", t.SecretName)
+			return nil, "", fmt.Errorf("remoteControl.tls mode=mtls requires tls.crt and tls.key in secret %q: %w", t.SecretName, errRemoteControlCredentialInvalid)
 		}
 		pair, err := tls.X509KeyPair(crt, key)
 		if err != nil {
-			return nil, "", fmt.Errorf("remoteControl.tls secret %q: invalid client certificate/key: %w", t.SecretName, err)
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: invalid client certificate/key (%v): %w", t.SecretName, err, errRemoteControlCredentialInvalid)
 		}
 		cfg.Certificates = []tls.Certificate{pair}
 	}

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -87,8 +88,15 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 		// Exercise the uncached-read path: APIReader is what production wires.
 		return &NTNCellConfigReconciler{Client: c, APIReader: c}
 	}
+	// Correctly owner-opted-in credential Secret (the label is now mandatory).
 	secret := func(name string, data map[string][]byte) *corev1.Secret {
-		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}, Data: data}
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns,
+				Labels: map[string]string{remoteControlCredentialLabel: "true"},
+			},
+			Data: data,
+		}
 	}
 	ctx := context.Background()
 
@@ -173,4 +181,83 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 			t.Fatal("expected an error for an invalid ca.crt PEM")
 		}
 	})
+
+	// SECURITY — confused-deputy gates.
+	t.Run("secret without the opt-in label → rejected", func(t *testing.T) {
+		unlabelled := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns}, // no remoteControlCredentialLabel
+			Data:       map[string][]byte{"ca.crt": certPEM, "token": []byte("shhh")},
+		}
+		r := newR(unlabelled)
+		rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+			TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "s"}}
+		_, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
+		if err == nil {
+			t.Fatal("an un-opted-in Secret (no owner label) must be rejected — a CR author must not point the operator at an arbitrary Secret")
+		}
+		if tok != "" {
+			t.Fatalf("no token may be returned on rejection, got %q", tok)
+		}
+		if !errors.Is(err, errRemoteControlCredentialInvalid) {
+			t.Errorf("a credential-config rejection must be classified permanent (wrap errRemoteControlCredentialInvalid) so it does not tight-requeue; got %v", err)
+		}
+	})
+
+	t.Run("service-account-token Secret → rejected even if labelled", func(t *testing.T) {
+		saTok := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "s", Namespace: ns,
+				Labels: map[string]string{remoteControlCredentialLabel: "true"}, // even opted-in
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{"token": []byte("apiserver-cred"), "ca.crt": certPEM},
+		}
+		r := newR(saTok)
+		rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+			TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "s"}}
+		_, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
+		if err == nil {
+			t.Fatal("a service-account-token Secret must never be usable as a remote-control credential — its token is an apiserver credential")
+		}
+		if tok != "" {
+			t.Fatalf("the apiserver token must never be returned, got %q", tok)
+		}
+		if !errors.Is(err, errRemoteControlCredentialInvalid) {
+			t.Errorf("a rejected Secret type must be classified permanent (wrap errRemoteControlCredentialInvalid); got %v", err)
+		}
+	})
+
+	t.Run("bootstrap-token Secret → rejected even if labelled", func(t *testing.T) {
+		bootstrap := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "s", Namespace: ns,
+				Labels: map[string]string{remoteControlCredentialLabel: "true"},
+			},
+			Type: secretTypeBootstrapToken,
+			Data: map[string][]byte{"token": []byte("bootstrap-cred"), "ca.crt": certPEM},
+		}
+		r := newR(bootstrap)
+		rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+			TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "s"}}
+		_, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
+		if err == nil || tok != "" {
+			t.Fatal("a bootstrap-token Secret must never be usable as a remote-control credential")
+		}
+		if !errors.Is(err, errRemoteControlCredentialInvalid) {
+			t.Errorf("must be classified permanent; got %v", err)
+		}
+	})
+}
+
+// TestEphemerisPushShouldRequeue_RemoteControlConfigIsPermanent pins that a
+// deterministic remoteControl.tls credential error does NOT tight-requeue: it clears
+// only on a Secret/spec edit (which re-triggers reconcile), so hammering the apiserver
+// every minute would be pointless — unlike a transient ProviderPushFailed.
+func TestEphemerisPushShouldRequeue_RemoteControlConfigIsPermanent(t *testing.T) {
+	if ephemerisPushShouldRequeue(ephemerisReasonRemoteControlConfig) {
+		t.Error("RemoteControlConfigInvalid is a permanent config error and must NOT requeue")
+	}
+	if !ephemerisPushShouldRequeue(ephemerisReasonProviderPushFailed) {
+		t.Error("a transient ProviderPushFailed must still requeue (control)")
+	}
 }

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -886,6 +886,14 @@ spec:
                               shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
+
+                              SECURITY: the Secret's owner must opt it in for remote-control use with the label
+                              "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
+                              credential (a service-account or bootstrap-token Secret) is refused. This is a
+                              mitigation, not a full authorization boundary: the opt-in is namespace-scoped, so
+                              ANY NTNCellConfig in the namespace may use a labelled Secret. Do not grant
+                              NTNCellConfig write to principals who should not be able to use every labelled
+                              remote-control credential in that namespace.
                             maxLength: 253
                             minLength: 1
                             type: string

--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -260,6 +260,10 @@ const (
 	wsMarshal
 	// wsRejected: the gNB replied {"error": ...} — permanent (bad config).
 	wsRejected
+	// wsHandshakeRejected: the handshake got a definitive HTTP response (a refused
+	// redirect, an auth rejection, or another non-101 in the 3xx/4xx range) rather
+	// than an Upgrade — permanent (config/credential), must not tight-requeue.
+	wsHandshakeRejected
 )
 
 // wsError is a typed runtime-push error carrying a kind for requeue decisions.
@@ -302,18 +306,37 @@ func pushNTNConfigUpdate(
 	// (incl. TLS) through the supplied http.Client, so Transport.TLSClientConfig is
 	// the TLS lever; the bearer header rides only over that TLS connection.
 	scheme := "ws://"
-	var dialOpts *websocket.DialOptions
+	// Refuse to follow redirects on the handshake. coder/websocket follows redirects
+	// by default (its wrapper only rewrites the ws/wss scheme, then honors the
+	// caller's CheckRedirect) and Go preserves the Authorization header on a
+	// same-host redirect — so a gNB/proxy 302 from wss:// to http://same-host would
+	// resend the bearer over cleartext. ErrUseLastResponse stops the client at the
+	// 30x, before it re-sends anything, on both the wss and plaintext paths.
+	dialOpts := &websocket.DialOptions{
+		HTTPClient: &http.Client{
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
 	if target.TLSConfig != nil {
 		scheme = "wss://"
-		dialOpts = &websocket.DialOptions{
-			HTTPClient: &http.Client{Transport: &http.Transport{TLSClientConfig: target.TLSConfig}},
-		}
+		dialOpts.HTTPClient.Transport = &http.Transport{TLSClientConfig: target.TLSConfig}
 		if target.AuthToken != "" {
 			dialOpts.HTTPHeader = http.Header{"Authorization": {"Bearer " + target.AuthToken}}
 		}
 	}
-	conn, _, err := websocket.Dial(dialCtx, scheme+endpoint, dialOpts)
+	conn, resp, err := websocket.Dial(dialCtx, scheme+endpoint, dialOpts)
 	if err != nil {
+		// A definitive HTTP handshake response (a refused redirect, an auth rejection,
+		// or any non-101 in the 3xx/4xx range) is a PERMANENT config/credential problem,
+		// not transient unreachability — classify it non-retryable so the reconciler does
+		// not tight-requeue it every minute (mirroring RemoteControlConfigInvalid). A nil
+		// response is a connection-level failure (dial/TLS/timeout, or a 5xx server error)
+		// and stays retryable. coder/websocket owns resp.Body, so we only read the status.
+		if resp != nil && resp.StatusCode >= 300 && resp.StatusCode < 500 {
+			return &wsError{wsHandshakeRejected, fmt.Sprintf("handshake to %s rejected: HTTP %d", endpoint, resp.StatusCode)}
+		}
 		return &wsError{wsUnreachable, fmt.Sprintf("dial %s: %v", endpoint, err)}
 	}
 	// CloseNow (not the graceful Close) on every path: the single request/reply

--- a/pkg/provider/ocudu/wsclient_test.go
+++ b/pkg/provider/ocudu/wsclient_test.go
@@ -341,6 +341,59 @@ func TestPushNTNConfigUpdate_WSS_UntrustedCertFails(t *testing.T) {
 	}
 }
 
+// TestPushNTNConfigUpdate_WSS_RefusesRedirectDowngrade pins the redirect-downgrade
+// defense: a gNB/proxy 302 from wss:// to a plaintext http:// endpoint on the same
+// host must NOT be followed, so the Authorization bearer never leaves the TLS
+// connection. Without the CheckRedirect guard, coder/websocket follows the redirect
+// and Go re-sends the same-host Authorization header over cleartext. The plaintext
+// capture server (different port, same 127.0.0.1 host — so Go would preserve the
+// header) must never see it.
+func TestPushNTNConfigUpdate_WSS_RefusesRedirectDowngrade(t *testing.T) {
+	var mu sync.Mutex
+	plaintextSawAuth := false
+	capture := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			mu.Lock()
+			plaintextSawAuth = true
+			mu.Unlock()
+		}
+	}))
+	t.Cleanup(capture.Close)
+
+	// A TLS server that redirects the handshake to the plaintext capture endpoint.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, capture.URL+"/downgraded", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+	endpoint := strings.TrimPrefix(srv.URL, "https://")
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	target := provider.ResolvedRemoteControl{
+		Endpoint:  endpoint,
+		TLSConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		AuthToken: "s3cr3t-token",
+	}
+	env, _ := buildNTNConfigUpdate(ecefRuntimeUpdate())
+	// A 302 is not a valid WS upgrade and must not be followed → the dial fails.
+	err := pushNTNConfigUpdate(context.Background(), target, env)
+	if err == nil {
+		t.Fatal("a handshake that 302-redirects must fail, not be followed")
+	}
+	// And it must be classified PERMANENT (a refused redirect is a config/attack, not a
+	// transient blip) so the reconciler does not tight-requeue it every minute.
+	var we *wsError
+	if !errors.As(err, &we) || we.retryable() {
+		t.Fatalf("a refused-redirect handshake must be non-retryable (permanent), got %v", err)
+	}
+	mu.Lock()
+	leaked := plaintextSawAuth
+	mu.Unlock()
+	if leaked {
+		t.Fatal("SECURITY: the bearer Authorization header was sent to the plaintext redirect target")
+	}
+}
+
 func TestPushNTNConfigUpdate_Rejected(t *testing.T) {
 	endpoint, _ := wsTestServer(t, `{"error":"epoch_timestamp value is in past","cmd":"ntn_config_update"}`)
 	env, _ := buildNTNConfigUpdate(ecefRuntimeUpdate())


### PR DESCRIPTION
## Summary

WSS runtime-push security hardening, from the #206 + #219 adversarial reviews. One **real fix** (redirect leak) plus **honest scoping** of the Secret gate.

## 1. Refuse handshake redirects (real fix)

`coder/websocket` follows redirects by default and Go preserves `Authorization` on a same-host redirect, so a gNB/proxy `302` from `wss://` to `http://same-host` would re-send the `Bearer` over cleartext. Fix: `CheckRedirect → http.ErrUseLastResponse`. A refused redirect (and any `3xx`/`4xx` handshake response) is now classified **permanent** (`wsHandshakeRejected` → non-requeuing), so it does not tight-requeue. **Mutation-tested** against the leak.

## 2. `remoteControl.tls` Secret gate — a MITIGATION, not an authorization boundary

Two gates raise the bar against the confused-deputy (operator reads the Secret with its own cluster-wide `secrets get` on behalf of the CR author): reject service-account/bootstrap-token Secrets, and require the owner's opt-in label. 

⚠ **This is attack-surface reduction, not authorization.** Stated honestly in the CHANGELOG, the **CRD/API doc (regenerated across all 4 copies + api-reference)**, and code. Known limits: the label is **namespace-scoped** (any `NTNCellConfig` may use a labelled Secret); a `patch`-only principal could label a Secret it can't read; the type check doesn't stop an `Opaque` Secret holding another bearer token. The repo ships `ntncellconfig-editor-role` (CR write without `secrets get`) in the default kustomization, so this delegation is a **real** scenario — a per-CR/endpoint **SubjectAccessReview or grant resource is the tracked follow-up** (mechanism TBD: admission-webhook vs `ReferenceGrant`-style CRD).

## 3. No Secret existence/type oracle

Credential-resolution failures now surface a **uniform** "unavailable or not authorized" message on the condition/event; the specific cause is logged for the operator only.

## Not adopted (with reason)

- **Routing the WSS dial through the env proxy** (review Finding 6's implied fix): the endpoint is **CR-author-controlled**, so `Proxy=nil` avoids proxy-amplified SSRF. To be clear, `Proxy=nil` does **not** eliminate SSRF — the operator still dials a CR-controlled `host:port` and can reach ClusterIP/loopback; an **endpoint allowlist / Service reference** is the real control, tracked separately.

## Deferred (tracked follow-ups)

Real authorization boundary (SAR/grant), Secret watch + credential revision in the dedup marker (rotation/revocation is currently bounded by the ~3m epoch cadence), endpoint allowlist.

## Verification

`make test`, `golangci-lint` (**0**), `gofmt`, `go test -race` — all green. Tests: redirect-downgrade (mutation-proven) + permanent classification; unlabelled / SA-token / bootstrap-token Secret rejected; permanent-vs-transient requeue classification.
