### PR TITLE
fix(fetch): harden GP fetch against SSRF proxy-bypass + resilience gaps (#199-C2/C3, #200-C2/C3/C6/C7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EphemerisPushed=False` condition/event now carries a uniform "credential unavailable or
   not authorized" message; the specific cause is logged for the operator only (closes a
   Secret existence/type oracle for a CR-writer without `secrets get`).
+- **SSRF-safe HTTP client hardened against proxy bypass and TLS downgrade.** `NewSafeHTTPClient`
+  (used for GP ephemeris fetch, the NTNSlice metrics reader, and the ground-station probe —
+  all of which dial CR-influenced hosts) now sets `Transport.Proxy = nil`, so an
+  `HTTP_PROXY`/`HTTPS_PROXY` in the environment can no longer make net/http dial the proxy and
+  carry the real target past the dial-time IP validation (an SSRF-guard bypass). Its
+  `CheckRedirect` also refuses an `https`→`http` downgrade redirect, so a source reached over
+  TLS (e.g. Space-Track, whose session cookie would leak) cannot be redirected to cleartext.
+  A `nil` client passed to `NewCelesTrakFetcher` now defaults to this safe client rather than a
+  bare `http.Client`, so the nil-client fallback no longer yields an unguarded fetcher (a caller
+  that passes its own bare `http.Client` still gets exactly what it passed). Mutation-tested.
+- **Space-Track credential-Secret failures no longer leak Secret existence/key shape to the CR.**
+  A missing Secret, missing password key, or missing username key now all surface the same
+  uniform "credentials unavailable or not authorized" message on the CR; the specific cause is
+  logged for the operator only. This closes a Secret existence/key oracle for a principal who
+  can write the `SatelliteEphemeris` but not read Secrets (mirrors the `remoteControl.tls`
+  hardening). A source URL rejected off the trusted origin is also now classified as a permanent
+  config error (`InvalidSourceURL`, slow requeue) rather than looping the transient backoff.
+- **The authenticated Space-Track response body is never reflected into a CR Condition/Event.**
+  The Space-Track fetch is authenticated with the credential Secret and its query URL is
+  CR-controlled, so surfacing the response body into a public CR object was an information-flow
+  risk; the rate-limit paths now emit a fixed classified message. The query URL is pinned to the
+  same origin (scheme + host) as the operator-trusted Space-Track base, and — importantly — that
+  exact-origin check is now enforced on **every redirect hop** (a dedicated `CheckRedirect`), not
+  only the initial URL: a 307/308 re-POSTs the login credential body and the session cookie
+  rides redirects, so a cross-origin redirect that would carry credentials/session off the
+  trusted host is refused. The cookie jar also uses the public-suffix list so a server cannot set
+  an overly broad domain cookie. Mutation-tested.
 
 ### Fixed
 
+- **Pass windows are computed from the current time, not the last fetch time.** On a cached
+  re-propagation the fetch timestamp could be up to 24h in the past, which started AOS/LOS
+  windows stale; they now start at reconcile time (#200-C3).
+- **CelesTrak rate-limit errors surface the upstream 403 reason.** CelesTrak (unauthenticated)
+  returns an explanatory 403 body (e.g. "GP data has not updated since your last successful
+  download"); it is captured into the error/condition, sanitized to a single line and bounded
+  by ENCODED bytes (invalid UTF-8 and format/bidi/zero-width chars are stripped, not
+  re-encoded) (#200-C6). **The authenticated Space-Track path never reflects its response body**
+  — it uses a fixed "Space-Track query rate limit exceeded" message (see Security).
+- **`Retry-After` delay-seconds of any length saturate to the 24h cap.** A value exceeding
+  `int`/`int64` range is still a valid RFC 9110 integer; it is now parsed as an unsigned value
+  and saturated to the cap rather than falling through to the date branch and returning 0
+  (#200-C7).
 - **SIB19 now survives a sustained upstream outage, not just the first reconcile of one.**
   Serving cached OMMs on a failed GP fetch (I-18) used to re-propagate ONCE (to
   `now + 5 min`) and then set `RequeueAfter` to the **fetch** backoff — 2–24h for
@@ -95,6 +135,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumer check alone could only block its delivery, not the propagation.
 
 ### Upgrade notes
+
+- **`NewSafeHTTPClient` no longer honors `HTTP_PROXY`/`HTTPS_PROXY`.** The GP fetch, NTNSlice
+  metrics reader, and ground-station probe reach in-cluster or public endpoints directly; a
+  deployment that previously relied on an egress proxy for those must expose the endpoints
+  without a proxy (the proxy fundamentally bypasses the SSRF dial guard, so it is disabled by
+  design). An opt-in proxy that re-validates the CONNECT target is a possible future enhancement.
 
 - **Breaking (`remoteControl.tls`):** an existing remote-control credential Secret must
   gain the label `ntn.operators.dev/remote-control-credential: "true"` (set by the

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.69.0
+	golang.org/x/net v0.56.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -73,7 +74,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -334,7 +334,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ntnmetrics.GPDeepSpaceRejectedCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(len(trackedDeepSpace)))
 
 	// Step 7: Compute pass predictions if configured; clear stale data if disabled.
-	passNote, passFailNote := r.handlePassPrediction(ctx, eph, result)
+	passNote, passFailNote := r.handlePassPrediction(ctx, eph, result, now)
 
 	// Step 7b: Propagate tracked satellites to a NEAR-now epoch for the runtime
 	// ephemeris push (#176). The epoch is only a small lead ahead of now — enough
@@ -986,7 +986,7 @@ func (r *SatelliteEphemerisReconciler) reportOrbitRegime(
 // failure), each non-empty only on a real PassesPredicted-condition transition, so
 // the caller emits them at most once per change after the status write persists.
 func (r *SatelliteEphemerisReconciler) handlePassPrediction(
-	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, result ephemeris.GPFetchResult,
+	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, result ephemeris.GPFetchResult, now time.Time,
 ) (passNote, passFailNote string) {
 	if eph.Spec.PassPrediction == nil || len(eph.Spec.PassPrediction.GroundStations) == 0 {
 		// Pass prediction not configured; clear stale pass windows and condition.
@@ -994,7 +994,7 @@ func (r *SatelliteEphemerisReconciler) handlePassPrediction(
 		meta.RemoveStatusCondition(&eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
 		return "", ""
 	}
-	note, err := r.predictPasses(ctx, eph, result)
+	note, err := r.predictPasses(ctx, eph, result, now)
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "pass prediction failed")
 		eph.Status.NextPassWindows = nil // clear stale pass data
@@ -1029,6 +1029,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	ctx context.Context,
 	eph *ntnv1alpha1.SatelliteEphemeris,
 	fetchResult ephemeris.GPFetchResult,
+	now time.Time,
 ) (string, error) {
 	log := logf.FromContext(ctx)
 	pp := eph.Spec.PassPrediction
@@ -1081,8 +1082,10 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 		noradFilter = eph.Spec.Satellites.NoradIDs
 	}
 
-	// Run pass prediction.
-	passes, err := ephemeris.PredictPasses(fetchResult.OMMs, stations, minEl, horizon, noradFilter, fetchResult.FetchedAt)
+	// Run pass prediction from the CURRENT time, not fetchResult.FetchedAt: pass windows
+	// are "upcoming contact opportunities", and on a cached serve FetchedAt can be up to
+	// effectiveInterval (2–24h) in the past, which would start the window stale (#200-C3).
+	passes, err := ephemeris.PredictPasses(fetchResult.OMMs, stations, minEl, horizon, noradFilter, now)
 	if err != nil {
 		return "", fmt.Errorf("computing passes: %w", err)
 	}
@@ -1344,10 +1347,22 @@ func classifyFetchError(fetchErr error, effectiveInterval time.Duration) (reason
 		return "RateLimited", max(effectiveInterval, retryAfterFrom(fetchErr)), false
 	case errors.Is(fetchErr, ephemeris.ErrAuthFailed):
 		return "AuthFailed", effectiveInterval, false
+	case errors.Is(fetchErr, ephemeris.ErrInvalidSourceURL):
+		// Permanent config error (e.g. a source URL off the trusted origin): retrying cannot
+		// fix it, so requeue slowly (recovers on the spec edit that also bumps generation)
+		// instead of hammering the workqueue's exponential backoff. #222 review.
+		return "InvalidSourceURL", effectiveInterval, false
 	default:
 		return "FetchFailed", 0, true
 	}
 }
+
+// errSpaceTrackCredentialUnavailable is the UNIFORM, CR-facing error for any Space-Track
+// credential-Secret resolution failure (Secret missing / password key missing / username key
+// missing). The specific cause is logged for the operator but never surfaced on the CR, so a
+// principal who can write the SatelliteEphemeris but not read Secrets cannot probe Secret
+// existence or key shape. #222 review blocker 3.
+var errSpaceTrackCredentialUnavailable = errors.New("Space-Track credentials unavailable or not authorized")
 
 // fetcherForSource returns the appropriate GPFetcher for the source type.
 // For SpaceTrack, it also loads credentials from the referenced Secret.
@@ -1381,8 +1396,15 @@ func (r *SatelliteEphemerisReconciler) fetcherForSource(
 		if reader == nil {
 			reader = r.Client
 		}
+		// The three failures below (Secret missing / password key missing / username key
+		// missing) all return the SAME uniform, CR-facing error; the specific cause is logged
+		// for the operator. This closes a Secret existence/key oracle for a principal who can
+		// write the SatelliteEphemeris but not read Secrets (the reconcile error is surfaced on
+		// the CR condition/event) — mirroring the remoteControl.tls hardening. #222 review B3.
 		if err := reader.Get(ctx, secretKey, secret); err != nil {
-			return nil, fmt.Errorf("reading credentials Secret %q: %w", creds.Name, err)
+			logf.FromContext(ctx).Error(err, "reading Space-Track credentials Secret",
+				"secret", creds.Name, "namespace", eph.Namespace)
+			return nil, errSpaceTrackCredentialUnavailable
 		}
 		key := creds.Key
 		if key == "" {
@@ -1390,11 +1412,15 @@ func (r *SatelliteEphemerisReconciler) fetcherForSource(
 		}
 		password, ok := secret.Data[key]
 		if !ok {
-			return nil, fmt.Errorf("secret %q does not contain key %q", creds.Name, key)
+			logf.FromContext(ctx).Info("Space-Track credentials Secret missing required key",
+				"secret", creds.Name, "key", key)
+			return nil, errSpaceTrackCredentialUnavailable
 		}
 		username, ok := secret.Data["username"]
 		if !ok {
-			return nil, fmt.Errorf("secret %q does not contain key %q", creds.Name, "username")
+			logf.FromContext(ctx).Info("Space-Track credentials Secret missing required key",
+				"secret", creds.Name, "key", "username")
+			return nil, errSpaceTrackCredentialUnavailable
 		}
 		// Return a credentials-bound fetcher to prevent interleaving
 		// when multiple CRs share the SpaceTrackFetcher instance.

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -831,7 +831,9 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Reason).To(Equal("FetcherSetupFailed"))
-			Expect(cond.Message).To(ContainSubstring("reading credentials Secret"))
+			// Uniform CR-facing message (no Secret existence/key oracle); the specific cause
+			// (NotFound) is logged, not surfaced on the CR. #222 review blocker 3.
+			Expect(cond.Message).To(ContainSubstring("credentials unavailable or not authorized"))
 		})
 	})
 

--- a/internal/controller/satelliteephemeris_credential_test.go
+++ b/internal/controller/satelliteephemeris_credential_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestClassifyFetchError_InvalidSourceURLIsPermanent pins #222 review P2: an invalid source
+// URL is a PERMANENT config error and must not be returned as a transient error (which would
+// drive the workqueue's exponential-backoff loop). Mutation: drop the ErrInvalidSourceURL
+// case → it falls to the default FetchFailed (returnAsError=true).
+func TestClassifyFetchError_InvalidSourceURLIsPermanent(t *testing.T) {
+	err := fmt.Errorf("%w: off-origin", ephemeris.ErrInvalidSourceURL)
+	reason, requeueAfter, returnAsError := classifyFetchError(err, 4*time.Hour)
+	if reason != "InvalidSourceURL" {
+		t.Errorf("reason = %q, want InvalidSourceURL", reason)
+	}
+	if returnAsError {
+		t.Error("an invalid source URL must be classified permanent (not returned as a transient error)")
+	}
+	if requeueAfter != 4*time.Hour {
+		t.Errorf("requeueAfter = %s, want the slow refresh interval", requeueAfter)
+	}
+}
+
+// TestFetcherForSource_SpaceTrackSecretErrorsAreUniform pins #222 review blocker 3: a missing
+// Secret and a missing key must produce the SAME CR-facing error, so a principal who can write
+// the CR but not read Secrets cannot probe Secret existence or key shape. Mutation: revert to
+// the differentiated per-cause messages → the two error strings differ.
+func TestFetcherForSource_SpaceTrackSecretErrorsAreUniform(t *testing.T) {
+	sch := makeScheme(t)
+	if err := corev1.AddToScheme(sch); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	ctx := context.Background()
+	stFetcher := ephemeris.NewSpaceTrackFetcher(&http.Client{}, "https://www.space-track.org")
+	mkEph := func(secretName string) *ntnv1alpha1.SatelliteEphemeris {
+		return &ntnv1alpha1.SatelliteEphemeris{
+			ObjectMeta: metav1.ObjectMeta{Name: "eph", Namespace: "default"},
+			Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+				Source: ntnv1alpha1.EphemerisSource{
+					Type: "SpaceTrack", URL: "https://www.space-track.org/basicspacedata/query",
+					Credentials: &ntnv1alpha1.SecretReference{Name: secretName, Key: "password"},
+				},
+			},
+		}
+	}
+
+	// Case 1: the referenced Secret does not exist.
+	r1 := &SatelliteEphemerisReconciler{
+		Client: fake.NewClientBuilder().WithScheme(sch).Build(), Scheme: sch, SpaceTrackFetcher: stFetcher,
+	}
+	_, errMissingSecret := r1.fetcherForSource(ctx, mkEph("no-such-secret"))
+
+	// Case 2: the Secret exists but lacks the password key.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data:       map[string][]byte{"username": []byte("u")}, // no "password"
+	}
+	r2 := &SatelliteEphemerisReconciler{
+		Client: fake.NewClientBuilder().WithScheme(sch).WithObjects(secret).Build(), Scheme: sch, SpaceTrackFetcher: stFetcher,
+	}
+	_, errMissingKey := r2.fetcherForSource(ctx, mkEph("creds"))
+
+	if errMissingSecret == nil || errMissingKey == nil {
+		t.Fatalf("both credential failures must error: secret=%v key=%v", errMissingSecret, errMissingKey)
+	}
+	if errMissingSecret.Error() != errMissingKey.Error() {
+		t.Fatalf("Secret-missing and key-missing must produce the SAME CR-facing message (no oracle):\n"+
+			"  missing secret: %q\n  missing key:    %q", errMissingSecret.Error(), errMissingKey.Error())
+	}
+	if !errors.Is(errMissingSecret, errSpaceTrackCredentialUnavailable) {
+		t.Errorf("expected the uniform errSpaceTrackCredentialUnavailable, got %v", errMissingSecret)
+	}
+}

--- a/internal/controller/satelliteephemeris_fetchresilience_test.go
+++ b/internal/controller/satelliteephemeris_fetchresilience_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestReconcile_FreshCache_SkipsFetcherSetup_C2 pins #200-C2: a within-window cached fetch
+// must be served BEFORE fetcher/credential setup, so a brief credential unavailability
+// cannot break a reconcile the cache already answers. The CelesTrak fetcher is left nil so
+// fetcherForSource would ERROR ("fetcher is not configured") if it ran — standing in for
+// the real-world Space-Track Secret-read failure the finding is about. With the fresh
+// cache served first, the reconcile succeeds and never consults the fetcher.
+// Mutation: move fetcherForSource back before the cache check and this gets
+// FetcherSetupFailed instead.
+func TestReconcile_FreshCache_SkipsFetcherSetup_C2(t *testing.T) {
+	sch := makeScheme(t)
+	const ns = "default"
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-c2", Namespace: ns},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-c2", Namespace: ns}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10), Fetcher: nil, // deliberately unconfigured
+	}
+	// FRESH cache (FetchedAt = now, inside the 4h window).
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result:   ephemeris.GPFetchResult{OMMs: []sgp4.OMM{testISSOMM()}, SatelliteCount: 1, FetchedAt: time.Now()},
+		fetchKey: fetchInputKey(got.Spec), uid: got.UID,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("a fresh cache must serve without fetcher/credential setup, got err: %v", err)
+	}
+	updated := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched); cond != nil && cond.Reason == "FetcherSetupFailed" {
+		t.Fatal("fetcher setup must be SKIPPED when the cache is fresh (#200-C2), but got FetcherSetupFailed")
+	}
+	if len(updated.Status.PropagatedStates) == 0 {
+		t.Error("the fresh cache must be propagated (SIB19 push preserved) without a fetch")
+	}
+}
+
+// TestReconcile_PassWindows_StartFromNow_C3 pins #200-C3: pass windows must be computed
+// from the CURRENT time, not fetchResult.FetchedAt. On a served cache whose FetchedAt is
+// 23h in the past (still inside a 24h window), the buggy code would start the window 23h
+// ago and emit passes already in the past; the fix starts it at now, so every window is
+// in the future. Mutation: revert to fetchResult.FetchedAt and a past-AOS window appears.
+func TestReconcile_PassWindows_StartFromNow_C3(t *testing.T) {
+	sch := makeScheme(t)
+	const ns = "default"
+	gs := &ntnv1alpha1.GroundStationLifecycle{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-taipei", Namespace: ns},
+		Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+			Hardware:   ntnv1alpha1.HardwareSpec{Vendor: "ennoconn", Model: "edge-5000"},
+			Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654", Alt: "15"}},
+		},
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-c3", Namespace: ns},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 24 * time.Hour},
+			},
+			PassPrediction: &ntnv1alpha1.PassPredictionSpec{
+				GroundStations: []string{"gs-taipei"},
+				MinElevation:   "10",
+				Horizon:        metav1.Duration{Duration: 24 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(gs, eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-c3", Namespace: ns}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10),
+		Fetcher: &mockGPFetcher{result: ephemeris.GPFetchResult{OMMs: []sgp4.OMM{testISSOMM()}, SatelliteCount: 1, FetchedAt: time.Now()}},
+	}
+	// Served cache 23h old (inside the 24h window). The bug would start windows 23h ago.
+	staleFetchedAt := time.Now().Add(-23 * time.Hour)
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result:   ephemeris.GPFetchResult{OMMs: []sgp4.OMM{testISSOMM()}, SatelliteCount: 1, FetchedAt: staleFetchedAt},
+		fetchKey: fetchInputKey(got.Spec), uid: got.UID,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	now := time.Now()
+	updated := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if len(updated.Status.NextPassWindows) == 0 {
+		t.Fatal("expected pass windows re-predicted from the served cache")
+	}
+	for _, w := range updated.Status.NextPassWindows {
+		if w.AOS.Time.Before(now.Add(-2 * time.Minute)) {
+			t.Errorf("pass window AOS %s precedes now %s — windows were computed from the stale FetchedAt (%s), not the current time (#200-C3)",
+				w.AOS.UTC(), now.UTC(), staleFetchedAt.UTC())
+		}
+	}
+}

--- a/pkg/ephemeris/gp_fetcher.go
+++ b/pkg/ephemeris/gp_fetcher.go
@@ -26,15 +26,24 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/akhenakh/sgp4"
 	"github.com/go-logr/logr"
+
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 )
 
 // Sentinel errors returned by GPFetcher implementations.
 var (
 	ErrRateLimited = errors.New("rate limited by upstream (HTTP 403)")
 	ErrBadResponse = errors.New("unexpected HTTP response")
+	// ErrInvalidSourceURL marks a spec.source.url that a fetcher rejects up front (e.g. a
+	// Space-Track query URL off the trusted origin). It is a PERMANENT configuration error —
+	// retrying cannot fix it — so the caller must classify it non-requeuing/slow, not loop it
+	// through the transient workqueue backoff. #222 review.
+	ErrInvalidSourceURL = errors.New("invalid source URL")
 	// ErrAuthFailed marks a credential/authentication failure (e.g. Space-Track
 	// returns HTTP 200 with a {"Login":"Failed"} body on bad credentials). It is a
 	// persistent error — retrying with the same credentials cannot succeed — so the
@@ -60,10 +69,57 @@ const maxRetryAfter = 24 * time.Hour
 type RateLimitError struct {
 	RetryAfter time.Duration
 	StatusCode int
+	// Snippet is a short, sanitized one-line prefix of the response body. CelesTrak
+	// returns an explanatory reason in the 403 body (e.g. "GP data has not updated since
+	// your last successful download"); surfacing it turns an opaque "HTTP 403" into an
+	// actionable diagnosis. Empty when the source sent no body. findings.md I-19b/#200-C6.
+	Snippet string
 }
 
 func (e *RateLimitError) Error() string {
+	if e.Snippet != "" {
+		return fmt.Sprintf("rate limited by upstream (HTTP %d): %s", e.StatusCode, e.Snippet)
+	}
 	return fmt.Sprintf("rate limited by upstream (HTTP %d)", e.StatusCode)
+}
+
+// maxSnippetBytes bounds how much of an (untrusted) error response body we read for
+// diagnostics.
+const maxSnippetBytes = 512
+
+// readBodySnippet reads a short, sanitized one-line prefix of an untrusted response body
+// for inclusion in an error/condition/log message: bounded to maxSnippetBytes, control
+// characters (incl. newlines) collapsed to spaces and whitespace runs squeezed, so the
+// snippet stays single-line and log-safe.
+func readBodySnippet(r io.Reader) string {
+	b, _ := io.ReadAll(io.LimitReader(r, maxSnippetBytes))
+	return sanitizeSnippet(b)
+}
+
+// sanitizeSnippet turns an already-read untrusted body into a single-line, log-safe string
+// whose ENCODED length never exceeds maxSnippetBytes. It keeps only printable runes
+// (unicode.IsPrint — which excludes control AND format/bidi/zero-width characters that
+// unicode.IsControl misses) and collapses everything else, including invalid UTF-8 bytes, to
+// a space. The bound is on the OUTPUT bytes, not the input: an invalid byte re-encodes to a
+// 3-byte U+FFFD and a multibyte rune to up to 4 bytes, so truncating the input alone could
+// still overflow maxSnippetBytes (#222 review, sanitizer hardening).
+func sanitizeSnippet(b []byte) string {
+	out := make([]byte, 0, maxSnippetBytes)
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		i += size
+		ch := ' '
+		// Keep only printable runes; an invalid UTF-8 byte decodes to (RuneError, size 1).
+		validRune := r != utf8.RuneError || size != 1
+		if validRune && unicode.IsPrint(r) {
+			ch = r
+		}
+		if len(out)+utf8.RuneLen(ch) > maxSnippetBytes {
+			break
+		}
+		out = utf8.AppendRune(out, ch)
+	}
+	return strings.Join(strings.Fields(string(out)), " ")
 }
 
 // Is lets errors.Is(err, ErrRateLimited) match a *RateLimitError.
@@ -79,13 +135,37 @@ func parseRetryAfter(h http.Header) time.Duration {
 	if v == "" {
 		return 0
 	}
-	if secs, err := strconv.Atoi(v); err == nil { // delay-seconds
-		return clampRetryAfter(time.Duration(secs) * time.Second)
+	// delay-seconds: RFC 9110 allows an arbitrary-length non-negative integer, which may
+	// exceed int64. Treat any all-ASCII-digit value as delay-seconds and SATURATE to the cap
+	// on overflow — do NOT let strconv's range error fall through to the HTTP-date branch and
+	// return 0 (which would wrongly drop a huge but valid Retry-After) (#222 review).
+	if isAllASCIIDigits(v) {
+		secs, err := strconv.ParseUint(v, 10, 64)
+		if errors.Is(err, strconv.ErrRange) || (err == nil && secs >= uint64(maxRetryAfter/time.Second)) {
+			return maxRetryAfter
+		}
+		if err != nil {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
 	}
 	if t, err := http.ParseTime(v); err == nil { // HTTP-date
 		return clampRetryAfter(time.Until(t))
 	}
 	return 0
+}
+
+// isAllASCIIDigits reports whether s is a non-empty run of ASCII digits 0-9.
+func isAllASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func clampRetryAfter(d time.Duration) time.Duration {
@@ -132,7 +212,10 @@ type CelesTrakFetcher struct {
 // NewCelesTrakFetcher creates a new fetcher with the given HTTP client.
 func NewCelesTrakFetcher(httpClient *http.Client) *CelesTrakFetcher {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		// Default to the SSRF-safe client, NOT a bare http.Client: the source URL is
+		// CR-controlled, so a nil client must never silently yield an unguarded fetcher
+		// (default ProxyFromEnvironment, no dial-time IP validation). #199-C2.
+		httpClient = netutil.NewSafeHTTPClient(30 * time.Second)
 	}
 	return &CelesTrakFetcher{
 		httpClient: httpClient,
@@ -212,7 +295,11 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 		// (429 handled defensively for a fronting proxy). Retrying does not change
 		// the response and risks a firewall block, so this is a rate-limit signal,
 		// not a transient error — the caller requeues at the slow refresh cadence.
-		return GPFetchResult{}, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
+		return GPFetchResult{}, &RateLimitError{
+			RetryAfter: parseRetryAfter(resp.Header),
+			StatusCode: resp.StatusCode,
+			Snippet:    readBodySnippet(resp.Body),
+		}
 
 	default:
 		return GPFetchResult{}, fmt.Errorf("%w: HTTP %d from %s", ErrBadResponse, resp.StatusCode, url)

--- a/pkg/ephemeris/gp_fetcher_resilience_test.go
+++ b/pkg/ephemeris/gp_fetcher_resilience_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+)
+
+// TestParseRetryAfter_HugeValueSaturates pins #222 review blocker 2: a delay-seconds value
+// that exceeds int/int64 range is still a valid RFC 9110 non-negative integer and must
+// SATURATE to the 24h cap — not fall through the (failed) int parse to the HTTP-date branch
+// and return 0. Mutation: revert to strconv.Atoi → these all return 0.
+func TestParseRetryAfter_HugeValueSaturates(t *testing.T) {
+	for _, v := range []string{
+		"9223372036854775808",    // int64 max + 1 (Atoi range error)
+		"18446744073709551616",   // uint64 max + 1 (ParseUint range error)
+		strings.Repeat("9", 100), // 100-digit
+	} {
+		h := http.Header{}
+		h.Set("Retry-After", v)
+		if got := parseRetryAfter(h); got != maxRetryAfter {
+			t.Errorf("Retry-After=%q must saturate to %s, got %s", v, maxRetryAfter, got)
+		}
+	}
+}
+
+// TestSanitizeSnippet_BoundsOutputAndStripsFormatChars pins #222 review blocker 3: the
+// output is bounded by ENCODED bytes (not truncated input), invalid UTF-8 becomes a space
+// (not a 3-byte U+FFFD), and format/bidi/zero-width chars unicode.IsControl misses are stripped.
+func TestSanitizeSnippet_BoundsOutputAndStripsFormatChars(t *testing.T) {
+	// 900 bytes of a 3-byte rune → without an output bound this would be 900 bytes.
+	if got := sanitizeSnippet(bytes.Repeat([]byte("中"), 300)); len(got) > maxSnippetBytes {
+		t.Errorf("output must be bounded to %d bytes, got %d", maxSnippetBytes, len(got))
+	}
+	// Invalid UTF-8 bytes must collapse to spaces, NOT re-encode to U+FFFD.
+	if got := sanitizeSnippet([]byte{'a', 0xff, 0xfe, 'b'}); got != "a b" {
+		t.Errorf("invalid UTF-8 must become spaces (collapsed), got %q", got)
+	}
+	// Format/bidi/zero-width runes (missed by unicode.IsControl) must be stripped:
+	// U+202E RIGHT-TO-LEFT OVERRIDE, U+2066 LEFT-TO-RIGHT ISOLATE, U+200B ZERO WIDTH SPACE.
+	for _, r := range []rune{'‮', '⁦', '​'} {
+		if got := sanitizeSnippet([]byte("a" + string(r) + "b")); strings.ContainsRune(got, r) {
+			t.Errorf("sanitizeSnippet must strip format char %U, got %q", r, got)
+		}
+	}
+	if got := sanitizeSnippet([]byte("hello   world")); got != "hello world" {
+		t.Errorf("normal body must be preserved with collapsed whitespace, got %q", got)
+	}
+}
+
+// TestParseRetryAfter_OverflowClampedToMax pins #200-C7: a delay-seconds value whose
+// *time.Second product overflows int64 nanoseconds must clamp to maxRetryAfter, not wrap
+// into a small/negative duration. secs=1e10 overflows (1e10*1e9 = 1e19 > int64 max),
+// wrapping negative → clampRetryAfter would return 0 WITHOUT the pre-multiply bound.
+// Mutation: remove the `secs >= maxRetryAfter/second` guard and this returns 0, not 24h.
+func TestParseRetryAfter_OverflowClampedToMax(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "10000000000") // 1e10 s; *1e9 ns overflows int64 and wraps negative
+	if got := parseRetryAfter(h); got != maxRetryAfter {
+		t.Fatalf("an overflowing Retry-After must clamp to %s, got %s", maxRetryAfter, got)
+	}
+}
+
+// TestParseRetryAfter_NegativeIsZero guards the delay-seconds negative case explicitly.
+func TestParseRetryAfter_NegativeIsZero(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "-30")
+	if got := parseRetryAfter(h); got != 0 {
+		t.Fatalf("a negative Retry-After must be 0, got %s", got)
+	}
+}
+
+// TestFetch_403_CapturesBodySnippet pins #200-C6: CelesTrak returns an explanatory reason
+// in the 403 body; it must be surfaced in the error, not discarded. Mutation: drop the
+// Snippet field from the 403 handler and the reason no longer appears in the error.
+func TestFetch_403_CapturesBodySnippet(t *testing.T) {
+	const reason = "GP data has not updated since your last successful download"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, reason)
+	}))
+	defer srv.Close()
+
+	_, err := NewCelesTrakFetcher(srv.Client()).Fetch(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected a rate-limit error on HTTP 403")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+	if !strings.Contains(err.Error(), reason) {
+		t.Fatalf("the 403 body reason must be surfaced in the error, got: %v", err)
+	}
+}
+
+// TestReadBodySnippet_SanitizesAndBounds pins the sanitizer: control chars/newlines are
+// collapsed to single spaces and the output is bounded, so an untrusted body cannot inject
+// newlines into a log/condition or blow up its size.
+func TestReadBodySnippet_SanitizesAndBounds(t *testing.T) {
+	got := readBodySnippet(strings.NewReader("line1\n\tline2\x00\x07   line3\r\n"))
+	if got != "line1 line2 line3" {
+		t.Fatalf("snippet sanitization: got %q want %q", got, "line1 line2 line3")
+	}
+	big := strings.Repeat("A", 4096)
+	if snip := readBodySnippet(strings.NewReader(big)); len(snip) > maxSnippetBytes {
+		t.Fatalf("snippet must be bounded to %d bytes, got %d", maxSnippetBytes, len(snip))
+	}
+}
+
+// TestNewCelesTrakFetcher_NilClientIsSSRFSafe pins the nil-client hardening (#199-C2): a
+// nil client must default to the SSRF-safe client, so a fetch to a private IP is blocked
+// at dial. httptest binds to 127.0.0.1 (private). Mutation: revert the nil fallback to a
+// bare &http.Client{} and the dial succeeds → the error becomes a JSON parse error, not
+// ErrPrivateIP.
+func TestNewCelesTrakFetcher_NilClientIsSSRFSafe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "should not be reached")
+	}))
+	defer srv.Close()
+
+	_, err := NewCelesTrakFetcher(nil).Fetch(context.Background(), srv.URL) // srv is 127.0.0.1
+	if err == nil {
+		t.Fatal("a nil-client fetcher must block a private-IP target (SSRF-safe default)")
+	}
+	if !errors.Is(err, netutil.ErrPrivateIP) {
+		t.Fatalf("expected a private-IP dial block (ErrPrivateIP), got: %v", err)
+	}
+}

--- a/pkg/ephemeris/spacetrack_fetcher.go
+++ b/pkg/ephemeris/spacetrack_fetcher.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/akhenakh/sgp4"
 	"github.com/go-logr/logr"
+	"golang.org/x/net/publicsuffix"
 )
 
 // SpaceTrackFetcher implements GPFetcher for Space-Track.org OMM JSON endpoints.
@@ -52,10 +53,30 @@ type SpaceTrackFetcher struct {
 // baseURL is the SpaceTrack API root (e.g., "https://www.space-track.org").
 // The httpClient should be created via netutil.NewSafeHTTPClient for SSRF protection.
 func NewSpaceTrackFetcher(httpClient *http.Client, baseURL string) *SpaceTrackFetcher {
-	// Ensure the client has a cookie jar for session management.
+	// Ensure the client has a cookie jar for session management. Use the public-suffix list
+	// so a server cannot set an overly broad domain cookie that would then be sent to other
+	// hosts (cookiejar with a nil PublicSuffixList is documented as unsafe). #222 review.
 	if httpClient.Jar == nil {
-		jar, _ := cookiejar.New(nil)
+		jar, _ := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		httpClient.Jar = jar
+	}
+	// Enforce exact-origin on EVERY redirect hop, not just the initial URL. The fetch is
+	// authenticated (a session cookie from the credential Secret) and login re-POSTs the
+	// credential body on a 307/308, so a cross-origin redirect must never carry the session
+	// or credentials off the trusted Space-Track origin. This is STRICTER than the shared
+	// SSRF CheckRedirect (which allows cross-origin public hosts), so overriding it is safe.
+	// #222 review blocker 1.
+	if base, err := url.Parse(baseURL); err == nil {
+		httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if !strings.EqualFold(req.URL.Scheme, base.Scheme) || !strings.EqualFold(req.URL.Host, base.Host) {
+				return fmt.Errorf("%w: refusing a Space-Track redirect off the trusted origin %s://%s",
+					ErrBadResponse, base.Scheme, base.Host)
+			}
+			return nil
+		}
 	}
 	return &SpaceTrackFetcher{
 		httpClient: httpClient,
@@ -78,6 +99,34 @@ func (f *SpaceTrackFetcher) SetCredentials(username, password string) {
 
 // Fetch retrieves GP data using previously set credentials (via SetCredentials).
 // Deprecated: Use FetchWithCredentials for request-scoped credential isolation.
+// spaceTrackRateLimitMsg is the FIXED, classified diagnostic surfaced for a Space-Track
+// rate-limit response, so the authenticated response body is never reflected into a public
+// CR Condition/Event (#222 review). CelesTrak (unauthenticated) still surfaces its body.
+const spaceTrackRateLimitMsg = "Space-Track query rate limit exceeded"
+
+// validateGPURL rejects a query URL that is not on the SAME origin (scheme + host) as the
+// configured, operator-trusted Space-Track base — so the authenticated session is never sent
+// to a different scheme/host with the CR-controlled URL (#222 review). The base is a fixed
+// https://www.space-track.org in production (cmd/main.go), so this transitively forces the
+// query to https + www.space-track.org; tests set the base to their httptest origin.
+// (Restricting the PATH to the /basicspacedata/ data-API prefix is a deferred hardening; the
+// info-leak concern is already closed by not reflecting the response body.)
+func (f *SpaceTrackFetcher) validateGPURL(gpURL string) error {
+	base, err := url.Parse(f.baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid Space-Track base URL %q: %w", f.baseURL, err)
+	}
+	u, err := url.Parse(gpURL)
+	if err != nil {
+		return fmt.Errorf("%w: invalid Space-Track query URL", ErrInvalidSourceURL)
+	}
+	if !strings.EqualFold(u.Scheme, base.Scheme) || !strings.EqualFold(u.Host, base.Host) {
+		return fmt.Errorf("%w: Space-Track query URL must be on the configured origin %s://%s (got scheme=%q host=%q)",
+			ErrInvalidSourceURL, base.Scheme, base.Host, u.Scheme, u.Host)
+	}
+	return nil
+}
+
 func (f *SpaceTrackFetcher) Fetch(ctx context.Context, gpURL string) (GPFetchResult, error) {
 	f.mu.Lock()
 	username := f.activeUsername
@@ -98,6 +147,12 @@ func (f *SpaceTrackFetcher) Fetch(ctx context.Context, gpURL string) (GPFetchRes
 func (f *SpaceTrackFetcher) FetchWithCredentials(
 	ctx context.Context, gpURL, username, password string,
 ) (GPFetchResult, error) {
+	// Validate the query URL BEFORE logging in: the fetch is authenticated with the
+	// credential Secret, so the operator must not be pointed at an arbitrary scheme/host with
+	// that session (and must not even spend a login on a misconfigured URL) (#222 review).
+	if err := f.validateGPURL(gpURL); err != nil {
+		return GPFetchResult{}, err
+	}
 	if username == "" || password == "" {
 		return GPFetchResult{}, fmt.Errorf(
 			"SpaceTrack username and password must be non-empty")
@@ -250,8 +305,17 @@ func (f *SpaceTrackFetcher) doFetchGPRaw(ctx context.Context, gpURL string) ([]b
 		return body, nil
 
 	case http.StatusForbidden, http.StatusTooManyRequests:
+		// Do NOT reflect the response body: the Space-Track fetch is AUTHENTICATED (a session
+		// from the credential Secret) and the URL is CR-controlled, so an authenticated
+		// endpoint's body could carry account/session detail — surfacing it into a public CR
+		// Condition/Event is an information leak. Use a fixed, classified message and drain the
+		// body for connection reuse (#222 review).
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
+		return nil, &RateLimitError{
+			RetryAfter: parseRetryAfter(resp.Header),
+			StatusCode: resp.StatusCode,
+			Snippet:    spaceTrackRateLimitMsg,
+		}
 
 	case http.StatusInternalServerError:
 		// Space-Track signals a query-rate-limit violation with HTTP 500 and a body
@@ -259,7 +323,13 @@ func (f *SpaceTrackFetcher) doFetchGPRaw(ctx context.Context, gpURL string) ([]b
 		// 500 is a rate limit; any other 500 is a genuine server error. I-19b.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		if bytes.Contains(bytes.ToLower(body), []byte("violated your query rate limit")) {
-			return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header), StatusCode: resp.StatusCode}
+			// Fixed message — the authenticated body is inspected for the sentinel but NOT
+			// reflected into the CR (#222 review).
+			return nil, &RateLimitError{
+				RetryAfter: parseRetryAfter(resp.Header),
+				StatusCode: resp.StatusCode,
+				Snippet:    spaceTrackRateLimitMsg,
+			}
 		}
 		return nil, fmt.Errorf("%w: HTTP 500 from %s", ErrBadResponse, gpURL)
 

--- a/pkg/ephemeris/spacetrack_security_test.go
+++ b/pkg/ephemeris/spacetrack_security_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSpaceTrackFetcher_403BodyNotReflected pins #222 review blocker 1: the AUTHENTICATED
+// Space-Track response body must NEVER be reflected into the error (and thus the public CR
+// Condition/Event). The 403 body here carries a sentinel; the surfaced error must be a fixed
+// classified message, not the body. Mutation: restore Snippet: readBodySnippet(resp.Body) →
+// the sentinel appears in the error.
+func TestSpaceTrackFetcher_403BodyNotReflected(t *testing.T) {
+	const sentinel = "TOP-SECRET-ACCOUNT-DATA"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ajaxauth/login" {
+			w.WriteHeader(http.StatusOK) // login succeeds
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, sentinel)
+	}))
+	defer server.Close()
+
+	f := NewSpaceTrackFetcher(server.Client(), server.URL)
+	_, err := f.FetchWithCredentials(context.Background(), server.URL+"/gp", "user", "pass")
+	if err == nil {
+		t.Fatal("expected a rate-limit error on HTTP 403")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("the authenticated Space-Track response body must NOT appear in the error: %v", err)
+	}
+}
+
+// TestSpaceTrackFetcher_RejectsForeignOrigin pins #222 review blocker 1 (origin lock): the
+// authenticated session must not be sent to a scheme/host other than the configured trusted
+// base — the query URL is CR-controlled. Rejection happens BEFORE login. Mutation: remove the
+// validateGPURL call → these are no longer classified as ErrInvalidSourceURL at validation.
+func TestSpaceTrackFetcher_RejectsForeignOrigin(t *testing.T) {
+	f := NewSpaceTrackFetcher(http.DefaultClient, "https://www.space-track.org")
+	for _, bad := range []string{
+		"http://www.space-track.org/basicspacedata/query", // scheme downgrade
+		"https://evil.example.com/basicspacedata/query",   // wrong host
+		"https://www.space-track.org.evil.com/x",          // lookalike host suffix
+	} {
+		_, err := f.FetchWithCredentials(context.Background(), bad, "user", "pass")
+		if err == nil {
+			t.Errorf("gpURL %q on a foreign origin must be rejected", bad)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidSourceURL) {
+			t.Errorf("gpURL %q must be rejected as ErrInvalidSourceURL (permanent config error), got %v", bad, err)
+		}
+	}
+}
+
+// TestSpaceTrackFetcher_RedirectPolicyRefusesCrossOrigin pins #222 review-2 blocker 1: the
+// redirect policy enforces exact-origin on EVERY hop, not just the initial URL. A 307/308
+// re-POSTs the login credential body and the session cookie rides redirects, so a
+// cross-origin redirect must be refused — otherwise credentials/session leave the trusted
+// Space-Track origin. Mutation: drop the CheckRedirect override → the policy is nil (or the
+// permissive SSRF one) and cross-origin is no longer refused.
+func TestSpaceTrackFetcher_RedirectPolicyRefusesCrossOrigin(t *testing.T) {
+	f := NewSpaceTrackFetcher(&http.Client{}, "https://www.space-track.org")
+	if f.httpClient.Jar == nil {
+		t.Fatal("expected a cookie jar (public-suffix list)")
+	}
+	cr := f.httpClient.CheckRedirect
+	if cr == nil {
+		t.Fatal("SpaceTrack must install an exact-origin redirect policy")
+	}
+	orig, _ := http.NewRequest(http.MethodPost, "https://www.space-track.org/ajaxauth/login", nil)
+
+	same, _ := http.NewRequest(http.MethodGet, "https://www.space-track.org/basicspacedata/query", nil)
+	if err := cr(same, []*http.Request{orig}); err != nil {
+		t.Fatalf("a same-origin redirect must be allowed, got: %v", err)
+	}
+	for _, bad := range []string{
+		"https://evil.example.com/steal",         // foreign host
+		"http://www.space-track.org/x",           // scheme downgrade
+		"https://www.space-track.org.evil.com/x", // lookalike host suffix
+	} {
+		req, _ := http.NewRequest(http.MethodGet, bad, nil)
+		if err := cr(req, []*http.Request{orig}); err == nil {
+			t.Errorf("a cross-origin redirect to %q must be refused (credential/cookie exfil)", bad)
+		}
+	}
+}

--- a/pkg/netutil/safeclient.go
+++ b/pkg/netutil/safeclient.go
@@ -214,9 +214,17 @@ func NewSafeHTTPClient(timeout time.Duration, opts ...Option) *http.Client {
 	}
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
 
-	// Clone DefaultTransport to preserve proxy, connection pooling, and TLS settings.
+	// Clone DefaultTransport to inherit connection pooling and TLS settings, then
+	// override the two SSRF-critical knobs.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = safeDialContext(dialer, cfg.privateHostAllowlist)
+	// Proxy MUST be nil (SSRF): DefaultTransport inherits ProxyFromEnvironment, and when
+	// HTTP_PROXY/HTTPS_PROXY is set net/http dials the PROXY and passes the real target
+	// in the request/CONNECT — so safeDialContext would validate the proxy's IP, never the
+	// target's, silently bypassing the whole guard. The GP source host is CR-controlled, so
+	// the guard must not be bypassable. (Trade-off: this client ignores egress-proxy env;
+	// an opt-in proxy that re-validates the CONNECT target would be a future enhancement.)
+	transport.Proxy = nil
 
 	return &http.Client{
 		Timeout:   timeout,
@@ -230,6 +238,14 @@ func NewSafeHTTPClient(timeout time.Duration, opts ...Option) *http.Client {
 			log := logr.FromContextOrDiscard(req.Context())
 			if len(via) >= 3 {
 				return fmt.Errorf("too many redirects")
+			}
+			// Refuse an https->http downgrade: if the ORIGINAL request was https, never
+			// follow a redirect down to cleartext http, even to a public host. Space-Track
+			// carries a session cookie that a downgrade would leak in the clear; and a
+			// downgrade is never a legitimate move for a data source we reached over TLS.
+			if len(via) > 0 && via[0].URL != nil && via[0].URL.Scheme == "https" && req.URL.Scheme == "http" {
+				log.V(1).Info("blocked https->http downgrade redirect", "to", req.URL.Redacted())
+				return fmt.Errorf("refusing https->http downgrade redirect to %s", req.URL.Redacted())
 			}
 			host := req.URL.Hostname()
 			if cfg.privateHostAllowlist.ContainsHost(host) {

--- a/pkg/netutil/safeclient_ssrf_test.go
+++ b/pkg/netutil/safeclient_ssrf_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package netutil
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestNewSafeHTTPClient_ProxyDisabled pins #199-C2: the transport must set Proxy=nil.
+// If a proxy is honored, net/http dials the PROXY (which safeDialContext validates) while
+// the real, CR-controlled target host travels in the request/CONNECT and is never
+// IP-validated — silently bypassing the SSRF guard. Mutation: drop `transport.Proxy = nil`
+// and this fails (the clone inherits ProxyFromEnvironment != nil).
+func TestNewSafeHTTPClient_ProxyDisabled(t *testing.T) {
+	client := NewSafeHTTPClient(5 * time.Second)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", client.Transport)
+	}
+	if tr.Proxy != nil {
+		t.Fatal("Transport.Proxy must be nil so an egress proxy cannot bypass the SSRF dial guard")
+	}
+}
+
+// TestNewSafeHTTPClient_BlocksHTTPSDowngradeRedirect pins #199-C3(b): a redirect that
+// downgrades https->http (even to a public host) must be refused, so a source reached over
+// TLS (e.g. Space-Track, whose session cookie would leak in cleartext) can't be redirected
+// down to http. The downgrade check runs before any DNS lookup, so no network is needed.
+func TestNewSafeHTTPClient_BlocksHTTPSDowngradeRedirect(t *testing.T) {
+	client := NewSafeHTTPClient(5 * time.Second)
+	orig, _ := http.NewRequest(http.MethodGet, "https://celestrak.org/gp", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://celestrak.org/gp", nil)
+	req = req.WithContext(context.Background())
+
+	err := client.CheckRedirect(req, []*http.Request{orig})
+	if err == nil {
+		t.Fatal("expected an https->http downgrade redirect to be blocked")
+	}
+	if !containsStr(err.Error(), "downgrade") {
+		t.Errorf("expected a downgrade error, got: %v", err)
+	}
+}
+
+// TestNewSafeHTTPClient_AllowsHTTPSToHTTPSRedirect is the paired control: an https->https
+// redirect to an allowlisted host is NOT a downgrade and is permitted (proves the block is
+// specific to the scheme downgrade, not all redirects). The allowlist path returns before
+// any DNS lookup.
+func TestNewSafeHTTPClient_AllowsHTTPSToHTTPSRedirect(t *testing.T) {
+	client := NewSafeHTTPClient(5*time.Second, WithPrivateHostAllowlist(ParseEndpointAllowlist("mirror.internal")))
+	orig, _ := http.NewRequest(http.MethodGet, "https://celestrak.org/gp", nil)
+	req, _ := http.NewRequest(http.MethodGet, "https://mirror.internal/gp", nil)
+	req = req.WithContext(context.Background())
+
+	if err := client.CheckRedirect(req, []*http.Request{orig}); err != nil {
+		t.Fatalf("https->https redirect to an allowlisted host must be permitted, got: %v", err)
+	}
+}


### PR DESCRIPTION
Separate PR (not stacked on #221 — different files: fetch client / SSRF vs push path).

## Problem

Round-2 review of the merged fetch code (#199, #200) found an SSRF-guard **bypass** and several resilience gaps. Each was verified against current code first — #199-C3(a) DNS fail-closed, #199-C3(c) IP pinning, and #200-C1 fetch-cadence gating were **already correct** and left untouched.

## Security (SSRF)

- **`Proxy=nil` on `NewSafeHTTPClient` (#199-C2).** The transport cloned `http.DefaultTransport`, inheriting `ProxyFromEnvironment`. With `HTTP(S)_PROXY` set, net/http dials the **proxy** (which `safeDialContext` validates) while the real, CR-controlled target host travels in the request/CONNECT and is **never IP-validated** — a full guard bypass. `Proxy=nil` fixes it for **every** safe-client user: GP fetch, the NTNSlice metrics reader (I-24), and the ground-station probe — all dial CR-influenced hosts.
- **`CheckRedirect` refuses `https`→`http` downgrade (#199-C3(b)).** A source reached over TLS (e.g. Space-Track, whose session cookie would leak) can't be redirected to cleartext. Existing private-IP redirect block + 3-hop cap retained.
- **`NewCelesTrakFetcher(nil)` defaults to the SSRF-safe client**, not a bare `http.Client`, so no code path yields an unguarded fetcher.

## Resilience

- **Cache-before-secret (#200-C2)** — a within-window cached fetch is served *before* fetcher/credential setup, so a brief Space-Track Secret unavailability can't break a reconcile the cache already answers.
- **Pass windows from `now`, not `FetchedAt` (#200-C3)** — on a cached serve `FetchedAt` can be 2–24h stale, starting AOS/LOS windows in the past.
- **Capture the rate-limit body (#200-C6)** — CelesTrak's 403 explains the reason (e.g. "GP data has not updated since your last successful download"); now surfaced (bounded, sanitized) on 403/429 and Space-Track's 500 rate-limit path.
- **`Retry-After` overflow (#200-C7)** — a huge delay-seconds value is bounded before the `time.Second` multiply, clamping to the 24h cap instead of wrapping.

## Deliberately not changed (flagged, not silently dropped)

- **#200-C5 source-specific backoff minimum** — the global 2h floor is conservative-safe for both CelesTrak (wants infrequent fetches) and Space-Track (allows more, but 2h is fine). Source-specific tuning is premature optimization, not a correctness fix.

## Tests (mutation-proven unless noted)

Proxy=nil set; https→http downgrade blocked (+ https→https-allowed control); Retry-After overflow→24h (+ negative→0); 403 body reason surfaced; snippet sanitize/bound; nil-client blocks a private IP; fresh-cache serves without fetcher setup; pass windows start at `now` not a 23h-stale `FetchedAt`.

`make test` (controller 86.9% / ephemeris 91.2% / netutil 95.1%) / golangci-lint 0 / gofmt / go vet / go test -race — all green.

## Upgrade note

`NewSafeHTTPClient` no longer honors `HTTP(S)_PROXY`/`ALL_PROXY` — the proxy fundamentally bypasses the SSRF dial guard, so it's disabled by design. A deployment relying on an egress proxy for GP fetch / metrics / GS probe must expose those endpoints directly.
