### PR TITLE
fix(push): gate runtime ephemeris push on input currency + per-satellite freshness (#204-G1, #200-C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not authorized" message; the specific cause is logged for the operator only (closes a
   Secret existence/type oracle for a CR-writer without `secrets get`).
 
+### Fixed
+
+- **Runtime ephemeris push is gated on propagation-input currency and per-satellite
+  freshness.** The `NTNCellConfig` runtime push consumes `SatelliteEphemeris.status.propagatedStates`
+  across a watch fan-out; it now refuses to push when those states were computed under
+  different propagation inputs than the live spec (`status.propagatedStatesInputHash` — a
+  digest of source type/url + NORAD selector, NOT the whole spec) so a source/selector edit
+  whose re-propagate has not yet succeeded can't ship stale orbital data (reason
+  `EphemerisInputsStale`, non-requeuing). Freshness is now **per-satellite** (new
+  `propagatedStates[].sourceEpochUnixMs`): a stale sibling in the same `SatelliteEphemeris`
+  no longer blocks a cell whose selected satellite is fresh.
+- **The runtime push re-validates currency on EVERY reconcile, not just when a new push is
+  imminent.** The dedup ("already pushed this marker") check now runs AFTER the epoch and
+  source-epoch gates. Previously a stalled producer — controller down, fetcher-setup
+  failure, upstream outage — stopped re-propagating, so the dedup marker stopped changing
+  and every reconcile short-circuited past the freshness gates while the already-delivered
+  epoch expired on the gNB, all while `ephemeris_push_ready` stayed at `1` (falsely
+  healthy). The push now fails closed (`EphemerisPushed=False`, `ephemeris_push_ready=0`)
+  once the delivered data goes stale, so `push_ready == 0 for 15m` alerts (issue #216).
+- **The in-memory OMM cache is keyed on the upstream payload identity (source type + URL),
+  not `.metadata.generation`.** Generation bumps on ANY spec edit — including
+  `passPrediction` / `refreshInterval`, which do not change the upstream payload — and
+  dropping the cache on those edits left a fetch that failed right afterwards with NO
+  fallback, so the producer could not re-propagate and SIB19 continuity broke. A
+  non-propagation edit now keeps last-good OMMs usable, so re-propagation survives an
+  upstream outage. (The NORAD selector is excluded from the cache key on purpose: it is
+  applied client-side, so a selector edit must not discard the raw OMMs.)
+- **An implausibly future-dated element set is rejected by the producer, before SGP4 runs**
+  (not only at the push). A far-future epoch from a corrupt or spoofed feed would otherwise
+  drive SGP4 *backward* from the bogus epoch and write a wildly wrong ECEF into status; the
+  consumer check alone could only block its delivery, not the propagation.
+
 ### Upgrade notes
 
 - **Breaking (`remoteControl.tls`):** an existing remote-control credential Secret must
@@ -44,6 +76,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RemoteControlConfigInvalid` (a permanent, non-tight-requeuing error that clears when
   the Secret is fixed). Add the label before upgrading. Note the opt-in is
   namespace-scoped; a per-CR grant is a future hardening.
+- **Runtime push is fail-closed for one reconcile cycle after upgrade.** Existing
+  `SatelliteEphemeris` objects have no `status.propagatedStatesInputHash` until the
+  controller re-propagates them, so the runtime push briefly reports
+  `EphemerisPushed=False` (reason `EphemerisInputsStale`) until the first successful
+  post-upgrade fetch+propagate stamps the hash. The gNB retains its last-pushed config in
+  the meantime. Ensure the GP source (CelesTrak/Space-Track) is reachable during the
+  rollout — a fetch outage coinciding with the upgrade (e.g. a CelesTrak per-update-window
+  rate-limit) extends the window until the next successful fetch. This is intentional
+  fail-closed behavior (never push data of unverified currency), not a data loss.
 
 ## [0.7.0] - 2026-07-12
 

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -155,6 +155,15 @@ type PropagatedState struct {
 	// epochUnixMs is the propagation epoch in Unix milliseconds (in the future,
 	// as OCUDU's ntn_config_update requires).
 	EpochUnixMs int64 `json:"epochUnixMs"`
+	// sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+	// this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+	// future propagation target), this is the element-set age used by the runtime-push
+	// consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+	// freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+	// this one. 0 means the source epoch could not be parsed (treated as unknown, not
+	// stale).
+	// +optional
+	SourceEpochUnixMs int64 `json:"sourceEpochUnixMs,omitempty"`
 	// ecef is the propagated position/velocity in 3GPP codepoints. The provider
 	// converts these to physical SI when pushing to OCUDU.
 	ECEF EphemerisECEF `json:"ecef"`
@@ -162,6 +171,19 @@ type PropagatedState struct {
 
 // SatelliteEphemerisStatus defines the observed state of SatelliteEphemeris.
 type SatelliteEphemerisStatus struct {
+	// propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+	// orbital data is fetched and WHICH satellites are propagated (source type/url and the
+	// NORAD selector) — NOT the whole spec. It is stamped whenever the current
+	// propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+	// cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+	// spec and refuses to push when it differs — i.e. the persisted states were computed
+	// under different propagation inputs (a source/selector edit whose re-propagate has
+	// not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+	// (#204-G1). Empty means the states predate this field (never re-propagated since
+	// upgrade) or no successful reconcile yet.
+	// +optional
+	PropagatedStatesInputHash string `json:"propagatedStatesInputHash,omitempty"`
+
 	// lastUpdated is when the GP data was last successfully fetched.
 	// +optional
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -357,6 +357,17 @@ spec:
                         truncates the externally-sourced name to this length).
                       maxLength: 64
                       type: string
+                    sourceEpochUnixMs:
+                      description: |-
+                        sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+                        this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+                        future propagation target), this is the element-set age used by the runtime-push
+                        consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+                        freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
+                        stale).
+                      format: int64
+                      type: integer
                   required:
                   - ecef
                   - epochUnixMs
@@ -365,6 +376,19 @@ spec:
                   type: object
                 maxItems: 128
                 type: array
+              propagatedStatesInputHash:
+                description: |-
+                  propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+                  orbital data is fetched and WHICH satellites are propagated (source type/url and the
+                  NORAD selector) — NOT the whole spec. It is stamped whenever the current
+                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  spec and refuses to push when it differs — i.e. the persisted states were computed
+                  under different propagation inputs (a source/selector edit whose re-propagate has
+                  not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+                  (#204-G1). Empty means the states predate this field (never re-propagated since
+                  upgrade) or no successful reconcile yet.
+                type: string
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -357,6 +357,17 @@ spec:
                         truncates the externally-sourced name to this length).
                       maxLength: 64
                       type: string
+                    sourceEpochUnixMs:
+                      description: |-
+                        sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+                        this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+                        future propagation target), this is the element-set age used by the runtime-push
+                        consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+                        freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
+                        stale).
+                      format: int64
+                      type: integer
                   required:
                   - ecef
                   - epochUnixMs
@@ -365,6 +376,19 @@ spec:
                   type: object
                 maxItems: 128
                 type: array
+              propagatedStatesInputHash:
+                description: |-
+                  propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+                  orbital data is fetched and WHICH satellites are propagated (source type/url and the
+                  NORAD selector) — NOT the whole spec. It is stamped whenever the current
+                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  spec and refuses to push when it differs — i.e. the persisted states were computed
+                  under different propagation inputs (a source/selector edit whose re-propagate has
+                  not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+                  (#204-G1). Empty means the states predate this field (never re-propagated since
+                  upgrade) or no successful reconcile yet.
+                type: string
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -360,6 +360,17 @@ spec:
                         truncates the externally-sourced name to this length).
                       maxLength: 64
                       type: string
+                    sourceEpochUnixMs:
+                      description: |-
+                        sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+                        this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+                        future propagation target), this is the element-set age used by the runtime-push
+                        consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+                        freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
+                        stale).
+                      format: int64
+                      type: integer
                   required:
                   - ecef
                   - epochUnixMs
@@ -368,6 +379,19 @@ spec:
                   type: object
                 maxItems: 128
                 type: array
+              propagatedStatesInputHash:
+                description: |-
+                  propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+                  orbital data is fetched and WHICH satellites are propagated (source type/url and the
+                  NORAD selector) — NOT the whole spec. It is stamped whenever the current
+                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  spec and refuses to push when it differs — i.e. the persisted states were computed
+                  under different propagation inputs (a source/selector edit whose re-propagate has
+                  not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+                  (#204-G1). Empty means the states predate this field (never re-propagated since
+                  upgrade) or no successful reconcile yet.
+                type: string
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3325,6 +3325,22 @@ under the etcd object-size limit.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>propagatedStatesInputHash</b></td>
+        <td>string</td>
+        <td>
+          propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+orbital data is fetched and WHICH satellites are propagated (source type/url and the
+NORAD selector) — NOT the whole spec. It is stamped whenever the current
+propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+spec and refuses to push when it differs — i.e. the persisted states were computed
+under different propagation inputs (a source/selector edit whose re-propagate has
+not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+(#204-G1). Empty means the states predate this field (never re-propagated since
+upgrade) or no successful reconcile yet.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>satelliteCount</b></td>
         <td>integer</td>
         <td>
@@ -3535,6 +3551,21 @@ as OCUDU's ntn_config_update requires).<br/>
 truncates the externally-sourced name to this length).<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>sourceEpochUnixMs</b></td>
+        <td>integer</td>
+        <td>
+          sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+future propagation target), this is the element-set age used by the runtime-push
+consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+this one. 0 means the source epoch could not be parsed (treated as unknown, not
+stale).<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -71,6 +71,14 @@ const (
 	ephemerisReasonProviderPushRejected = "ProviderPushRejected"
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
 	ephemerisReasonRemoteControlConfig  = "RemoteControlConfigInvalid"
+	// ephemerisReasonInputsStale marks a push HELD because the referenced
+	// SatelliteEphemeris's propagatedStates were computed under DIFFERENT propagation
+	// inputs than the live spec (status.propagatedStatesInputHash != hash(spec)) — a
+	// source/selector edit whose re-propagate has not yet succeeded (#204-G1). It does NOT
+	// fire on a pass-prediction-only edit. It clears when the producer re-propagates (its
+	// Status().Update re-triggers this reconcile via the ephemeris watch), so it is
+	// non-requeuing like the other await-external-change reasons.
+	ephemerisReasonInputsStale = "EphemerisInputsStale"
 )
 
 // epochSkewMargin is how far in the future a propagated epoch must be to be worth
@@ -79,6 +87,19 @@ const (
 // margin of now is treated as stale and skipped (awaiting the SatelliteEphemeris
 // producer's refresh) rather than pushed and rejected in a tight loop.
 const epochSkewMargin = 10 * time.Second
+
+// maxSourceEpochFutureSkew bounds how far into the future a SOURCE element-set epoch may
+// be before it is treated as implausible (a corrupt or spoofed feed). Real OMM/TLE epochs
+// are at or before "now"; a far-future epoch would otherwise sail past the "older than
+// maxEpochAge" check, which only catches the PAST direction.
+//
+// It is enforced in TWO places, deliberately: the producer refuses to PROPAGATE from such
+// an element set (propagateStates — SGP4 would be driven backward from the bogus epoch,
+// writing a wildly wrong ECEF into status), and the consumer refuses to PUSH one if it
+// ever reaches status anyway (defense in depth). The consumer check alone cannot prevent
+// the backward propagation, only its delivery. Generous, so legitimate near-present epochs
+// are never rejected.
+const maxSourceEpochFutureSkew = 24 * time.Hour
 
 type ephemerisPushError struct {
 	reason string
@@ -119,6 +140,7 @@ func ephemerisPushShouldRequeue(reason string) bool {
 	case ephemerisReasonRefNotFound,
 		ephemerisReasonPayloadMissing,
 		ephemerisReasonEphemerisStale,
+		ephemerisReasonInputsStale,
 		ephemerisReasonRemoteControlConfig,
 		ephemerisReasonProviderPushRejected:
 		// These clear only on an external change — a spec edit (generation bump)
@@ -563,6 +585,25 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	eph *ntnv1alpha1.SatelliteEphemeris,
 	prov provider.NTNProvider,
 ) (bool, string, error) {
+	// Gate — stale propagation inputs (#204-G1): the propagatedStates must reflect the
+	// CURRENT propagation-relevant spec (source type/url + NORAD selector). The producer
+	// stamps status.propagatedStatesInputHash whenever it (re)propagates; if the live
+	// spec hashes differently, a source/selector edit's re-propagate has not yet
+	// succeeded and the persisted states are stale for the current inputs — pushing them
+	// would send orbital data computed under superseded inputs. This deliberately does
+	// NOT fire on a pass-prediction-only / refreshInterval edit (those do not change the
+	// propagated ECEF), preserving last-good continuity during an upstream outage
+	// (#221 review finding 2). An empty stored hash — states predating this field on
+	// upgrade, or no successful reconcile yet — also blocks until the first
+	// re-propagation stamps it (fail-closed; see CHANGELOG upgrade note). Wait for the
+	// producer to re-propagate; its Status().Update re-triggers this reconcile via the
+	// ephemeris watch.
+	if eph.Status.PropagatedStatesInputHash != propagationInputHash(eph.Spec) {
+		return false, ephemerisPushMarker(eph), newEphemerisPushError(
+			ephemerisReasonInputsStale,
+			fmt.Errorf("SatelliteEphemeris %q propagatedStates were computed under different propagation inputs than the current spec; awaiting re-propagation", eph.Name),
+		)
+	}
 	state := selectPropagatedState(eph.Status.PropagatedStates, spec.EphemerisNoradID)
 	if state == nil {
 		// A referenced satellite that the SatelliteEphemeris rejected as deep-space
@@ -580,16 +621,17 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		)
 	}
 
-	// Dedup on the propagated epoch (I-12): re-push whenever the SatelliteEphemeris
-	// re-propagated to a fresh epoch — the watch fans that out to this reconcile, so
-	// keying on the epoch (not the 2h-stable LastUpdated) keeps the gNB fresh between
-	// GP fetches and recovers it after a gNB restart. Same epoch ⇒ same marker ⇒ no
-	// redundant push; spec changes (koffset/TA/satSwitch) still re-push via the
-	// ObservedGeneration check in isEphemerisPushUpToDate.
 	marker := runtimeEphemerisPushMarker(eph, state)
-	if isEphemerisPushUpToDate(cc, marker) {
-		return false, marker, nil
-	}
+
+	// ---- Currency gates: these MUST run BEFORE the dedup early-return below. ----
+	// A stalled producer (controller down, fetcher-setup failure, upstream outage) stops
+	// re-propagating, so the marker STOPS CHANGING while the already-delivered epoch
+	// expires on the gNB. If dedup returned first, these gates would never run again and
+	// the caller would keep reporting EphemerisPushReady=1 — falsely healthy in exactly
+	// the producer-stall case the hard gate exists for. Re-validating currency on EVERY
+	// reconcile (not only when a new push is imminent) makes the push fail CLOSED
+	// (EphemerisPushed=False + push_ready=0) once the delivered data goes stale, so
+	// `push_ready == 0 for 15m` alerts (issue #216). #221 review finding 1.
 
 	// Skip a stale (past / about-to-expire) epoch rather than push a value OCUDU
 	// will reject. The state is only valid for its own epoch, so re-labeling it
@@ -603,6 +645,43 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 				eph.Name, state.EpochUnixMs),
 		)
 	}
+	// Hard-stale, per-satellite (#200-C4; #221 review finding 1): refuse to push the
+	// SELECTED satellite when its OWN source element-set epoch is beyond the freshness
+	// bound (drifting) or implausibly future-dated. Per-satellite, so a stale, cap-omitted,
+	// or unselected sibling in the same SatelliteEphemeris does NOT block this cell. A 0
+	// source epoch means the producer could not parse it (unknown, not stale) — allowed,
+	// matching the producer's stale-count which also skips unparseable epochs.
+	if state.SourceEpochUnixMs != 0 {
+		src := time.UnixMilli(state.SourceEpochUnixMs)
+		nowT := time.Now()
+		if nowT.Sub(src) > maxEpochAge {
+			return false, marker, newEphemerisPushError(
+				ephemerisReasonEphemerisStale,
+				fmt.Errorf("selected satellite %d source element epoch is older than %s (drifting); awaiting SatelliteEphemeris refresh",
+					state.NoradID, maxEpochAge),
+			)
+		}
+		if src.After(nowT.Add(maxSourceEpochFutureSkew)) {
+			return false, marker, newEphemerisPushError(
+				ephemerisReasonEphemerisStale,
+				fmt.Errorf("selected satellite %d source element epoch %s is implausibly future-dated; refusing",
+					state.NoradID, src.UTC()),
+			)
+		}
+	}
+
+	// Dedup on the propagated epoch (I-12): re-push whenever the SatelliteEphemeris
+	// re-propagated to a fresh epoch — the watch fans that out to this reconcile, so
+	// keying on the epoch (not the 2h-stable LastUpdated) keeps the gNB fresh between
+	// GP fetches and recovers it after a gNB restart. Same epoch ⇒ same marker ⇒ no
+	// redundant push; spec changes (koffset/TA/satSwitch) still re-push via the
+	// ObservedGeneration check in isEphemerisPushUpToDate. Deliberately placed AFTER the
+	// currency gates above, so a same-marker reconcile still re-validates freshness
+	// instead of short-circuiting past it (#221 review finding 1).
+	if isEphemerisPushUpToDate(cc, marker) {
+		return false, marker, nil
+	}
+
 	ulSync := 5
 	if spec.NTN.NTNUlSyncValidityDur != nil {
 		ulSync = *spec.NTN.NTNUlSyncValidityDur

--- a/internal/controller/ntncellconfig_pushcorrect_test.go
+++ b/internal/controller/ntncellconfig_pushcorrect_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestPushRuntime_SameMarkerBecomesStale_Blocked pins #221 review finding 1: the dedup
+// early-return must NOT short-circuit past the currency gates. When the producer stalls
+// (controller down / fetcher-setup failure / upstream outage) it stops re-propagating, so
+// the marker STOPS CHANGING while the already-delivered epoch expires on the gNB. If dedup
+// ran first, every 5-minute reconcile would return "up to date" and the caller would set
+// EphemerisPushReady=1 — falsely healthy in exactly the producer-stall case the hard gate
+// exists for. Here the state's epoch has EXPIRED but the marker is identical to the one
+// already recorded as pushed; the push must fail CLOSED with EphemerisStale.
+// Mutation: move isEphemerisPushUpToDate back above the epoch check → err becomes nil.
+func TestPushRuntime_SameMarkerBecomesStale_Blocked(t *testing.T) {
+	ctx := context.Background()
+	// Previously-pushed state whose propagated epoch has since expired (producer stalled).
+	eph := ephWithPropagatedState(time.Now().Add(-time.Hour).UnixMilli())
+	marker := runtimeEphemerisPushMarker(eph, &eph.Status.PropagatedStates[0])
+
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+	// Record the EXACT same marker as already pushed, so dedup would match.
+	meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionEphemerisPushed,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Pushed",
+		Message:            marker,
+		ObservedGeneration: cc.Generation,
+	})
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("an expired state must never be (re)pushed: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+	if err == nil {
+		t.Fatal("a same-marker reconcile whose delivered epoch has EXPIRED must report EphemerisStale, " +
+			"not silently return up-to-date (the caller would then set EphemerisPushReady=1 — falsely healthy)")
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonEphemerisStale {
+		t.Fatalf("stale-after-dedup reason = %q, want %q", got, ephemerisReasonEphemerisStale)
+	}
+}
+
+// TestPushRuntime_StaleInputs_Blocked_G1 pins #204-G1: when a source/selector edit has
+// changed the propagation inputs but the re-propagate has not yet succeeded (the stored
+// propagatedStatesInputHash no longer matches hash(spec)), the persisted states are stale
+// for the current inputs and MUST NOT be pushed.
+func TestPushRuntime_StaleInputs_Blocked_G1(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	// Simulate a source edit AFTER the fixture stamped the hash: the live spec now hashes
+	// differently from the persisted states' recorded inputs.
+	eph.Spec.Source.URL = "https://celestrak.org/CHANGED"
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("states computed under superseded inputs must NOT be pushed: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonInputsStale {
+		t.Fatalf("blocked-push reason = %q, want %q", got, ephemerisReasonInputsStale)
+	}
+	if ephemerisPushShouldRequeue(ephemerisReasonInputsStale) {
+		t.Fatal("inputs-stale must be non-requeuing (it clears on the ephemeris watch)")
+	}
+}
+
+// TestPushRuntime_CurrentInputs_Pushes_G1 is the paired positive: matching input hash
+// (the fixture stamps it) pushes normally — proving the gate is input-specific.
+func TestPushRuntime_CurrentInputs_Pushes_G1(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if err != nil || !pushed || mock.RuntimeCalls != 1 {
+		t.Fatalf("current-inputs states must push: pushed=%v err=%v RuntimeCalls=%d", pushed, err, mock.RuntimeCalls)
+	}
+}
+
+// TestPushRuntime_EmptyInputHash_Blocked_ColdUpgrade pins the fail-closed cold-upgrade
+// behavior (#221 review finding 3): an object whose propagatedStates predate this field
+// (empty hash) blocks until the first post-upgrade re-propagation stamps it.
+func TestPushRuntime_EmptyInputHash_Blocked_ColdUpgrade(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	eph.Status.PropagatedStatesInputHash = "" // legacy object, never re-propagated since upgrade
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("an empty input hash must fail closed until re-propagation: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonInputsStale {
+		t.Fatalf("cold-upgrade block reason = %q, want %q", got, ephemerisReasonInputsStale)
+	}
+}
+
+// TestPushRuntime_SelectedSatelliteStale_Blocked_C4 pins per-satellite #200-C4: the
+// SELECTED satellite's own source element epoch is beyond the freshness bound → block,
+// even with a valid future propagation epoch and matching input hash.
+func TestPushRuntime_SelectedSatelliteStale_Blocked_C4(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	eph.Status.PropagatedStates[0].SourceEpochUnixMs = time.Now().Add(-8 * 24 * time.Hour).UnixMilli() // 8 days old
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("a stale SELECTED satellite must block the push: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonEphemerisStale {
+		t.Fatalf("selected-stale reason = %q, want %q", got, ephemerisReasonEphemerisStale)
+	}
+}
+
+// TestPushRuntime_UnselectedSiblingStale_Pushes_C4 is THE regression fix for #221 review
+// finding 1: a stale UNSELECTED sibling in the same SatelliteEphemeris must NOT block a
+// cell whose selected satellite is fresh. The old per-resource EphemerisEpochStale gate
+// wrongly blocked this.
+func TestPushRuntime_UnselectedSiblingStale_Pushes_C4(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli()) // NORAD 25544, fresh (selected)
+	// Add a stale sibling the cell does NOT select.
+	eph.Status.PropagatedStates = append(eph.Status.PropagatedStates, ntnv1alpha1.PropagatedState{
+		Satellite: "SAT-OLD", NoradID: 200, EpochUnixMs: time.Now().Add(time.Hour).UnixMilli(),
+		SourceEpochUnixMs: time.Now().Add(-30 * 24 * time.Hour).UnixMilli(), // 30 days old
+		ECEF:              ntnv1alpha1.EphemerisECEF{PosX: 1, PosY: 2, PosZ: 3},
+	})
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl() // selects NORAD 25544
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if err != nil || !pushed || mock.RuntimeCalls != 1 {
+		t.Fatalf("a stale UNSELECTED sibling must not block a fresh selected satellite: pushed=%v err=%v RuntimeCalls=%d",
+			pushed, err, mock.RuntimeCalls)
+	}
+}
+
+// TestPushRuntime_FutureDatedSource_Blocked pins #221 review finding 5: an implausibly
+// future-dated source epoch is rejected rather than driving a long backward propagation.
+func TestPushRuntime_FutureDatedSource_Blocked(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	eph.Status.PropagatedStates[0].SourceEpochUnixMs = time.Now().Add(30 * 24 * time.Hour).UnixMilli() // 30 days future
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("an implausibly future-dated source epoch must block: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonEphemerisStale {
+		t.Fatalf("future-dated reason = %q, want %q", got, ephemerisReasonEphemerisStale)
+	}
+}

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -53,16 +53,23 @@ func TestSelectPropagatedState(t *testing.T) {
 }
 
 func ephWithPropagatedState(futureMs int64) *ntnv1alpha1.SatelliteEphemeris {
-	return &ntnv1alpha1.SatelliteEphemeris{
+	eph := &ntnv1alpha1.SatelliteEphemeris{
 		ObjectMeta: metav1.ObjectMeta{Name: "eph1", Namespace: "ns", Generation: 1},
 		Status: ntnv1alpha1.SatelliteEphemerisStatus{
 			LastUpdated: &metav1.Time{Time: time.Now()},
 			PropagatedStates: []ntnv1alpha1.PropagatedState{{
 				Satellite: "SAT-A", NoradID: 25544, EpochUnixMs: futureMs,
-				ECEF: ntnv1alpha1.EphemerisECEF{PosX: 5000000, PosY: 4000000, PosZ: 3000000},
+				// Fresh source element epoch so the per-satellite C4 freshness gate passes.
+				SourceEpochUnixMs: time.Now().Add(-time.Hour).UnixMilli(),
+				ECEF:              ntnv1alpha1.EphemerisECEF{PosX: 5000000, PosY: 4000000, PosZ: 3000000},
 			}},
 		},
 	}
+	// A reconciled ephemeris stamps the propagation-input hash of its current spec; the
+	// runtime-push gate requires status.propagatedStatesInputHash == hash(spec) to treat
+	// the propagatedStates as current, so the fixture stamps it.
+	eph.Status.PropagatedStatesInputHash = propagationInputHash(eph.Spec)
+	return eph
 }
 
 // ccWithRemoteControl builds an NTNCellConfig on the runtime-push path: remote

--- a/internal/controller/satelliteephemeris_cachefallback_test.go
+++ b/internal/controller/satelliteephemeris_cachefallback_test.go
@@ -83,8 +83,8 @@ func TestReconcile_FetchError_ServesCache(t *testing.T) {
 		result: ephemeris.GPFetchResult{
 			OMMs: []sgp4.OMM{testISSOMM()}, SatelliteCount: 1, FetchedAt: time.Now().Add(-5 * time.Hour),
 		},
-		generation: got.Generation,
-		uid:        got.UID,
+		fetchKey: fetchInputKey(got.Spec),
+		uid:      got.UID,
 	})
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -18,11 +18,14 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
 	neturl "net/url"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -360,6 +363,16 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// epoch keeps OCUDU's internal propagation short and forward.
 	truncEvent := r.propagateStates(ctx, eph, result, now.Add(propagationEpochLead))
 
+	// Stamp the propagation-input digest these propagatedStates were computed under.
+	// Reaching here means the current spec's inputs were (re)propagated — from a fresh
+	// fetch OR a valid same-generation cache. A fetch failure with NO matching cache
+	// early-returns via handleFetchError, which deliberately does NOT restamp, so the hash
+	// keeps pointing at the LAST inputs that actually produced states. The consumer blocks
+	// only when the live spec's propagation inputs differ from this — a source/selector
+	// edit whose re-propagate has not yet succeeded — not on a pass-prediction-only edit
+	// (#204-G1; #221 review finding 2).
+	eph.Status.PropagatedStatesInputHash = propagationInputHash(eph.Spec)
+
 	if err := r.Status().Update(ctx, eph); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -446,15 +459,32 @@ const propagationEpochLead = 5 * time.Minute
 // NTNCellConfig watch) a fresh push to every referencing cell.
 const propagationRefreshInterval = 3 * time.Minute
 
-// cachedFetch is a per-CR OMM cache entry. generation+uid pin it to the exact
-// spec revision of the exact object: a spec/source edit (generation bump) or a
-// delete-recreate reusing the same name (uid change) invalidates the entry and
-// forces a fresh fetch, so an edited source.URL/type/credentials takes effect
-// immediately rather than after the refresh window (#179 regression guard).
+// cachedFetch is a per-CR OMM cache entry. fetchKey+uid pin it to the RAW UPSTREAM
+// PAYLOAD identity of the exact object: an edited source.type/URL (fetchKey change) or a
+// delete-recreate reusing the same name (uid change) invalidates the entry and forces a
+// fresh fetch, so a changed source takes effect immediately rather than after the refresh
+// window (#179 regression guard).
+//
+// It is deliberately NOT keyed on .metadata.generation. Generation bumps on ANY spec edit
+// — including passPrediction / refreshInterval, which do not change the upstream payload —
+// and dropping the cache on those edits meant a fetch failing right afterwards had NO
+// cache to fall back on, so the producer could not re-propagate and SIB19 continuity broke.
+// Keying on the fetch inputs keeps last-good OMMs usable across non-fetch edits
+// (#221 review finding 2).
 type cachedFetch struct {
-	result     ephemeris.GPFetchResult
-	generation int64
-	uid        types.UID
+	result   ephemeris.GPFetchResult
+	fetchKey string
+	uid      types.UID
+}
+
+// fetchInputKey identifies WHAT RAW upstream payload a cached entry holds: the source type
+// and URL. It deliberately EXCLUDES the NORAD selector — FilterOMMs applies that
+// client-side to the raw payload, so a selector edit must NOT discard the raw OMMs — and
+// every non-fetch field (passPrediction, refreshInterval, credentials: the same URL returns
+// the same GP data regardless of which account fetched it). %q-quoted so a crafted URL
+// cannot forge another spec's key.
+func fetchInputKey(spec ntnv1alpha1.SatelliteEphemerisSpec) string {
+	return fmt.Sprintf("type=%q url=%q", spec.Source.Type, spec.Source.URL)
 }
 
 // cachedOMMResult returns the cached fetch for key, if any.
@@ -511,6 +541,29 @@ func (r *SatelliteEphemerisReconciler) reportEphemerisEpochStale(eph *ntnv1alpha
 	ntnmetrics.EphemerisEpochStaleCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(stale))
 }
 
+// propagationInputHash is a stable digest of the SatelliteEphemeris spec fields that
+// determine WHICH orbital data is fetched and WHICH satellites are propagated — the
+// source (type + url) and the NORAD selector. It deliberately EXCLUDES every field that
+// does not change the propagated ECEF (pass-prediction params, refreshInterval,
+// credentials, the deprecated constellation), so a pass-prediction-only edit does NOT
+// falsely invalidate valid propagated states and break last-good continuity during an
+// upstream outage (#221 review, finding 2). The producer stamps it on every successful
+// (re)propagation; the runtime-push consumer recomputes it from the live spec and blocks
+// only when the propagation-relevant inputs have actually changed.
+func propagationInputHash(spec ntnv1alpha1.SatelliteEphemerisSpec) string {
+	var norad []int
+	if spec.Satellites != nil {
+		norad = append(norad, spec.Satellites.NoradIDs...)
+	}
+	sort.Ints(norad)
+	h := sha256.New()
+	// Quote the user-controlled strings (%q) so a crafted source.url can't embed the field
+	// delimiters and collide with a different spec's serialization. hash.Hash.Write never
+	// returns an error (documented); ignore it explicitly.
+	_, _ = fmt.Fprintf(h, "type=%q\nurl=%q\nnorad=%v\n", spec.Source.Type, spec.Source.URL, norad)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // propagateStates propagates the tracked satellites' orbits (SGP4) to the given
 // future epoch and records the ECEF state vectors in status.propagatedStates for
 // downstream runtime ephemeris push (#176). The set is filtered by
@@ -552,6 +605,22 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 				"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
 			break
 		}
+		// Parse the SOURCE element-set epoch BEFORE propagating (0 if unparseable →
+		// unknown, not stale). An implausibly FUTURE-dated epoch (corrupt or spoofed feed)
+		// must be rejected HERE, not only at the consumer: SGP4 would otherwise be driven
+		// backward from the bogus epoch down to the target, writing a wildly wrong ECEF
+		// into status. Refusing it at the push only stops delivery — it does not stop the
+		// propagation — so the guard belongs on the producer too (#221 review finding 3).
+		srcEpochMs := int64(0)
+		if t, ok := parseOMMEpoch(omms[i].EpochStr); ok {
+			if t.After(epoch.Add(maxSourceEpochFutureSkew)) {
+				logf.FromContext(ctx).Info("skipping satellite: source element epoch is implausibly future-dated",
+					"norad", omms[i].NoradCatID, "sourceEpoch", t.UTC(), "targetEpoch", epoch.UTC(),
+					"allowedSkew", maxSourceEpochFutureSkew.String())
+				continue
+			}
+			srcEpochMs = t.UnixMilli()
+		}
 		ecef, err := ephemeris.PropagateToECEF(omms[i], epoch)
 		if err != nil {
 			continue // skip satellites whose SGP4 propagation fails / goes out of range
@@ -563,10 +632,11 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 			name = name[:maxSatelliteNameLen]
 		}
 		states = append(states, ntnv1alpha1.PropagatedState{
-			Satellite:   name,
-			NoradID:     omms[i].NoradCatID,
-			EpochUnixMs: epochMs,
-			ECEF:        *ecef,
+			Satellite:         name,
+			NoradID:           omms[i].NoradCatID,
+			EpochUnixMs:       epochMs,
+			SourceEpochUnixMs: srcEpochMs,
+			ECEF:              *ecef,
 		})
 	}
 	eph.Status.PropagatedStates = states
@@ -946,8 +1016,9 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 	fetcher ephemeris.GPFetcher, effectiveInterval time.Duration, now time.Time,
 ) (ommFetchOutcome, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
+	fetchKey := fetchInputKey(eph.Spec)
 	if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
-		c.generation == eph.Generation && c.uid == eph.UID &&
+		c.fetchKey == fetchKey && c.uid == eph.UID &&
 		now.Sub(c.result.FetchedAt) < effectiveInterval {
 		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
 			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
@@ -969,8 +1040,11 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 	ntnmetrics.GPFetchDuration.With(prometheus.Labels{"source_type": eph.Spec.Source.Type, "status": fetchStatus}).Observe(time.Since(fetchStart).Seconds())
 
 	if fetchErr != nil {
+		// Fall back to the last-good OMMs for THIS source (fetchKey), not this spec
+		// revision: a passPrediction/refreshInterval edit must not strand the fallback
+		// and break re-propagation during an upstream outage (#221 review finding 2).
 		if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
-			c.generation == eph.Generation && c.uid == eph.UID {
+			c.fetchKey == fetchKey && c.uid == eph.UID {
 			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
 				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String())
 			return ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: fetchErr}, nil, nil
@@ -979,7 +1053,7 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 		return ommFetchOutcome{}, &res, err
 	}
 
-	r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, generation: eph.Generation, uid: eph.UID})
+	r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, fetchKey: fetchKey, uid: eph.UID})
 	return ommFetchOutcome{result: result}, nil, nil
 }
 

--- a/internal/controller/satelliteephemeris_inputhash_test.go
+++ b/internal/controller/satelliteephemeris_inputhash_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestFetchInputKey_ExcludesNonFetchFields pins #221 review finding 2: the OMM cache key
+// must identify the RAW UPSTREAM PAYLOAD (source type + URL) only. Keying it on
+// .metadata.generation over-invalidated — ANY spec edit dropped the cache, so a fetch that
+// failed right after an unrelated edit had NO fallback and the producer could not
+// re-propagate. Note the NORAD selector is EXCLUDED on purpose: FilterOMMs applies it
+// client-side to the raw payload, so a selector edit must not discard the raw OMMs.
+func TestFetchInputKey_ExcludesNonFetchFields(t *testing.T) {
+	base := ntnv1alpha1.SatelliteEphemerisSpec{
+		Source: ntnv1alpha1.EphemerisSource{
+			Type: "CelesTrak", URL: "https://celestrak.org/x",
+			RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+		},
+		Satellites: &ntnv1alpha1.SatelliteSelector{NoradIDs: []int{25544, 200}},
+		PassPrediction: &ntnv1alpha1.PassPredictionSpec{
+			GroundStations: []string{"gs"}, MinElevation: "10",
+			Horizon: metav1.Duration{Duration: 24 * time.Hour},
+		},
+	}
+	k0 := fetchInputKey(base)
+
+	// Edits that do NOT change the upstream payload must keep the SAME key.
+	pp := *base.DeepCopy()
+	pp.PassPrediction.Horizon = metav1.Duration{Duration: 48 * time.Hour}
+	if fetchInputKey(pp) != k0 {
+		t.Error("a passPrediction edit must NOT invalidate the raw OMM cache")
+	}
+	ri := *base.DeepCopy()
+	ri.Source.RefreshInterval = metav1.Duration{Duration: 12 * time.Hour}
+	if fetchInputKey(ri) != k0 {
+		t.Error("a refreshInterval edit must NOT invalidate the raw OMM cache")
+	}
+	ns := *base.DeepCopy()
+	ns.Satellites.NoradIDs = []int{25544}
+	if fetchInputKey(ns) != k0 {
+		t.Error("a NORAD-selector edit must NOT invalidate the raw OMM cache (FilterOMMs is client-side)")
+	}
+
+	// Edits that DO change the upstream payload must change the key.
+	su := *base.DeepCopy()
+	su.Source.URL = "https://celestrak.org/y"
+	if fetchInputKey(su) == k0 {
+		t.Error("a source URL edit MUST invalidate the raw OMM cache")
+	}
+	st := *base.DeepCopy()
+	st.Source.Type = "SpaceTrack"
+	if fetchInputKey(st) == k0 {
+		t.Error("a source type edit MUST invalidate the raw OMM cache")
+	}
+}
+
+// TestReconcile_PassPredictionEdit_FetchFails_ReusesCache is the behavioral half of
+// finding 2: a passPrediction-only edit (which bumps .metadata.generation but changes
+// NOTHING about the upstream payload) followed by a FAILING fetch must still fall back to
+// the last-good OMMs and keep re-propagating — the "non-propagation edits preserve
+// continuity" property this PR claims. With the old generation-keyed cache the fallback was
+// stranded and SIB19 continuity broke.
+// Mutation: make fetchInputKey include passPrediction → the fallback misses → no states.
+func TestReconcile_PassPredictionEdit_FetchFails_ReusesCache(t *testing.T) {
+	sch := makeScheme(t)
+	ctx := context.Background()
+	const ns = "default"
+	gs := &ntnv1alpha1.GroundStationLifecycle{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-taipei", Namespace: ns},
+		Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+			Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "edge-5000"},
+			Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654", Alt: "15"}},
+		},
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-pp", Namespace: ns, Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+			PassPrediction: &ntnv1alpha1.PassPredictionSpec{
+				GroundStations: []string{"gs-taipei"}, MinElevation: "10",
+				Horizon: metav1.Duration{Duration: 24 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(gs, eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-pp", Namespace: ns}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10),
+		Fetcher: &mockGPFetcher{err: errors.New("connection refused")}, // upstream is DOWN
+	}
+	// Cache seeded under the PRE-EDIT spec, older than the 4h window so a fetch is forced.
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now().Add(-5 * time.Hour),
+		},
+		fetchKey: fetchInputKey(got.Spec),
+		uid:      got.UID,
+	})
+
+	// A passPrediction-ONLY edit. Bump generation to simulate the apiserver.
+	got.Spec.PassPrediction.Horizon = metav1.Duration{Duration: 48 * time.Hour}
+	got.Generation = 2
+	if err := cli.Update(ctx, got); err != nil {
+		t.Fatalf("passPrediction edit: %v", err)
+	}
+
+	// Fetch fails; the cache must still serve because the upstream payload identity is
+	// unchanged, so propagation (and therefore SIB19 continuity) survives the outage.
+	_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+
+	after := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, after); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if len(after.Status.PropagatedStates) == 0 {
+		t.Fatal("a passPrediction-only edit + failing fetch must STILL re-propagate from the cached OMMs " +
+			"(#221 review finding 2): the cache key must not include non-fetch spec fields")
+	}
+	if after.Status.PropagatedStatesInputHash != propagationInputHash(after.Spec) {
+		t.Errorf("the re-propagated states must be stamped with the current propagation-input hash")
+	}
+	cond := meta.FindStatusCondition(after.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "FetchFailedServingCache" {
+		t.Errorf("expected GPDataFetched=False/FetchFailedServingCache (degraded but serving), got %+v", cond)
+	}
+}
+
+// TestPropagateStates_SkipsFutureDatedSourceEpoch pins #221 review finding 3: an
+// implausibly FUTURE-dated element set must be rejected by the PRODUCER, before SGP4 runs.
+// The consumer's future-skew check only blocks delivery — it cannot prevent SGP4 being
+// driven backward from a bogus epoch and writing a wildly wrong ECEF into status.
+// Mutation: remove the producer-side guard → a state is produced from the future epoch.
+func TestPropagateStates_SkipsFutureDatedSourceEpoch(t *testing.T) {
+	r := &SatelliteEphemerisReconciler{}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-future", Namespace: "default"},
+	}
+	epoch := time.Now().Add(propagationEpochLead)
+
+	// Element epoch 30 days in the FUTURE (negative age) → must not be propagated at all.
+	r.propagateStates(context.Background(), eph,
+		ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMWithEpoch(-30 * 24 * time.Hour)}}, epoch)
+	if n := len(eph.Status.PropagatedStates); n != 0 {
+		t.Fatalf("an implausibly future-dated element set must NOT be propagated, got %d state(s)", n)
+	}
+
+	// Control: a recent element set still propagates normally.
+	r.propagateStates(context.Background(), eph,
+		ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMWithEpoch(2 * time.Hour)}}, epoch)
+	if n := len(eph.Status.PropagatedStates); n != 1 {
+		t.Fatalf("a fresh element set must still propagate, got %d state(s)", n)
+	}
+}
+
+// TestPropagationInputHash_ScopedToPropagationInputs pins #221 review finding 2: the hash
+// changes ONLY when a propagation-relevant input changes (source type/url, NORAD
+// selector) and is STABLE across edits that do not change the propagated ECEF
+// (pass-prediction params, refreshInterval) — so a pass-prediction-only edit does not
+// falsely invalidate valid propagated states.
+func TestPropagationInputHash_ScopedToPropagationInputs(t *testing.T) {
+	base := ntnv1alpha1.SatelliteEphemerisSpec{
+		Source: ntnv1alpha1.EphemerisSource{
+			Type: "CelesTrak", URL: "https://celestrak.org/x",
+			RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+		},
+		Satellites: &ntnv1alpha1.SatelliteSelector{NoradIDs: []int{25544, 200}},
+	}
+	h0 := propagationInputHash(base)
+
+	// NORAD order must not matter (sorted).
+	reordered := *base.DeepCopy()
+	reordered.Satellites.NoradIDs = []int{200, 25544}
+	if propagationInputHash(reordered) != h0 {
+		t.Fatal("NORAD selector order must not change the hash")
+	}
+
+	// refreshInterval change → SAME hash (not a propagation input).
+	ri := *base.DeepCopy()
+	ri.Source.RefreshInterval = metav1.Duration{Duration: 12 * time.Hour}
+	if propagationInputHash(ri) != h0 {
+		t.Fatal("a refreshInterval-only edit must NOT change the propagation-input hash")
+	}
+
+	// source URL change → DIFFERENT hash.
+	su := *base.DeepCopy()
+	su.Source.URL = "https://celestrak.org/y"
+	if propagationInputHash(su) == h0 {
+		t.Fatal("a source URL edit MUST change the propagation-input hash")
+	}
+
+	// NORAD selector change → DIFFERENT hash.
+	ns := *base.DeepCopy()
+	ns.Satellites.NoradIDs = []int{25544}
+	if propagationInputHash(ns) == h0 {
+		t.Fatal("a NORAD selector edit MUST change the propagation-input hash")
+	}
+}
+
+// TestReconcile_InputHash_StampedOnSuccess_NotRestampedOnStaleInputsFetchFail pins the
+// producer half of #204-G1 under the input-hash model: a successful reconcile stamps
+// propagatedStatesInputHash = hash(spec); after a source edit whose re-fetch then FAILS,
+// the hash is NOT restamped, so it keeps pointing at the OLD inputs (!= hash of the new
+// spec) — which is exactly what lets the consumer detect the stale states.
+func TestReconcile_InputHash_StampedOnSuccess_NotRestampedOnStaleInputsFetchFail(t *testing.T) {
+	sch := makeScheme(t)
+	ctx := context.Background()
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-hash", Namespace: "default", Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/original",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+		},
+	}
+	oldHash := propagationInputHash(eph.Spec)
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	fetcher := &mockGPFetcher{result: ephemeris.GPFetchResult{
+		OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now(),
+	}}
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10), Fetcher: fetcher,
+	}
+	key := types.NamespacedName{Name: "eph-hash", Namespace: "default"}
+
+	// 1) Success stamps hash(spec) and populates a per-state source epoch.
+	if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile 1 (success): %v", err)
+	}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, got); err != nil {
+		t.Fatalf("get after reconcile 1: %v", err)
+	}
+	if got.Status.PropagatedStatesInputHash != oldHash {
+		t.Fatalf("successful reconcile must stamp the input hash, got %q want %q", got.Status.PropagatedStatesInputHash, oldHash)
+	}
+	if len(got.Status.PropagatedStates) == 0 || got.Status.PropagatedStates[0].SourceEpochUnixMs == 0 {
+		t.Fatal("sanity: a successful propagate must write states with a source epoch")
+	}
+
+	// 2) Edit the source URL (new propagation inputs) and fail the re-fetch → the hash
+	//    must NOT be restamped, so it still reflects the OLD inputs. Bump .Generation to
+	//    simulate the apiserver (a spec edit bumps generation, which invalidates the
+	//    generation-keyed OMM cache — otherwise the fetch-fail path would serve old-source
+	//    cache and wrongly restamp; #221 review finding 6, test fidelity).
+	got.Spec.Source.URL = "https://celestrak.org/changed"
+	got.Generation = 2
+	newHash := propagationInputHash(got.Spec)
+	if newHash == oldHash {
+		t.Fatal("test setup: the edited spec must hash differently")
+	}
+	if err := cli.Update(ctx, got); err != nil {
+		t.Fatalf("edit source url: %v", err)
+	}
+	fetcher.err = errors.New("connection refused")
+	fetcher.result = ephemeris.GPFetchResult{}
+	_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+	after := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, after); err != nil {
+		t.Fatalf("get after reconcile 2: %v", err)
+	}
+	if after.Status.PropagatedStatesInputHash != oldHash {
+		t.Fatalf("a failed re-fetch under new inputs must NOT restamp the hash: got %q want (old) %q",
+			after.Status.PropagatedStatesInputHash, oldHash)
+	}
+	if after.Status.PropagatedStatesInputHash == newHash {
+		t.Fatal("the stored hash must NOT match the new spec inputs (states are stale for them)")
+	}
+}

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -357,6 +357,17 @@ spec:
                         truncates the externally-sourced name to this length).
                       maxLength: 64
                       type: string
+                    sourceEpochUnixMs:
+                      description: |-
+                        sourceEpochUnixMs is the epoch of the SOURCE orbital element set (the OMM EPOCH)
+                        this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
+                        future propagation target), this is the element-set age used by the runtime-push
+                        consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
+                        freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
+                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
+                        stale).
+                      format: int64
+                      type: integer
                   required:
                   - ecef
                   - epochUnixMs
@@ -365,6 +376,19 @@ spec:
                   type: object
                 maxItems: 128
                 type: array
+              propagatedStatesInputHash:
+                description: |-
+                  propagatedStatesInputHash is a digest of the spec fields that determine WHICH
+                  orbital data is fetched and WHICH satellites are propagated (source type/url and the
+                  NORAD selector) — NOT the whole spec. It is stamped whenever the current
+                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
+                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  spec and refuses to push when it differs — i.e. the persisted states were computed
+                  under different propagation inputs (a source/selector edit whose re-propagate has
+                  not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
+                  (#204-G1). Empty means the states predate this field (never re-propagated since
+                  upgrade) or no successful reconcile yet.
+                type: string
               satelliteCount:
                 description: satelliteCount is the number of satellites currently
                   tracked.


### PR DESCRIPTION
## Problem

The `NTNCellConfig` runtime push (`ntn_config_update`) consumes `SatelliteEphemeris.status.propagatedStates` across a watch fan-out, but nothing tied those states to the spec revision or the elements they were computed from.

- **Stale push (#204-G1):** on a source/selector edit whose re-fetch then **fails**, `handleFetchError` leaves the old `propagatedStates` intact and persists, re-triggering the consumer — which pushes stale orbital data.
- **Advisory-only staleness (#200-C4):** the 7-day `maxEpochAge` freshness never blocked a push.

## Fix

**Input-currency gate (#204-G1) — keyed on propagation inputs, not `.metadata.generation`:**

- New `status.propagatedStatesInputHash` — SHA-256 over **only** the spec fields that determine which orbital data is fetched / which satellites are propagated (source type/url + sorted NORAD selector; `%q`-quoted so a crafted url can't collide). Stamped whenever the producer (re)propagates.
- `pushRuntimeEphemeris` refuses to push when `hash(live spec) != stored hash` (reason `EphemerisInputsStale`, non-requeuing). A **pass-prediction-only / `refreshInterval` edit does not change the hash**. Empty hash (cold upgrade / never reconciled) fails closed until re-propagation stamps it.

**Per-satellite hard-stale gate (#200-C4) — replaces a per-resource block:**

- New `propagatedStates[].sourceEpochUnixMs` (the source OMM EPOCH each state was propagated from).
- The consumer checks the **selected** satellite's own source epoch: refuse when older than `maxEpochAge` or implausibly future-dated. **A stale, cap-omitted, or unselected sibling no longer blocks a cell whose selected satellite is fresh** — the old per-resource `EphemerisEpochStale` gate wrongly blocked all cells for one unrelated stale satellite. That condition remains as an observability summary.

**Currency is re-validated on EVERY reconcile (review round 2, finding 1):**

The dedup ("already pushed this marker") check now runs **after** the epoch/source-epoch gates. A stalled producer stops re-propagating, so the marker **stops changing** while the already-delivered epoch expires on the gNB — with dedup first, every 5-minute reconcile short-circuited past the freshness gates and the caller still set `ephemeris_push_ready=1` (**falsely healthy**), in exactly the producer-stall case the hard gate exists for. The push now fails closed (`EphemerisPushed=False`, `push_ready=0`), so `push_ready == 0 for 15m` alerts (issue #216).

**OMM cache keyed on upstream payload identity, not generation (review round 2, finding 2):**

`.metadata.generation` bumps on **any** spec edit — including `passPrediction`/`refreshInterval`, which don't change the upstream payload — and dropping the cache on those edits left a fetch failing right afterwards with **no fallback**, so the producer couldn't re-propagate and SIB19 continuity broke. The cache is now keyed on `(source type, URL)`. This is what makes "non-propagation edits preserve continuity" **actually true** rather than merely claimed. The NORAD selector is excluded on purpose: `FilterOMMs` applies it client-side, so a selector edit must not discard the raw OMMs.

**Future-dated element sets rejected by the producer (review round 2, finding 3):**

An implausibly future-dated epoch is now refused **before SGP4 runs**, not only at the push — SGP4 would otherwise be driven *backward* from the bogus epoch and write a wildly wrong ECEF into status. The consumer check is kept as defense in depth.

Regenerated all 4 CRD copies + `docs/api-reference.md`; bundle+nephio drift-verify clean.

## Tests (mutation-proven where noted)

- input-hash scoped to propagation inputs (order-independent, refreshInterval-stable, url/norad-sensitive)
- producer stamps on success, does **not** restamp on a failed re-fetch under new inputs
- consumer blocks: stale inputs \*, empty-hash cold upgrade, stale **selected** satellite \*, future-dated source
- consumer **passes** a fresh selected satellite despite a 30-day-stale **unselected** sibling
- **same-marker-becomes-stale must fail closed** \* (round-2 finding 1)
- **`fetchInputKey` excludes passPrediction/refreshInterval/NORAD, includes source type+url** \*, and a **passPrediction edit + failing fetch still re-propagates from cache** \* (round-2 finding 2)
- **producer skips a future-dated element set before SGP4** \* (round-2 finding 3)

`make test` (controller 87.3% cov) / golangci-lint 0 / gofmt / go vet / go test -race — all green.

## ~~Kept deliberately~~ — SUPERSEDED by #225

> ⚠ This PR originally argued that `sourceEpochUnixMs == 0` should stay **fail-open**, on the grounds that our `parseOMMEpoch` accepts fewer layouts than the sgp4 dependency. **That rationale was wrong and has been retracted.** Checked layout-for-layout against `akhenakh/sgp4 v1.0.1`: there is nothing the dependency accepts that we reject (Go's `time.Parse` takes a fractional second even when the layout omits it, and defaults to UTC), and `PropagateToECEF -> ToTLE` parses the *same* epoch, so an unparseable element set fails propagation anyway. Meanwhile `0` is also the legal instant `1970-01-01T00:00:00Z`, so the fail-open let a 1970-dated element set bypass the entire 7-day freshness gate.
>
> **#225 (stacked on this PR) fixes it:** the producer never emits a state whose epoch it could not parse, and the consumer validates unconditionally. Merge #225 together with / right after this one.


## Deferred

- envtest lifecycle test with a **real** apiserver generation bump (the unit test documents the simulated bump).
- G2 bounded reassert — the 3-min re-propagation cadence already bounds re-pushes.

