### PR TITLE
fix(ephemeris): conservative whole-second pass windows + minElevation [0,90] (#201-P2-1, P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drive SGP4 *backward* from the bogus epoch and write a wildly wrong ECEF into status; the
   consumer check alone could only block its delivery, not the propagation.
 
+### Fixed
+
+- **Pass windows (`status.nextPassWindows`) are now conservative to the whole second.**
+  AOS is rounded up and LOS down before storage, so the persisted window stays within the
+  window the mask-trim computed — previously AOS/LOS carried ~200 ms of sub-second residual
+  and `metav1.Time` serializes at second granularity without the fractional second, which
+  pushed the stored AOS *earlier*, over-claiming availability by up to a second (#201-P2-1).
+  (When mask-boundary evaluation succeeds that computed window is the usable ≥ minElevation
+  interval; on the fail-open elevation-error path it is the wider 0°-horizon window — see
+  the deferred narrow fail-closed proposal.)
+
+### Changed
+
+- **`passPrediction.minElevation` is constrained to `[0, 90]` degrees.** 0 is the
+  geometric horizon and 90 the zenith; a negative or `>90` mask is physically meaningless.
+  Enforced by an admission CEL rule plus a finite-value runtime range check. The value
+  pattern otherwise preserves the prior grammar (a trailing dot such as `"10."` stays
+  valid — only the leading `-` was removed). The bound is on the parsed **float64** value
+  (the pass pipeline is float64), so a literal within ~half a ULP above 90 rounds to 90 and
+  is accepted; `NaN`/`Inf` are rejected (#201-P3).
+
 ### Upgrade notes
 
 - **`NewSafeHTTPClient` no longer honors `HTTP_PROXY`/`HTTPS_PROXY`.** The GP fetch, NTNSlice
@@ -157,6 +178,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rollout — a fetch outage coinciding with the upgrade (e.g. a CelesTrak per-update-window
   rate-limit) extends the window until the next successful fetch. This is intentional
   fail-closed behavior (never push data of unverified currency), not a data loss.
+- **`passPrediction.minElevation` must be within `[0, 90]`.** New objects, and any edit that
+  CHANGES `minElevation` itself, must be in range. Because of Kubernetes CRD validation
+  ratcheting (default from 1.30; the project's min is 1.31), an existing object with an
+  out-of-range value is NOT necessarily rejected on an unrelated edit — the illegal value can
+  persist in etcd until `minElevation` is next changed. In that state the controller's runtime
+  check refuses to use the value, clears `status.nextPassWindows`, and reports
+  `PassesPredicted=False`/`PredictionFailed`. Correct any out-of-range `minElevation` before
+  upgrading (the default "10" is unaffected).
 
 ## [0.7.0] - 2026-07-12
 

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -97,10 +97,18 @@ type PassPredictionSpec struct {
 	// +kubebuilder:validation:items:MaxLength=253
 	GroundStations []string `json:"groundStations"`
 
-	// minElevation is the minimum elevation angle in degrees (string, e.g., "10").
+	// minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+	// range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+	// is physically meaningless (it would make every / no pass "usable"), so the pattern
+	// rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+	// pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+	// leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+	// parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+	// 90 rounds to 90 and is accepted; the controller uses the float64 value.
 	// +kubebuilder:default="10"
-	// +kubebuilder:validation:Pattern=`^-?[0-9]+\.?[0-9]*$`
+	// +kubebuilder:validation:Pattern=`^[0-9]+\.?[0-9]*$`
 	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="double(self) <= 90.0",message="minElevation must be between 0 and 90 degrees"
 	MinElevation string `json:"minElevation,omitempty"`
 
 	// horizon is how far into the future to predict passes.

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -82,11 +82,21 @@ spec:
                     type: string
                   minElevation:
                     default: "10"
-                    description: minElevation is the minimum elevation angle in degrees
-                      (string, e.g., "10").
+                    description: |-
+                      minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+                      range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+                      is physically meaningless (it would make every / no pass "usable"), so the pattern
+                      rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+                      pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+                      leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+                      parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+                      90 rounds to 90 and is accepted; the controller uses the float64 value.
                     maxLength: 32
-                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    pattern: ^[0-9]+\.?[0-9]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: minElevation must be between 0 and 90 degrees
+                      rule: double(self) <= 90.0
                 required:
                 - groundStations
                 type: object

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -82,11 +82,21 @@ spec:
                     type: string
                   minElevation:
                     default: "10"
-                    description: minElevation is the minimum elevation angle in degrees
-                      (string, e.g., "10").
+                    description: |-
+                      minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+                      range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+                      is physically meaningless (it would make every / no pass "usable"), so the pattern
+                      rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+                      pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+                      leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+                      parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+                      90 rounds to 90 and is accepted; the controller uses the float64 value.
                     maxLength: 32
-                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    pattern: ^[0-9]+\.?[0-9]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: minElevation must be between 0 and 90 degrees
+                      rule: double(self) <= 90.0
                 required:
                 - groundStations
                 type: object

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -85,11 +85,21 @@ spec:
                     type: string
                   minElevation:
                     default: "10"
-                    description: minElevation is the minimum elevation angle in degrees
-                      (string, e.g., "10").
+                    description: |-
+                      minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+                      range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+                      is physically meaningless (it would make every / no pass "usable"), so the pattern
+                      rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+                      pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+                      leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+                      parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+                      90 rounds to 90 and is accepted; the controller uses the float64 value.
                     maxLength: 32
-                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    pattern: ^[0-9]+\.?[0-9]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: minElevation must be between 0 and 90 degrees
+                      rule: double(self) <= 90.0
                 required:
                 - groundStations
                 type: object

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3223,8 +3223,16 @@ to compute pass windows against.<br/>
         <td><b>minElevation</b></td>
         <td>string</td>
         <td>
-          minElevation is the minimum elevation angle in degrees (string, e.g., "10").<br/>
+          minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+is physically meaningless (it would make every / no pass "usable"), so the pattern
+rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+90 rounds to 90 and is accepted; the controller uses the float64 value.<br/>
           <br/>
+            <i>Validations</i>:<li>double(self) <= 90.0: minElevation must be between 0 and 90 degrees</li>
             <i>Default</i>: 10<br/>
         </td>
         <td>false</td>

--- a/internal/controller/ntncellconfig_admission_test.go
+++ b/internal/controller/ntncellconfig_admission_test.go
@@ -184,12 +184,39 @@ var _ = Describe("CRD string-length admission (MaxLength boundaries)", func() {
 		func(mLen int, ok bool) {
 			eph := mkEph(func(e *ntnv1alpha1.SatelliteEphemeris) {
 				e.Spec.PassPrediction = &ntnv1alpha1.PassPredictionSpec{
-					GroundStations: []string{"gs-1"}, MinElevation: rep("1", mLen),
+					GroundStations: []string{"gs-1"}, MinElevation: "1." + rep("0", mLen-2),
 				}
 			})
 			assertAdmit(k8sClient.Create(ctx, eph), ok, eph, fmt.Sprintf("minElevation len %d", mLen))
 		},
 		Entry("at 32", 32, true),
 		Entry("over at 33", 33, false),
+	)
+
+	// Value bound [0,90] via pattern (negatives) + CEL (>90). Also pins that the
+	// grammar-preserving "10." (trailing dot) is still admitted through both the pattern
+	// AND the CEL double() conversion (#201-P3, review finding 2).
+	DescribeTable("SatelliteEphemeris minElevation value bound [0,90]",
+		func(val string, ok bool) {
+			eph := mkEph(func(e *ntnv1alpha1.SatelliteEphemeris) {
+				e.Spec.PassPrediction = &ntnv1alpha1.PassPredictionSpec{
+					GroundStations: []string{"gs-1"}, MinElevation: val,
+				}
+			})
+			assertAdmit(k8sClient.Create(ctx, eph), ok, eph, fmt.Sprintf("minElevation %q", val))
+		},
+		Entry("zero", "0", true),
+		Entry("ten", "10", true),
+		Entry("trailing dot stays valid", "10.", true),
+		Entry("fractional", "72.5", true),
+		Entry("zenith inclusive", "90", true),
+		// float64 contract: a literal within ~half a ULP above 90 rounds to 90.0 and is
+		// accepted (CEL double() converts via strconv.ParseFloat), while one that rounds
+		// strictly above 90 is rejected. Pins the intended float64 semantics.
+		Entry("sub-ULP above 90 accepted as float64 90", "90.000000000000001", true),
+		Entry("rounds strictly above 90 rejected", "90.0000000000001", false),
+		Entry("negative rejected", "-5", false),
+		Entry("just over 90 rejected", "90.5", false),
+		Entry("far over 90 rejected", "1000", false),
 	)
 })

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -82,11 +82,21 @@ spec:
                     type: string
                   minElevation:
                     default: "10"
-                    description: minElevation is the minimum elevation angle in degrees
-                      (string, e.g., "10").
+                    description: |-
+                      minElevation is the minimum elevation angle in degrees (string, e.g., "10"), in the
+                      range [0, 90]: 0 is the geometric horizon and 90 the zenith. A negative or >90 mask
+                      is physically meaningless (it would make every / no pass "usable"), so the pattern
+                      rejects negatives and the CEL rule rejects values above 90. The pattern keeps the
+                      pre-existing grammar otherwise (a trailing "." such as "10." stays valid — only the
+                      leading "-" was removed) to avoid an unrelated API-grammar break. The bound is on the
+                      parsed float64 value (the pipeline is float64), so a literal within ~half a ULP above
+                      90 rounds to 90 and is accepted; the controller uses the float64 value.
                     maxLength: 32
-                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    pattern: ^[0-9]+\.?[0-9]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: minElevation must be between 0 and 90 degrees
+                      rule: double(self) <= 90.0
                 required:
                 - groundStations
                 type: object

--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -18,6 +18,7 @@ package ephemeris
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -51,7 +52,9 @@ type PassResult struct {
 }
 
 // PredictPasses computes satellite pass windows for the given OMMs over ground stations.
-// It filters by minElevation, limits results to MaxPassWindows, and uses concurrent workers.
+// minElevation must be a finite value in [0, 90] degrees; otherwise PredictPasses returns an
+// error (it does not silently degrade). It filters by minElevation, limits results to
+// MaxPassWindows, and uses concurrent workers.
 // The startTime parameter sets the prediction window start; pass time.Time{} to use time.Now().
 func PredictPasses(
 	omms []sgp4.OMM,
@@ -61,6 +64,14 @@ func PredictPasses(
 	noradFilter []int,
 	startTime time.Time,
 ) ([]PassResult, error) {
+	// Enforce the [0,90] finite mask invariant at the exported entry point (defense in
+	// depth): the operator path pre-validates via ParseElevation, but a direct caller could
+	// otherwise pass NaN/Inf/out-of-range — and because every mask comparison against NaN is
+	// false, an unchecked NaN would silently degrade to emitting 0°-horizon passes instead of
+	// rejecting the bad mask (#223 review finding 2).
+	if math.IsNaN(minElevation) || math.IsInf(minElevation, 0) || minElevation < 0 || minElevation > 90 {
+		return nil, fmt.Errorf("minElevation must be a finite value in [0,90], got %v", minElevation)
+	}
 	if len(omms) == 0 || len(stations) == 0 {
 		return nil, nil
 	}
@@ -231,9 +242,22 @@ func predictSingle(
 		// elevation >= minElevation (I-22) so availability consumers (e.g. NTNSlice
 		// failover) never treat a below-mask, unusable link as available.
 		aos, los := trimPassToMask(elevFn, p, minElevation)
-		if !los.After(aos) {
-			// Grazing pass whose usable window collapsed to (near) zero once the
-			// mask is applied — the satellite only brushes the mask, so drop it.
+		// Conservative whole-second window (#201-P2-1): ceil AOS up and floor LOS down.
+		// The bisection resolves the crossing to ~200ms, and metav1.Time serializes at
+		// second granularity WITHOUT the fractional second — which would push the stored
+		// AOS EARLIER than the computed acquisition (an over-claim). Rounding keeps the
+		// persisted window within the window trimPassToMask returned. NOTE that is the
+		// usable (>= minElevation) interval only WHEN the mask-boundary evaluation
+		// succeeded; on the fail-open elevation-error path trimPassToMask leaves the wider
+		// 0°-horizon window (see its doc + the deferred narrow fail-closed), and the
+		// rounding only keeps the window within THAT. Round BEFORE the collapse check so a
+		// window that shrinks below one second is dropped, not stored with AOS >= LOS.
+		aos, los, valid := conservativePassWindow(aos, los)
+		if !valid {
+			// Grazing pass whose usable window collapsed to (near) zero once the mask and
+			// whole-second rounding are applied — the satellite only brushes the mask, so
+			// drop it. (The collapse decision is made inside conservativePassWindow so it is
+			// locked by that helper's unit test, not just this branch.)
 			continue
 		}
 		results = append(results, PassResult{
@@ -367,7 +391,45 @@ func FilterOMMs(omms []sgp4.OMM, noradFilter []int) []sgp4.OMM {
 	return filtered
 }
 
-// ParseElevation parses a string elevation value (e.g., "10") to float64.
+// ceilToSecond rounds t UP to the next whole second (a no-op when t is already on a
+// second boundary). Applied to AOS so the acquisition time is never claimed earlier than
+// the sub-second computed value, even after metav1.Time truncates on serialization.
+func ceilToSecond(t time.Time) time.Time {
+	trunc := t.Truncate(time.Second)
+	if trunc.Before(t) {
+		return trunc.Add(time.Second)
+	}
+	return trunc
+}
+
+// floorToSecond rounds t DOWN to the previous whole second. Applied to LOS so the loss
+// time is never claimed later than the computed value.
+func floorToSecond(t time.Time) time.Time {
+	return t.Truncate(time.Second)
+}
+
+// conservativePassWindow rounds a pass window to whole seconds CONSERVATIVELY: AOS up
+// (ceil) and LOS down (floor), so the persisted window never extends past the computed
+// edges once metav1.Time drops the fractional second. It ALSO returns whether the rounded
+// window is still valid (LOS strictly after AOS): a sub-second window straddling a second
+// boundary collapses to zero length and the caller must drop it. Both the rounding
+// DIRECTION and the collapse decision live here so a single unit test locks them — swapping
+// a side, or weakening `After` to `!Before` (which would keep a zero-length window), fails
+// that test (#201-P2-1; #223 review finding 1).
+func conservativePassWindow(aos, los time.Time) (roundedAOS, roundedLOS time.Time, valid bool) {
+	roundedAOS = ceilToSecond(aos)
+	roundedLOS = floorToSecond(los)
+	return roundedAOS, roundedLOS, roundedLOS.After(roundedAOS)
+}
+
+// ParseElevation parses a string elevation value (e.g., "10") to a float64 in [0, 90].
+// 0 is the geometric horizon and 90 the zenith; a negative or >90 mask is physically
+// meaningless (it would make every / no pass "usable"), so it is rejected. The bound is on
+// the parsed float64 VALUE, not the exact decimal literal: the whole pass pipeline is
+// float64, so a literal within ~half a ULP above 90 (e.g. "90.000000000000001", which
+// rounds to exactly 90.0) is accepted as 90 — while "90.0000000000001" rounds above 90 and
+// is rejected. This matches the CEL admission rule, which converts via the same
+// strconv.ParseFloat; this is the runtime backstop for that bound.
 func ParseElevation(s string) (float64, error) {
 	if s == "" {
 		return 10.0, nil // default
@@ -375,6 +437,12 @@ func ParseElevation(s string) (float64, error) {
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid elevation %q: %w", s, err)
+	}
+	// strconv.ParseFloat accepts "NaN"/"Inf" without error, and NaN fails EVERY ordered
+	// comparison so `v < 0 || v > 90` would let it through — reject non-finite explicitly
+	// so this backstop truly guarantees a finite value in [0,90].
+	if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > 90 {
+		return 0, fmt.Errorf("elevation %q must be a finite value in [0,90]", s)
 	}
 	return v, nil
 }

--- a/pkg/ephemeris/pass_predictor_rounding_test.go
+++ b/pkg/ephemeris/pass_predictor_rounding_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+)
+
+// TestPredictPasses_RejectsInvalidMask pins the exported-API [0,90]-finite invariant
+// (#223 review finding 2): a direct caller passing NaN/Inf/out-of-range must get an error,
+// not a silent degradation to 0°-horizon passes (NaN mask comparisons are all false).
+func TestPredictPasses_RejectsInvalidMask(t *testing.T) {
+	for _, mask := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -1, 90.1, 1000} {
+		_, err := PredictPasses([]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, mask, 24*time.Hour, nil, time.Time{})
+		if err == nil {
+			t.Errorf("PredictPasses(minElevation=%v) must error (invalid mask), got nil", mask)
+		}
+	}
+	// A valid mask still works.
+	_, err := PredictPasses([]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, 10, 24*time.Hour, nil, time.Time{})
+	if err != nil {
+		t.Fatalf("a valid mask must not error: %v", err)
+	}
+}
+
+// TestCeilFloorToSecond pins the conservative whole-second rounding helpers (#201-P2-1):
+// ceil never moves earlier than t, floor never later, both are no-ops on a whole second.
+// Mutation: swap the ceil/floor direction and this fails.
+func TestCeilFloorToSecond(t *testing.T) {
+	base := time.Date(2026, 7, 13, 10, 30, 15, 0, time.UTC)
+
+	// Already on a second boundary → both are no-ops.
+	if got := ceilToSecond(base); !got.Equal(base) {
+		t.Errorf("ceilToSecond(whole) = %v, want %v", got, base)
+	}
+	if got := floorToSecond(base); !got.Equal(base) {
+		t.Errorf("floorToSecond(whole) = %v, want %v", got, base)
+	}
+
+	// Sub-second value → ceil rounds UP to next second, floor DOWN to this second.
+	sub := base.Add(200 * time.Millisecond)
+	if got := ceilToSecond(sub); !got.Equal(base.Add(time.Second)) {
+		t.Errorf("ceilToSecond(+200ms) = %v, want %v", got, base.Add(time.Second))
+	}
+	if got := floorToSecond(sub); !got.Equal(base) {
+		t.Errorf("floorToSecond(+200ms) = %v, want %v", got, base)
+	}
+
+	// Direction invariants: ceil >= t, floor <= t.
+	if ceilToSecond(sub).Before(sub) {
+		t.Error("ceilToSecond must never move earlier than t (would over-claim AOS)")
+	}
+	if floorToSecond(sub).After(sub) {
+		t.Error("floorToSecond must never move later than t (would over-claim LOS)")
+	}
+}
+
+// TestConservativePassWindow_Direction pins the ROUNDING DIRECTION at the production call
+// site (#201-P2-1, review finding 5): predictSingle rounds via conservativePassWindow, so
+// swapping/removing either side here fails this test — the earlier helper + whole-second
+// tests alone would still pass under a floor-AOS/ceil-LOS swap. AOS must round UP, LOS DOWN.
+func TestConservativePassWindow_Direction(t *testing.T) {
+	base := time.Date(2026, 7, 13, 10, 30, 15, 0, time.UTC)
+	rawAOS := base.Add(200 * time.Millisecond) // 10:30:15.2
+	rawLOS := base.Add(300*time.Second + 800*time.Millisecond)
+
+	aos, los, valid := conservativePassWindow(rawAOS, rawLOS)
+
+	if !valid {
+		t.Fatal("a multi-second window must be reported valid")
+	}
+	// AOS rounds UP (never earlier than the computed acquisition).
+	if want := base.Add(time.Second); !aos.Equal(want) {
+		t.Fatalf("AOS must ceil up to %v, got %v (direction reversed?)", want, aos)
+	}
+	if aos.Before(rawAOS) {
+		t.Fatalf("rounded AOS %v is earlier than the computed AOS %v — over-claims acquisition", aos, rawAOS)
+	}
+	// LOS rounds DOWN (never later than the computed loss).
+	if want := base.Add(300 * time.Second); !los.Equal(want) {
+		t.Fatalf("LOS must floor down to %v, got %v (direction reversed?)", want, los)
+	}
+	if los.After(rawLOS) {
+		t.Fatalf("rounded LOS %v is later than the computed LOS %v — over-claims loss", los, rawLOS)
+	}
+}
+
+// TestConservativePassWindow_CollapsesSubSecondWindow deterministically pins the collapse
+// decision (#223 review finding 1): a sub-second window straddling a second boundary rounds
+// to zero length (ceil AOS == floor LOS) and conservativePassWindow reports it INVALID, which
+// predictSingle drops via `if !valid`. The decision lives in the helper, so a mutation that
+// weakens `After` to `!Before` (keeping a zero-length window) fails here — not left to a
+// real-orbit test hitting a grazing pass by chance.
+func TestConservativePassWindow_CollapsesSubSecondWindow(t *testing.T) {
+	base := time.Date(2026, 7, 13, 10, 30, 15, 0, time.UTC)
+	// [15.800, 16.200] — 400 ms long, but ceil(AOS)=:16 and floor(LOS)=:16.
+	aos, los, valid := conservativePassWindow(base.Add(800*time.Millisecond), base.Add(1200*time.Millisecond))
+	if valid {
+		t.Fatalf("a sub-second window straddling a second boundary must be reported INVALID (so predictSingle "+
+			"drops it), got AOS=%v LOS=%v valid=true", aos.UTC(), los.UTC())
+	}
+	if !aos.Equal(base.Add(time.Second)) || !los.Equal(base.Add(time.Second)) {
+		t.Fatalf("both edges must round to :16, got AOS=%v LOS=%v", aos.UTC(), los.UTC())
+	}
+}
+
+// TestPredictPasses_WholeSecondWindow_P2_1 pins the end-to-end conservative window: every
+// AOS/LOS emitted by PredictPasses is on a whole-second boundary, so metav1.Time's
+// second-granularity serialization can't shift the window. mask=10 exercises the
+// sub-second bisection (refineMaskCrossing, ~200ms tol) that the rounding then cleans up.
+// Mutation: remove the ceil/floor in predictSingle → AOS/LOS carry sub-second nanos.
+func TestPredictPasses_WholeSecondWindow_P2_1(t *testing.T) {
+	passes, err := PredictPasses(
+		[]sgp4.OMM{issOMM()},
+		[]GroundStation{montrealStation, taipeiStation},
+		10, // above the horizon, so the mask trim + bisection actually run
+		48*time.Hour,
+		nil,
+		time.Time{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(passes) == 0 {
+		t.Fatal("expected ISS passes over Montreal/Taipei in 48h at a 10° mask")
+	}
+	for _, p := range passes {
+		if p.AOS.Nanosecond() != 0 {
+			t.Errorf("AOS %v must be ceil'd to a whole second (#201-P2-1)", p.AOS.UTC())
+		}
+		if p.LOS.Nanosecond() != 0 {
+			t.Errorf("LOS %v must be floor'd to a whole second (#201-P2-1)", p.LOS.UTC())
+		}
+		if !p.LOS.After(p.AOS) {
+			t.Errorf("window collapsed after rounding but was still emitted: AOS=%v LOS=%v", p.AOS, p.LOS)
+		}
+	}
+}

--- a/pkg/ephemeris/pass_predictor_test.go
+++ b/pkg/ephemeris/pass_predictor_test.go
@@ -261,8 +261,18 @@ func TestParseElevation(t *testing.T) {
 		{"10", 10.0, false},
 		{"0", 0.0, false},
 		{"72.5", 72.5, false},
-		{"-5", -5.0, false},
-		{"", 10.0, false}, // default
+		{"90", 90.0, false},                 // zenith, inclusive
+		{"90.000000000000001", 90.0, false}, // within half a ULP of 90 → float64 90 (accepted; float64 contract)
+		{"10.", 10.0, false},                // trailing dot stays valid (grammar unchanged besides "-")
+		{"-5", 0, true},                     // negative rejected (below the horizon) — P3
+		{"90.0000000000001", 0, true},       // rounds strictly above float64 90 → rejected (exact reject-side boundary)
+		{"90.5", 0, true},                   // above the zenith rejected — P3
+		{"1000", 0, true},                   // far above 90 rejected — P3
+		{"NaN", 0, true},                    // non-finite rejected — P3 backstop
+		{"nan", 0, true},                    // non-finite rejected — P3 backstop
+		{"+Inf", 0, true},                   // non-finite rejected — P3 backstop
+		{"-Inf", 0, true},                   // non-finite rejected — P3 backstop
+		{"", 10.0, false},                   // default
 		{"abc", 0, true},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Round-2 review of the merged elevation-mask code (#201). Each finding verified against current code first.

## Fixed / Changed

- **#201-P2-1 — conservative whole-second pass windows.** AOS/LOS came out of the bisection with ~200 ms sub-second residual, and `metav1.Time` serializes at RFC3339 second precision (the fractional second is dropped) — pushing the stored AOS **earlier** than the true acquisition, over-claiming availability (the opposite of the mask's purpose). `predictSingle` now **ceils AOS up / floors LOS down** (via `conservativePassWindow`) *before* the collapse check, so a window that shrinks below one second is dropped rather than stored with `AOS >= LOS`.

  **Scope of the guarantee (deliberately not absolute):** the rounding guarantees the persisted window never extends outside the window `trimPassToMask` computed. That computed window *is* the usable `>= minElevation` interval **when mask-boundary evaluation succeeds**; on the **fail-open elevation-error path** it is the wider 0°-horizon window (see the deferred item below). So this PR does **not** claim the persisted window is always a subset of the usable interval — that would contradict the fail-open path that is still in place.

  Rounding direction is **mutation-proven**: it lives in one extracted function (`conservativePassWindow`), and swapping ceil/floor, removing the rounding, or swapping the arguments each fails a test.

- **#201-P3 — `minElevation` constrained to `[0, 90]`.** The field accepted negatives and `>90` (pattern allowed a leading `-`, no upper bound; `ParseElevation` unbounded). Now: the pattern rejects negatives, a CEL rule rejects `>90`, and `ParseElevation` is a **finite-value** runtime backstop.
  - **Grammar otherwise preserved:** only the leading `-` was removed (`^-?[0-9]+\.?[0-9]*$` → `^[0-9]+\.?[0-9]*$`). A trailing dot such as `"10."` **stays valid** — it was accepted before, parses fine, and is unrelated to this fix. An envtest admission case pins that it is still admitted through *both* the pattern and the CEL rule.
  - **Non-finite rejected:** `strconv.ParseFloat` accepts `"NaN"`/`"Inf"`, and `NaN` fails *every* ordered comparison, so a bare `v < 0 || v > 90` would let `NaN` through. `ParseElevation` now rejects non-finite explicitly, so the backstop really does guarantee a finite value in `[0,90]`.
  - 4 CRD copies + docs regenerated.

## Deferred for your decision — #201-P2-2 ("drop uncertain passes / fail-closed")

**I did not flip this** — it reverses a *deliberate, commit-documented (`328fdc5`), test-pinned* choice (`TestTrimPassToMask_Guards`, rationale: "degrade to the 0°-horizon window rather than dropping a real pass"). My analysis: the review conflates two cases —

| Case | Current | Correct? |
|------|---------|----------|
| **Boundary-clip** — satellite already **above** the mask at the window edge | fail-open (emit clipped) | ✅ correct — it's a real usable pass; dropping it under-reports availability |
| **Genuine elevation-eval error** — can't tell if it clears the mask | fail-open (emit 0°-horizon window) | ⚠️ debatable — a 0° window claims availability **below** the mask, contradicting the mask's purpose; a narrow fail-**closed**-on-error is arguably better |

So a **blanket** reversal is wrong; only the **narrow error case** has merit, and even that reverses a documented decision on a **rare** path (endpoints rarely error since the orbit was already propagated for coarse detection).

**Recommendation:** either (a) leave fail-open as-is (a documented, defensible trade-off — the guarantee above is scoped honestly to match), or (b) I add a *narrow* fail-closed-on-elevation-error (keeping boundary-clip fail-open) — a small change + a test update, which would then let the guarantee be stated absolutely. **Your call** — I'll amend this PR or open a follow-up.

## Tests

Mutation-proven: `conservativePassWindow` rounding **direction** (swap / remove / argument-swap each fail); end-to-end whole-second AOS/LOS from `PredictPasses`. `ParseElevation` rejects `-5`/`90.5`/`1000`/`NaN`/`+Inf`/`-Inf` and accepts `0`/`90`/`10.`. Envtest admission pins that `"10."` is still admitted and that out-of-range values are rejected; the MaxLength=32 boundary test uses an in-range value (still exercising the length boundary).

`make test` (controller 87.0% / ephemeris 91.3%) / golangci-lint 0 / gofmt / go vet / go test -race / CRD drift-verify — all green.

## Upgrade note

**`passPrediction.minElevation` must be within `[0, 90]`.** New objects, and any edit that **changes `minElevation` itself**, must be in range. Because of **Kubernetes CRD validation ratcheting** (on by default from 1.30; this project's minimum is 1.31), an existing object holding an out-of-range value is **not necessarily rejected on an unrelated edit** — the illegal value can persist in etcd until `minElevation` is next changed. In that state the controller's runtime check refuses to use the value, clears `status.nextPassWindows`, and reports `PassesPredicted=False` / `PredictionFailed`. **Correct any out-of-range `minElevation` before upgrading.** The default `"10"` is unaffected.
