### PR TITLE
fix(failover): three-state recovery semantics (unknown != recovered)

### DIFF
--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -124,6 +124,25 @@ func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, st slice.A
 	r.flapState[key] = st
 }
 
+// resetRecoveryStreak clears the confirmation and recovery clocks for a slice while
+// KEEPING the min-dwell clock. Called when metrics are unreliable or satellite
+// availability is unknown: a telemetry gap breaks the "continuous" recovery/degraded
+// streaks (absence of evidence is not evidence of recovery — otherwise a single
+// healthy sample after a long gap, plus a stale recovery timestamp, would satisfy the
+// switchback delay and switch back immediately). The dwell since the last hand-back
+// keeps elapsing on wall-clock time, so LastSwitchback is preserved.
+func (r *NTNSliceReconciler) resetRecoveryStreak(key types.NamespacedName) {
+	r.flapMu.Lock()
+	defer r.flapMu.Unlock()
+	st, ok := r.flapState[key]
+	if !ok || (st.RecoveryObservedAt.IsZero() && st.ConsecutiveDegraded == 0) {
+		return // nothing tracked, or already clear — do not create a spurious entry
+	}
+	st.RecoveryObservedAt = time.Time{}
+	st.ConsecutiveDegraded = 0
+	r.flapState[key] = st
+}
+
 // dropFlapState releases a slice's anti-flap state (on deletion).
 func (r *NTNSliceReconciler) dropFlapState(key types.NamespacedName) {
 	r.flapMu.Lock()
@@ -232,6 +251,18 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// armed-but-dead (never fires against the healthy placeholder). Only
 		// meaningful once metrics were actually read (qualityReliable).
 		r.reportInertTriggers(ns, slice.InertTriggers(ns.Spec.FailoverPolicy.Triggers, metrics), &pending)
+	} else {
+		// Metrics are unreliable, so whether a trigger is inert or sourced cannot be
+		// evaluated. Report TriggersReady=Unknown for THIS generation rather than leave
+		// a stale True/False from the last reliable reconcile (a condition must not lie
+		// about the current state; absent evidence is Unknown, not the old answer).
+		meta.SetStatusCondition(&ns.Status.Conditions, metav1.Condition{
+			Type:               ntnv1alpha1.ConditionTriggersReady,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "MetricsUnavailable",
+			Message:            "Trigger sourcing cannot be evaluated while path-quality metrics are unreliable",
+			ObservedGeneration: ns.Generation,
+		})
 	}
 
 	// Step 4: Evaluate the failover decision. With reliable metrics the full
@@ -258,6 +289,9 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		log.Info("satellite availability unknown; holding current path",
 			"path", currentPath, "reason", result.Reason)
+		// H2: a gap in the ability to evaluate transitions breaks the continuous
+		// recovery/degraded streaks; do not let a stale recovery clock survive it.
+		r.resetRecoveryStreak(client.ObjectKeyFromObject(ns))
 	case qualityReliable:
 		// Parse hysteresis margin from spec (string → float64, default 0).
 		var hysteresisMargin float64
@@ -306,6 +340,10 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		result = slice.EvaluateSafeHold(currentPath, satelliteAvailable)
 		log.Info("metrics unreliable; failing static",
 			"decision", result.Decision, "targetPath", result.TargetPath, "reason", result.Reason)
+		// H2: unreliable metrics break the continuous recovery/degraded streaks — a
+		// single healthy sample after the gap must not satisfy the switchback delay via
+		// a stale recovery timestamp. Keep the min-dwell clock (wall-clock based).
+		r.resetRecoveryStreak(client.ObjectKeyFromObject(ns))
 	}
 
 	// Step 5: Apply decision.

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -463,6 +463,18 @@ var _ = Describe("NTNSlice Controller", func() {
 			// Put slice on satellite with old failover (5 min ago, delay is 60s).
 			ntnSlice := &ntnv1alpha1.NTNSlice{}
 			Expect(k8sClient.Get(context.Background(), typeNamespacedName, ntnSlice)).To(Succeed())
+			// Terrestrial is GENUINELY recovered — all trigger metrics are SOURCED and
+			// healthy (rsrp -90 > -120, latency 20 < 200, packetLoss 0.1 < 5). Without
+			// these annotations the metrics are Missing and the triggers are inert; the
+			// three-state fix now HOLDS on such unconfirmable "recovery" rather than
+			// switching back, so this test must supply a real, confirmed recovery.
+			ntnSlice.Annotations = map[string]string{
+				"ntn.operators.dev/simulated-rsrp":        "-90",
+				"ntn.operators.dev/simulated-latency":     "20",
+				"ntn.operators.dev/simulated-packet-loss": "0.1",
+			}
+			Expect(k8sClient.Update(context.Background(), ntnSlice)).To(Succeed())
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, ntnSlice)).To(Succeed())
 			ntnSlice.Status.ActivePathType = pathSatellite
 			ntnSlice.Status.FailoverCount = 1
 			ntnSlice.Status.LastFailover = &metav1.Time{Time: time.Date(2026, 4, 17, 11, 55, 0, 0, time.UTC)} // 5min ago

--- a/internal/controller/ntnslice_three_state_test.go
+++ b/internal/controller/ntnslice_three_state_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown pins two
+// three-state controller fixes at once, on the metrics-unreliable path:
+//
+//	H2 — the in-memory recovery/confirmation streak must be RESET (a telemetry gap is
+//	     not evidence of recovery; a stale RecoveryObservedAt + one later healthy
+//	     sample would otherwise satisfy the switchback delay). The min-dwell clock is
+//	     wall-clock based and must be PRESERVED.
+//	C5 — TriggersReady must report Unknown/MetricsUnavailable for the current
+//	     generation rather than keep a stale True/False from the last reliable read.
+func TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+
+	// Active pass window: satellite is available (so fail-static holds on satellite).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+
+	// Metrics STALE beyond the freshness bound → unreliable path.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -90, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       true,
+		LastFreshAt: fixedNow.Add(-100 * time.Second),
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	// Seed a recovery/confirmation streak AND a dwell clock from an earlier (reliable)
+	// window, to prove the unreliable reconcile clears the former but keeps the latter.
+	dwell := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, slice.AntiFlapState{
+		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
+		ConsecutiveDegraded: 2,
+		LastSwitchback:      dwell,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// C5: TriggersReady must be Unknown for the current generation.
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	c := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionTriggersReady)
+	if c == nil || c.Status != metav1.ConditionUnknown || c.Reason != "MetricsUnavailable" {
+		t.Fatalf("TriggersReady must be Unknown/MetricsUnavailable while metrics are unreliable, got %+v", c)
+	}
+
+	// H2: recovery + confirmation cleared, dwell preserved.
+	st := r.loadFlapState(key)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("recovery clock must reset on unreliable metrics (H2), got %v", st.RecoveryObservedAt)
+	}
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("confirmation streak must reset on unreliable metrics (H2), got %d", st.ConsecutiveDegraded)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("the min-dwell clock is wall-clock based and must be PRESERVED, got %v want %v", st.LastSwitchback, dwell)
+	}
+}

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -257,6 +257,12 @@ type triggerSetResult struct {
 	anyTriggered bool
 	parseSuffix  string
 	allInvalid   bool
+	// hasUnknownTrigger is true if any syntactically-valid trigger was skipped because
+	// its metric has no live source (inert). Terrestrial recovery cannot be CONFIRMED
+	// while a trigger is unknown, so the caller must not treat !anyTriggered as
+	// "recovered" and switch back onto a link whose quality is unverifiable (I-10 /
+	// the inert-trigger vacuous-recovery bug): unknown != recovered.
+	hasUnknownTrigger bool
 }
 
 // parseTriggerSet parses all triggers, evaluates them (OR logic), and returns
@@ -283,6 +289,7 @@ func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) trigge
 		if trigger.metricMissing(metrics) {
 			log.V(1).Info("trigger references a metric with no configured source; it is inert",
 				"trigger", triggerStr, "metric", trigger.Metric)
+			result.hasUnknownTrigger = true
 			continue
 		}
 		result.parsed = append(result.parsed, trigger)
@@ -299,6 +306,22 @@ func parseTriggerSet(log logr.Logger, triggers []string, metrics Metrics) trigge
 			parseErrors, len(triggers))
 	}
 	return result
+}
+
+// passEndedReason is the honest reason for the forced return to terrestrial when a
+// satellite pass has physically ended. It must not claim "terrestrial recovered" when
+// recovery is unverifiable (an unknown-source or all-invalid trigger set): the decision
+// (leave the set satellite) is right regardless, but the condition/event must not
+// mislead incident diagnosis into thinking terrestrial telemetry has recovered.
+func passEndedReason(ts triggerSetResult) string {
+	switch {
+	case ts.anyTriggered:
+		return "Satellite pass ended, falling back to degraded terrestrial"
+	case ts.hasUnknownTrigger || ts.allInvalid:
+		return "Satellite pass ended; returning to terrestrial (recovery unconfirmed)"
+	default:
+		return "Satellite pass ended, terrestrial recovered"
+	}
 }
 
 // EvaluateFailoverWithContext is the context-aware variant of EvaluateFailover.
@@ -336,6 +359,18 @@ func EvaluateFailoverWithContext(
 		currentPath = PathTerrestrial
 	}
 
+	// Orbital reality precedes everything: a satellite whose pass has physically ended
+	// must return to terrestrial regardless of trigger validity or knownness — staying
+	// would black-hole traffic on a set satellite. This MUST precede the allInvalid
+	// guard (all-invalid triggers on an ended pass would otherwise Stay on the satellite).
+	if currentPath == PathSatellite && !satelliteAvailable {
+		return finish(FailoverResult{
+			Decision:   DecisionSwitchback,
+			Reason:     passEndedReason(ts) + ts.parseSuffix,
+			TargetPath: PathTerrestrial,
+		})
+	}
+
 	if ts.allInvalid {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
@@ -367,26 +402,23 @@ func EvaluateFailoverWithContext(
 		})
 
 	case PathSatellite:
-		// If satellite pass ended, must switch back regardless.
-		if !satelliteAvailable {
-			if ts.anyTriggered {
-				return finish(FailoverResult{
-					Decision:   DecisionSwitchback,
-					Reason:     "Satellite pass ended, falling back to degraded terrestrial" + ts.parseSuffix,
-					TargetPath: PathTerrestrial,
-				})
-			}
-			return finish(FailoverResult{
-				Decision:   DecisionSwitchback,
-				Reason:     "Satellite pass ended, terrestrial recovered" + ts.parseSuffix,
-				TargetPath: PathTerrestrial,
-			})
-		}
+		// (A physically-ended pass is handled before the allInvalid guard above.)
 		if ts.anyTriggered {
 			// Terrestrial still degraded, stay on satellite.
 			return finish(FailoverResult{
 				Decision:   DecisionStay,
 				Reason:     "Terrestrial still degraded, staying on satellite" + ts.parseSuffix,
+				TargetPath: PathSatellite,
+			})
+		}
+		if ts.hasUnknownTrigger {
+			// No trigger fired, but a trigger metric is unknown — recovery is
+			// UNCONFIRMED. Hold on satellite rather than switch back onto a link whose
+			// quality can't be verified; the pass-ended path above still forces a
+			// return to terrestrial if the satellite physically sets.
+			return finish(FailoverResult{
+				Decision:   DecisionStay,
+				Reason:     "Recovery unconfirmed (a trigger metric is unsourced), holding on satellite" + ts.parseSuffix,
 				TargetPath: PathSatellite,
 			})
 		}
@@ -406,8 +438,29 @@ func EvaluateFailoverWithContext(
 		})
 
 	default:
-		// Unknown or unavailable path — try terrestrial first.
+		// Unknown or unavailable path — initializing.
 		if !ts.anyTriggered {
+			// No trigger fired. But "no trigger fired" only means "terrestrial healthy"
+			// when every trigger is KNOWN. If a trigger metric is unknown, do NOT read the
+			// silence as health: prefer a CONFIRMED-available satellite; otherwise fall back
+			// to terrestrial (the primary) but say so honestly — a partial view is not a
+			// recovered view. We do NOT park on PathUnavailable when terrestrial is a viable
+			// fallback, as that would black-hole traffic on an unproven assumption. (When a
+			// real trigger IS firing, terrestrial is confirmed degraded → the paths below.)
+			if ts.hasUnknownTrigger {
+				if satelliteAvailable {
+					return finish(FailoverResult{
+						Decision:   DecisionFailover,
+						Reason:     "Terrestrial quality unknown; using the confirmed satellite pass" + ts.parseSuffix,
+						TargetPath: PathSatellite,
+					})
+				}
+				return finish(FailoverResult{
+					Decision:   DecisionSwitchback,
+					Reason:     "Initializing on terrestrial (quality unconfirmed; no satellite pass)" + ts.parseSuffix,
+					TargetPath: PathTerrestrial,
+				})
+			}
 			return finish(FailoverResult{
 				Decision:   DecisionSwitchback,
 				Reason:     "Initializing on terrestrial path" + ts.parseSuffix,
@@ -473,6 +526,19 @@ func EvaluateFailoverWithHysteresis(
 
 	ts := parseTriggerSet(log, triggers, metrics)
 
+	// Satellite pass ended — force switchback regardless of hysteresis OR trigger
+	// validity. currentPath is guaranteed PathSatellite here (line 485 delegates
+	// otherwise), so this is a genuine set-pass. It MUST precede the allInvalid guard,
+	// else an all-invalid trigger set on an ended pass would Stay on the set satellite
+	// (a traffic black hole).
+	if !satelliteAvailable {
+		return finish(FailoverResult{
+			Decision:   DecisionSwitchback,
+			Reason:     passEndedReason(ts) + ts.parseSuffix,
+			TargetPath: PathTerrestrial,
+		})
+	}
+
 	if ts.allInvalid {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
@@ -481,26 +547,19 @@ func EvaluateFailoverWithHysteresis(
 		})
 	}
 
-	// Satellite pass ended — force switchback regardless of hysteresis.
-	if !satelliteAvailable {
-		if ts.anyTriggered {
-			return finish(FailoverResult{
-				Decision:   DecisionSwitchback,
-				Reason:     "Satellite pass ended, falling back to degraded terrestrial" + ts.parseSuffix,
-				TargetPath: PathTerrestrial,
-			})
-		}
-		return finish(FailoverResult{
-			Decision:   DecisionSwitchback,
-			Reason:     "Satellite pass ended, terrestrial recovered" + ts.parseSuffix,
-			TargetPath: PathTerrestrial,
-		})
-	}
-
 	if ts.anyTriggered {
 		return finish(FailoverResult{
 			Decision:   DecisionStay,
 			Reason:     "Terrestrial still degraded, staying on satellite" + ts.parseSuffix,
+			TargetPath: PathSatellite,
+		})
+	}
+	if ts.hasUnknownTrigger {
+		// Recovery unconfirmed: a trigger metric is unknown, so the empty/partial
+		// parsed set below would vacuously pass allRecovered. Hold on satellite.
+		return finish(FailoverResult{
+			Decision:   DecisionStay,
+			Reason:     "Recovery unconfirmed (a trigger metric is unsourced), holding on satellite" + ts.parseSuffix,
 			TargetPath: PathSatellite,
 		})
 	}
@@ -554,12 +613,15 @@ type AntiFlapConfig struct {
 	MinTerrestrialDwell time.Duration
 }
 
-// AntiFlapState is the per-slice, in-memory flap-suppression state. It is safe
-// to lose: a reset re-requires N consecutive confirmations and restarts the
-// recovery/dwell clocks, which only ever DELAYS a switch, never advances one
-// (so a controller restart or leader-election handoff cannot cause a spurious
-// flap). Per the Kubernetes API convention, such transient history is best-effort
-// and need not be persisted.
+// AntiFlapState is the per-slice, in-memory flap-suppression state. Losing it (a
+// controller restart or leader-election handoff) is MOSTLY safe: a reset re-requires N
+// consecutive confirmations and restarts the recovery clock, both of which only DELAY a
+// switch. The ONE exception is LastSwitchback: losing it drops the post-switchback
+// min-dwell, so a failover that dwell would have delayed can happen immediately — a reset
+// can ADVANCE (never fabricate) a failover on that single axis. This is an accepted
+// trade-off: a restart is rare and one early re-failover is bounded; making dwell durable
+// would require persisting LastSwitchback to status (tracked, deferred). The other two
+// clocks bias a restart toward holding, never toward a spurious flap.
 type AntiFlapState struct {
 	// ConsecutiveDegraded counts consecutive reliable samples on which the
 	// terrestrial triggers fired. Reset to 0 by any healthy/unreliable sample.
@@ -596,6 +658,42 @@ func terrestrialDegraded(triggers []string, m Metrics) bool {
 	return false
 }
 
+// terrestrialConfirmedRecovered reports whether terrestrial is CONFIRMED recovered:
+// every syntactically-valid trigger is known (has a live metric) AND has recovered
+// past the hysteresis margin. It is deliberately stricter than !terrestrialDegraded:
+//   - an unknown (inert) trigger returns false — recovery is unverifiable (C1);
+//   - a known trigger still inside the hysteresis dead-band returns false, so the
+//     switchback recovery clock measures only continuous PAST-hysteresis recovery,
+//     not time spent in the dead-band (H3).
+//
+// An EMPTY policy (no triggers) is trivially recovered (true), matching the base
+// evaluator's switch-back-to-terrestrial behavior for an empty policy. But a non-empty
+// policy whose triggers are ALL invalid is a broken config, not a recovered link — it
+// returns false so a syntactically-broken policy cannot pre-start the recovery clock
+// (the base evaluator independently Stays on allInvalid). With margin <= 0 this reduces
+// to !terrestrialDegraded (no dead-band).
+func terrestrialConfirmedRecovered(triggers []string, m Metrics, margin float64) bool {
+	sawValid := false
+	for _, s := range triggers {
+		t, err := ParseTrigger(s)
+		if err != nil {
+			continue // invalid triggers are accounted for elsewhere (allInvalid → Stay)
+		}
+		sawValid = true
+		if t.metricMissing(m) {
+			return false // unknown metric — recovery cannot be confirmed
+		}
+		if !t.EvaluateRecovery(m, margin) {
+			return false // known but still degraded or inside the dead-band
+		}
+	}
+	// A non-empty policy with no valid trigger is all-invalid: not a confirmed recovery.
+	if len(triggers) > 0 && !sawValid {
+		return false
+	}
+	return true
+}
+
 // EvaluateFailoverWithAntiFlap wraps EvaluateFailoverWithHysteresis with the
 // in-memory anti-flap gates. It must be called ONLY with reliable metrics (the
 // caller fails static via EvaluateSafeHold otherwise). It:
@@ -623,15 +721,27 @@ func EvaluateFailoverWithAntiFlap(
 	cfg AntiFlapConfig,
 	st AntiFlapState,
 ) (FailoverResult, AntiFlapState) {
-	// 1. Update the confirmation + recovery clocks from this sample.
-	if terrestrialDegraded(triggers, metrics) {
+	// 1. Update the confirmation + recovery clocks from this sample. Three states:
+	//    degraded (a raw trigger fires) / confirmed-recovered (all known triggers past
+	//    the hysteresis margin, none unknown) / neither (dead-band or an unknown
+	//    metric). The recovery clock advances ONLY while confirmed-recovered, so the
+	//    switchback delay measures continuous PAST-hysteresis recovery and never counts
+	//    dead-band or unknown-metric time as recovery (H3/C1).
+	switch {
+	case terrestrialDegraded(triggers, metrics):
 		st.ConsecutiveDegraded++
 		st.RecoveryObservedAt = time.Time{} // re-degraded → reset the switchback clock
-	} else {
+	case terrestrialConfirmedRecovered(triggers, metrics, hysteresisMargin):
 		st.ConsecutiveDegraded = 0
 		if st.RecoveryObservedAt.IsZero() {
-			st.RecoveryObservedAt = now // a fresh continuous-recovery streak begins
+			st.RecoveryObservedAt = now // a fresh continuous past-hysteresis streak begins
 		}
+	default:
+		// Dead-band or unknown metric: neither degraded nor confirmed recovered. Break
+		// the recovery streak so a later confirmed recovery must re-accumulate the full
+		// switchback delay. (The evaluator independently holds on satellite here.)
+		st.ConsecutiveDegraded = 0
+		st.RecoveryObservedAt = time.Time{}
 	}
 
 	// 2. Run the base engine, measuring the switchback delay from the recovery
@@ -666,10 +776,13 @@ func EvaluateFailoverWithAntiFlap(
 		}
 	}
 
-	// 4. Start the dwell clock only on a quality-driven hand-back (satellite still
-	//    available). A pass-ended forced switchback (satellite gone) is orbital, not
-	//    a ping-pong, so it must not block the next pass's legitimate re-failover.
-	if res.Decision == DecisionSwitchback && satelliteAvailable {
+	// 4. Start the dwell clock only on a quality-driven hand-back FROM satellite
+	//    (satellite still available). A pass-ended forced switchback (satellite gone)
+	//    is orbital, not a ping-pong; and initialising onto terrestrial from an
+	//    unavailable/unknown path also emits DecisionSwitchback but is not a hand-back —
+	//    the currentPath==PathSatellite guard excludes both so neither blocks a
+	//    legitimate re-failover.
+	if res.Decision == DecisionSwitchback && satelliteAvailable && currentPath == PathSatellite {
 		st.LastSwitchback = now
 	}
 

--- a/pkg/slice/failover_three_state_test.go
+++ b/pkg/slice/failover_three_state_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package slice
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// inertPacketLoss is a metrics snapshot where packetLoss has no live source (inert),
+// but rsrp/latency are healthy — so a `packetLoss > 5` trigger is unknown.
+var inertPacketLoss = Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1, PacketLossMissing: true}
+
+// TestHysteresis_AllInertTriggers_HoldsOnSatellite pins the inert-trigger
+// vacuous-recovery fix: on satellite, if the only trigger is inert, the empty parsed
+// set must NOT be read as "recovered" (which would switch traffic back onto a link
+// whose quality is unverifiable). Unknown != recovered → HOLD.
+func TestHysteresis_AllInertTriggers_HoldsOnSatellite(t *testing.T) {
+	res := EvaluateFailoverWithHysteresis(
+		context.Background(), PathSatellite, []string{"packetLoss > 5"}, inertPacketLoss,
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if res.Decision != DecisionStay || res.TargetPath != PathSatellite {
+		t.Fatalf("an all-inert trigger set must HOLD on satellite (recovery unconfirmed), got %s→%s: %s",
+			res.Decision, res.TargetPath, res.Reason)
+	}
+}
+
+// TestBase_AllInertTriggers_HoldsOnSatellite pins the same fix on the no-hysteresis
+// (base) evaluator, which the anti-flap wrapper delegates to when margin <= 0.
+func TestBase_AllInertTriggers_HoldsOnSatellite(t *testing.T) {
+	res := EvaluateFailoverWithContext(
+		context.Background(), PathSatellite, []string{"packetLoss > 5"}, inertPacketLoss,
+		true, 60*time.Second, now.Add(-90*time.Second), now,
+	)
+	if res.Decision != DecisionStay || res.TargetPath != PathSatellite {
+		t.Fatalf("all-inert must HOLD on satellite in the base path too, got %s→%s: %s",
+			res.Decision, res.TargetPath, res.Reason)
+	}
+}
+
+// TestHysteresis_AllInert_PassEnded_ForcesSwitchback confirms the hold is overridden
+// by the orbital reality: if the satellite pass has physically ended, we must return
+// to terrestrial even though recovery is unconfirmed (staying would black-hole traffic).
+func TestHysteresis_AllInert_PassEnded_ForcesSwitchback(t *testing.T) {
+	res := EvaluateFailoverWithHysteresis(
+		context.Background(), PathSatellite, []string{"packetLoss > 5"}, inertPacketLoss,
+		false /* pass ended */, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if res.Decision != DecisionSwitchback {
+		t.Fatalf("a physically-ended pass must force switchback even with unknown triggers, got %s: %s",
+			res.Decision, res.Reason)
+	}
+}
+
+// TestHysteresis_MixedKnownRecoveredAndInert_Holds: rsrp has recovered past the
+// dead-band, but packetLoss is inert. Recovery of the WHOLE policy is unconfirmed, so
+// the conservative decision is to hold — a partial view is not a recovered view.
+func TestHysteresis_MixedKnownRecoveredAndInert_Holds(t *testing.T) {
+	m := Metrics{RSRP: -105, LatencyMs: 20, PacketLossPercent: 0.1, PacketLossMissing: true}
+	res := EvaluateFailoverWithHysteresis(
+		context.Background(), PathSatellite, []string{"rsrp < -120", "packetLoss > 5"}, m,
+		true, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if res.Decision != DecisionStay {
+		t.Fatalf("a mix of recovered + unknown triggers must HOLD (unknown != recovered), got %s: %s",
+			res.Decision, res.Reason)
+	}
+}
+
+// TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay pins the hysteresis-aware
+// recovery clock: the switchback delay must measure continuous PAST-hysteresis
+// recovery, not time spent sitting in the dead-band. rsrp < -120, margin 10 →
+// recovery threshold -110; delay 60s.
+func TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay(t *testing.T) {
+	trg := []string{"rsrp < -120"}
+	const margin = 10.0
+	deadBand := Metrics{RSRP: -115, LatencyMs: 20, PacketLossPercent: 0.1}  // above -120, below -110
+	recovered := Metrics{RSRP: -105, LatencyMs: 20, PacketLossPercent: 0.1} // above -110
+
+	st := AntiFlapState{}
+	var res FailoverResult
+
+	// Sit in the dead-band longer than the switchback delay. The recovery clock must
+	// stay unset — the dead-band is not recovery.
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand,
+		true, 60*time.Second, now, margin, AntiFlapConfig{}, st)
+	if res.Decision != DecisionStay {
+		t.Fatalf("dead-band must stay on satellite, got %s: %s", res.Decision, res.Reason)
+	}
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Fatal("the recovery clock must NOT start in the dead-band (H3)")
+	}
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand,
+		true, 60*time.Second, now.Add(120*time.Second), margin, AntiFlapConfig{}, st)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Fatal("still in dead-band 120s later: the recovery clock must remain unset (H3)")
+	}
+
+	// Cross the margin. The clock starts NOW, so the 60s delay is not yet elapsed → hold.
+	tCross := now.Add(121 * time.Second)
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered,
+		true, 60*time.Second, tCross, margin, AntiFlapConfig{}, st)
+	if res.Decision != DecisionStay {
+		t.Fatalf("the switchback delay must be measured from the past-hysteresis recovery, not the "+
+			"dead-band entry — expected Stay, got %s: %s", res.Decision, res.Reason)
+	}
+	if !st.RecoveryObservedAt.Equal(tCross) {
+		t.Fatalf("the recovery clock must start at the margin cross, got %v want %v", st.RecoveryObservedAt, tCross)
+	}
+
+	// After a full switchback delay of continuous past-hysteresis recovery → switchback.
+	res, _ = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered,
+		true, 60*time.Second, tCross.Add(60*time.Second), margin, AntiFlapConfig{}, st)
+	if res.Decision != DecisionSwitchback {
+		t.Fatalf("after switchbackDelay of continuous past-hysteresis recovery, expected Switchback, got %s: %s",
+			res.Decision, res.Reason)
+	}
+}
+
+// invalidExponentTrigger is syntactically well-formed and PASSES CEL admission (the
+// pattern allows an unbounded exponent) yet is invalid at runtime: strconv.ParseFloat
+// overflows to +Inf → ParseTrigger errors → the set is allInvalid. It is the realistic
+// production input for the pass-ended-vs-allInvalid ordering test below.
+const invalidExponentTrigger = "rsrp < 1e999"
+
+// TestBase_AllInvalid_PassEnded_ForcesSwitchback is the P1 regression: an all-invalid
+// trigger set on a satellite whose pass has ENDED must return to terrestrial. Before the
+// fix the allInvalid guard ran BEFORE the pass-ended check and returned Stay(satellite) —
+// a traffic black hole on a satellite that has physically set. Orbital reality precedes
+// trigger validity. (Mutation check: revert the reorder → this Stays on satellite.)
+func TestBase_AllInvalid_PassEnded_ForcesSwitchback(t *testing.T) {
+	res := EvaluateFailoverWithContext(
+		context.Background(), PathSatellite, []string{invalidExponentTrigger}, inertPacketLoss,
+		false /* pass ended */, 60*time.Second, now.Add(-90*time.Second), now,
+	)
+	if res.Decision != DecisionSwitchback || res.TargetPath != PathTerrestrial {
+		t.Fatalf("all-invalid triggers on an ENDED pass must switch back to terrestrial, not black-hole on "+
+			"the set satellite, got %s→%s: %s", res.Decision, res.TargetPath, res.Reason)
+	}
+}
+
+// TestHysteresis_AllInvalid_PassEnded_ForcesSwitchback pins the same ordering in the
+// hysteresis evaluator (allInvalid guard was at line 508, pass-ended at 517).
+func TestHysteresis_AllInvalid_PassEnded_ForcesSwitchback(t *testing.T) {
+	res := EvaluateFailoverWithHysteresis(
+		context.Background(), PathSatellite, []string{invalidExponentTrigger}, inertPacketLoss,
+		false /* pass ended */, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if res.Decision != DecisionSwitchback || res.TargetPath != PathTerrestrial {
+		t.Fatalf("all-invalid + ended pass must switch back to terrestrial in the hysteresis path too, "+
+			"got %s→%s: %s", res.Decision, res.TargetPath, res.Reason)
+	}
+}
+
+// TestPassEnded_UnknownTrigger_HonestReason pins the honest reason (Finding 3): when the
+// pass ends while recovery is unverifiable (an unknown/unsourced trigger), the reason must
+// NOT claim "terrestrial recovered" — the decision (leave the set satellite) is right, but
+// the condition must not mislead diagnosis.
+func TestPassEnded_UnknownTrigger_HonestReason(t *testing.T) {
+	res := EvaluateFailoverWithHysteresis(
+		context.Background(), PathSatellite, []string{"packetLoss > 5"}, inertPacketLoss,
+		false /* pass ended */, 60*time.Second, now.Add(-90*time.Second), now, 10,
+	)
+	if res.Decision != DecisionSwitchback {
+		t.Fatalf("ended pass must switch back, got %s: %s", res.Decision, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "unconfirmed") || strings.Contains(res.Reason, "recovered") {
+		t.Fatalf("pass-ended reason must be honest about unconfirmed recovery, not claim 'recovered': %q", res.Reason)
+	}
+}
+
+// TestBase_UnknownTrigger_Init_PrefersSatellite pins Finding 2: initialising from an
+// unavailable/unknown path with unknown terrestrial telemetry must NOT be read as
+// "terrestrial healthy". A CONFIRMED-available satellite is preferred over an unproven
+// terrestrial assumption.
+func TestBase_UnknownTrigger_Init_PrefersSatellite(t *testing.T) {
+	res := EvaluateFailoverWithContext(
+		context.Background(), PathUnavailable, []string{"packetLoss > 5"}, inertPacketLoss,
+		true /* satellite available */, 60*time.Second, time.Time{}, now,
+	)
+	if res.Decision != DecisionFailover || res.TargetPath != PathSatellite {
+		t.Fatalf("init with unknown terrestrial telemetry + a confirmed satellite must use the satellite, "+
+			"not init on unproven terrestrial, got %s→%s: %s", res.Decision, res.TargetPath, res.Reason)
+	}
+}
+
+// TestBase_UnknownTrigger_Init_NoSatellite_FallsBackTerrestrial is the calibration of
+// Finding 2: with NO satellite, we still fall back to terrestrial (the primary) rather
+// than park on PathUnavailable — parking would black-hole traffic on an unproven
+// assumption. The reason must be honest that quality is unconfirmed.
+func TestBase_UnknownTrigger_Init_NoSatellite_FallsBackTerrestrial(t *testing.T) {
+	res := EvaluateFailoverWithContext(
+		context.Background(), PathUnavailable, []string{"packetLoss > 5"}, inertPacketLoss,
+		false /* no satellite */, 60*time.Second, time.Time{}, now,
+	)
+	if res.Decision != DecisionSwitchback || res.TargetPath != PathTerrestrial {
+		t.Fatalf("init with unknown telemetry and no satellite must fall back to terrestrial, not park on "+
+			"unavailable, got %s→%s: %s", res.Decision, res.TargetPath, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "unconfirmed") {
+		t.Fatalf("the terrestrial-fallback reason must be honest that quality is unconfirmed: %q", res.Reason)
+	}
+}
+
+// TestConfirmedRecovered_AllInvalid_NotRecovered pins the cheap half of Finding 6: an
+// all-invalid (broken) policy must NOT count as a confirmed recovery (which would
+// pre-start the switchback recovery clock). An EMPTY policy still trivially recovers.
+func TestConfirmedRecovered_AllInvalid_NotRecovered(t *testing.T) {
+	healthy := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
+	if terrestrialConfirmedRecovered([]string{invalidExponentTrigger}, healthy, 10) {
+		t.Fatal("an all-invalid policy must NOT be treated as confirmed-recovered")
+	}
+	if !terrestrialConfirmedRecovered(nil, healthy, 10) {
+		t.Fatal("an empty policy must remain trivially confirmed-recovered")
+	}
+	if !terrestrialConfirmedRecovered([]string{"rsrp < -120"}, healthy, 10) {
+		t.Fatal("a valid, past-margin-recovered policy must be confirmed-recovered")
+	}
+}
+
+// TestAntiFlap_InitToTerrestrial_DoesNotStartDwell pins M1: initialising onto
+// terrestrial from an unavailable path emits DecisionSwitchback, but it is NOT a
+// quality-driven hand-back, so it must not start the min-dwell clock — otherwise a
+// subsequent real degradation would be wrongly dwell-blocked.
+func TestAntiFlap_InitToTerrestrial_DoesNotStartDwell(t *testing.T) {
+	cfg := AntiFlapConfig{MinTerrestrialDwell: 90 * time.Second}
+	healthy := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
+
+	res, st := EvaluateFailoverWithAntiFlap(context.Background(), PathUnavailable, triggers, healthy,
+		true, 60*time.Second, now, 0, cfg, AntiFlapState{})
+	if res.Decision != DecisionSwitchback {
+		t.Fatalf("init from unavailable → terrestrial expected Switchback, got %s: %s", res.Decision, res.Reason)
+	}
+	if !st.LastSwitchback.IsZero() {
+		t.Fatal("init-to-terrestrial must NOT start the min-dwell clock (M1)")
+	}
+
+	// A real degradation immediately after must be free to fail over, not dwell-blocked.
+	degraded := Metrics{RSRP: -130, LatencyMs: 20, PacketLossPercent: 0.1}
+	res2, _ := EvaluateFailoverWithAntiFlap(context.Background(), PathTerrestrial, triggers, degraded,
+		true, 60*time.Second, now.Add(time.Second), 0, cfg, st)
+	if res2.Decision != DecisionFailover {
+		t.Fatalf("a real degradation after init must fail over (not be dwell-blocked), got %s: %s",
+			res2.Decision, res2.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

The failover state machine treated **"no trigger fired" as "terrestrial recovered"**, even when triggers couldn't be evaluated. Several audit-review findings (#199, #203) share this binary-boolean root cause; this replaces it with **Healthy / Degraded / Unknown** handling. Pure logic — **no API/CRD change**.

## Fixes

- **Inert-trigger vacuous recovery (P1 data-plane)** — #199-C1. When every trigger's metric has no live source, the empty parsed set was read as "recovered" and the slice switched traffic **back onto a link whose quality is unverifiable**. `parseTriggerSet` now records `hasUnknownTrigger`; on the satellite path (both the base and hysteresis evaluators) an unknown trigger **HOLDS on satellite** instead of switching back. A physically-ended pass still forces the return to terrestrial. **Mutation-proven** (removing the hold → it switches back "Terrestrial recovered past hysteresis dead-band").
- **Hysteresis-aware recovery clock** — #203-H3. The switchback delay was measured from the raw threshold clearing, so time in the dead-band counted as recovery. New `terrestrialConfirmedRecovered` (all known triggers past the margin, none unknown) drives a three-state clock update — the recovery clock advances **only while confirmed recovered**. **Mutation-proven**.
- **Dwell only on a real hand-back** — #203-M1. `LastSwitchback` (min-dwell start) is set only when `currentPath==PathSatellite`, so initialising onto terrestrial from an unavailable/unknown path no longer spuriously starts the dwell and blocks a later failover.
- **`TriggersReady=Unknown` when metrics are unreliable** — #199-C5. It was a stale `True`/`False` on the current generation (`reportInertTriggers` ran only on the reliable path).
- **Reset recovery/confirmation streak on a telemetry gap** — #203-H2. When metrics are unreliable or satellite availability is unknown, `resetRecoveryStreak` clears `RecoveryObservedAt` + `ConsecutiveDegraded` (absence of evidence is not evidence of recovery — a single healthy sample after a long gap must not satisfy the switchback delay via a stale timestamp). The **min-dwell clock is wall-clock based and preserved**.

## Notable

An existing test (`should switchback when terrestrial recovers and delay has passed`) was passing **via the vacuous-recovery bug** — it used a slice with no sourced metrics (all triggers inert). It now supplies genuine, sourced recovery metrics, matching its stated intent.

## Deferred (tracked follow-ups — need new status fields)

Persist dwell/recovery to `.status` (restart-safe, #203-H1/M4), reset on generation change (#203-M2), `confirmationSamples` observation-gating (#203-M3), `*int→*int32` (#203-Low); and the CEL exponent-overflow admission/runtime parity fix (#199-C4). These need API/CRD changes and are a separate PR.

## Verification

`make test` (envtest, slice 92.7% / controller 87.3%), `golangci-lint` (**0**), `gofmt`, `go test -race` — all green. Both key fixes mutation-proven.