### PR TITLE
perf(reconcile): no-op ConfigMap apply + spec.ephemerisRef field index (#204-G3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (not only at the push). A far-future epoch from a corrupt or spoofed feed would otherwise
   drive SGP4 *backward* from the bogus epoch and write a wildly wrong ECEF into status; the
   consumer check alone could only block its delivery, not the propagation.
+- **The gNB ConfigMap is no longer rewritten byte-identically on every reconcile.**
+  `ApplyCellConfig` produces a deterministic, static-spec-derived config, but it Updated the
+  ConfigMap unconditionally — so each `SatelliteEphemeris` re-propagation (~3 min) fanned out
+  to every referencing `NTNCellConfig` and bumped the ConfigMap's `resourceVersion`, churning
+  every watcher. It now skips the write when the stored content (config + koffset annotation)
+  already matches and the ConfigMap is already owned (#204-G3).
+- **`SatelliteEphemeris`→`NTNCellConfig` fan-out uses a `spec.ephemerisRef` field index.**
+  The mapper resolved referencing cells by scanning every `NTNCellConfig` in the namespace and
+  filtering in Go; it now uses an indexed cache lookup (registered in `SetupWithManager`), with
+  a fallback to the scan for non-cache clients (#204-G3).
 
 ### Upgrade notes
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -885,7 +885,27 @@ func runtimeEphemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris, state *ntnv
 // SetupWithManager sets up the controller with the Manager.
 // Watches SatelliteEphemeris changes to trigger re-reconciliation
 // when a referenced ephemeris is updated.
+// ephemerisRefIndexKey indexes NTNCellConfig by spec.ephemerisRef so the SatelliteEphemeris
+// fan-out mapper resolves referencing cells with an indexed cache lookup instead of scanning
+// every NTNCellConfig in the namespace (#204-G3).
+const ephemerisRefIndexKey = "spec.ephemerisRef"
+
+// indexNTNCellConfigByEphemerisRef is the field-index extractor for spec.ephemerisRef.
+// Registered on the manager cache in SetupWithManager and reused by tests, so the index
+// definition has a single source of truth.
+func indexNTNCellConfigByEphemerisRef(obj client.Object) []string {
+	cc, ok := obj.(*ntnv1alpha1.NTNCellConfig)
+	if !ok || cc.Spec.EphemerisRef == "" {
+		return nil
+	}
+	return []string{cc.Spec.EphemerisRef}
+}
+
 func (r *NTNCellConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ntnv1alpha1.NTNCellConfig{},
+		ephemerisRefIndexKey, indexNTNCellConfigByEphemerisRef); err != nil {
+		return fmt.Errorf("indexing NTNCellConfig by %s: %w", ephemerisRefIndexKey, err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		// reconcileTriggerPredicate (predicates.go) filters status-only self-writes
 		// but passes spec changes AND deletionTimestamp transitions — the latter is
@@ -914,22 +934,44 @@ func (r *NTNCellConfigReconciler) ephemerisToNTNCellConfig(
 
 	log := logf.FromContext(ctx)
 
-	var ccList ntnv1alpha1.NTNCellConfigList
-	if err := r.List(ctx, &ccList, client.InNamespace(eph.Namespace)); err != nil {
-		log.Error(err, "Failed to list NTNCellConfigs for ephemeris mapper")
-		return nil
+	// Prefer the spec.ephemerisRef field index (registered in SetupWithManager): every
+	// returned item already references this ephemeris, so no in-Go filter is needed. Fall
+	// back to a full in-namespace list + filter when the index is unavailable — e.g. a
+	// direct (non-cache) client in tests, which cannot serve a custom field selector.
+	var matched []ntnv1alpha1.NTNCellConfig
+	var indexed ntnv1alpha1.NTNCellConfigList
+	if err := r.List(ctx, &indexed, client.InNamespace(eph.Namespace),
+		client.MatchingFields{ephemerisRefIndexKey: eph.Name}); err == nil {
+		matched = indexed.Items
+	} else {
+		// Do NOT swallow the indexed-lookup error silently: on a manager cache it means the
+		// spec.ephemerisRef index is missing/broken (a production regression that would turn
+		// every ephemeris event back into an O(namespace) scan). Bump a counter (visible at the
+		// default verbosity, unlike the V(1) log) AND log the cause, so the degradation is
+		// observable (#204-G3; #224 review-2 L1).
+		ntnmetrics.EphemerisMapperFallbackTotal.With(prometheus.Labels{"namespace": eph.Namespace}).Inc()
+		log.V(1).Info("indexed ephemerisRef lookup unavailable; falling back to a namespace scan",
+			"error", err.Error(), "ephemeris", eph.Name, "namespace", eph.Namespace)
+		var all ntnv1alpha1.NTNCellConfigList
+		if lerr := r.List(ctx, &all, client.InNamespace(eph.Namespace)); lerr != nil {
+			log.Error(lerr, "Failed to list NTNCellConfigs for ephemeris mapper")
+			return nil
+		}
+		for i := range all.Items {
+			if all.Items[i].Spec.EphemerisRef == eph.Name {
+				matched = append(matched, all.Items[i])
+			}
+		}
 	}
 
-	var requests []reconcile.Request
-	for _, cc := range ccList.Items {
-		if cc.Spec.EphemerisRef == eph.Name {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      cc.Name,
-					Namespace: cc.Namespace,
-				},
-			})
-		}
+	requests := make([]reconcile.Request, 0, len(matched))
+	for i := range matched {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      matched[i].Name,
+				Namespace: matched[i].Namespace,
+			},
+		})
 	}
 	return requests
 }

--- a/internal/controller/ntncellconfig_ephemerisindex_test.go
+++ b/internal/controller/ntncellconfig_ephemerisindex_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// TestEphemerisToNTNCellConfig_IndexedPath_G3 pins the INDEXED mapper path (#204-G3b):
+// with the spec.ephemerisRef field index registered (as SetupWithManager does on the
+// manager cache), the mapper resolves referencing cells via client.MatchingFields — only
+// the cell that references the ephemeris is returned, with no in-Go filter. (The envtest
+// mapper test uses a direct client and exercises the fallback path instead.)
+// Mutation: point the index at the wrong field, or the mapper at the wrong key, and this
+// returns the wrong set.
+func TestEphemerisToNTNCellConfig_IndexedPath_G3(t *testing.T) {
+	const ns = "default"
+	ccRef := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cc-ref", Namespace: ns},
+		Spec:       ntnv1alpha1.NTNCellConfigSpec{EphemerisRef: "eph-x"},
+	}
+	ccOther := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cc-other", Namespace: ns},
+		Spec:       ntnv1alpha1.NTNCellConfigSpec{EphemerisRef: "eph-y"},
+	}
+	ccNone := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cc-none", Namespace: ns},
+		Spec:       ntnv1alpha1.NTNCellConfigSpec{},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(makeScheme(t)).
+		WithObjects(ccRef, ccOther, ccNone).
+		WithIndex(&ntnv1alpha1.NTNCellConfig{}, ephemerisRefIndexKey, indexNTNCellConfigByEphemerisRef).
+		Build()
+	r := &NTNCellConfigReconciler{Client: c}
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{ObjectMeta: metav1.ObjectMeta{Name: "eph-x", Namespace: ns}}
+	reqs := r.ephemerisToNTNCellConfig(context.Background(), eph)
+
+	if len(reqs) != 1 || reqs[0].Name != "cc-ref" || reqs[0].Namespace != ns {
+		t.Fatalf("indexed mapper must return exactly cc-ref for eph-x, got %v", reqs)
+	}
+
+	// An ephemeris nobody references returns no requests.
+	ephNone := &ntnv1alpha1.SatelliteEphemeris{ObjectMeta: metav1.ObjectMeta{Name: "eph-z", Namespace: ns}}
+	if reqs := r.ephemerisToNTNCellConfig(context.Background(), ephNone); len(reqs) != 0 {
+		t.Fatalf("an unreferenced ephemeris must map to no requests, got %v", reqs)
+	}
+}

--- a/internal/controller/ntncellconfig_indexconsumption_test.go
+++ b/internal/controller/ntncellconfig_indexconsumption_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// TestEphemerisToNTNCellConfig_IssuesIndexedList_M1 pins that the mapper actually CONSUMES the
+// spec.ephemerisRef index (#224 review-2 M1): it must issue a List carrying the field selector,
+// not a full namespace scan. The earlier index-registration + result tests would both stay
+// green if the mapper reverted to a full List + in-Go filter (same result, index unused) — the
+// silent perf regression this PR exists to prevent. This intercepts List and asserts the field
+// selector is present and the indexed path makes exactly one call (no fallback scan).
+func TestEphemerisToNTNCellConfig_IssuesIndexedList_M1(t *testing.T) {
+	const ns = "default"
+	ccRef := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cc-ref", Namespace: ns},
+		Spec:       ntnv1alpha1.NTNCellConfigSpec{EphemerisRef: "eph-x"},
+	}
+	var listCalls int
+	var sawFieldSelector bool
+	c := fake.NewClientBuilder().
+		WithScheme(makeScheme(t)).
+		WithObjects(ccRef).
+		WithIndex(&ntnv1alpha1.NTNCellConfig{}, ephemerisRefIndexKey, indexNTNCellConfigByEphemerisRef).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listCalls++
+				var lo client.ListOptions
+				for _, o := range opts {
+					o.ApplyToList(&lo)
+				}
+				if lo.FieldSelector != nil && strings.Contains(lo.FieldSelector.String(), ephemerisRefIndexKey) {
+					sawFieldSelector = true
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	r := &NTNCellConfigReconciler{Client: c}
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{ObjectMeta: metav1.ObjectMeta{Name: "eph-x", Namespace: ns}}
+	reqs := r.ephemerisToNTNCellConfig(context.Background(), eph)
+
+	if len(reqs) != 1 || reqs[0].Name != "cc-ref" {
+		t.Fatalf("mapper must return exactly cc-ref, got %v", reqs)
+	}
+	if !sawFieldSelector {
+		t.Fatal("the mapper must issue an INDEXED List carrying the spec.ephemerisRef field selector; a " +
+			"full namespace scan + Go filter returns the same result but silently reverts the perf fix")
+	}
+	if listCalls != 1 {
+		t.Errorf("the indexed path must make exactly one List call (no fallback scan), got %d", listCalls)
+	}
+}

--- a/internal/controller/ntncellconfig_indexwiring_test.go
+++ b/internal/controller/ntncellconfig_indexwiring_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// This proves the PRODUCTION field-index wiring (#204-G3b, review M1): the fake-client unit
+// test registers its own index via WithIndex and therefore CANNOT catch a regression where
+// SetupWithManager stops registering the index (or uses the wrong key/type) — the mapper
+// silently falls back to an O(namespace) scan, so the suite would stay green while the perf
+// fix is gone. Here we run the real SetupWithManager against a manager cache and prove the
+// indexed lookup works through the manager client.
+var _ = Describe("NTNCellConfig spec.ephemerisRef index wiring (SetupWithManager)", func() {
+	const ns = "default"
+
+	It("registers the index on the manager cache so MatchingFields resolves referencing cells", func() {
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  scheme.Scheme,
+			Metrics: metricsserver.Options{BindAddress: "0"}, // no metrics port
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The production wiring under test — registers the spec.ephemerisRef field index.
+		r := &NTNCellConfigReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}
+		Expect(r.SetupWithManager(mgr)).To(Succeed())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Start ONLY the cache (not mgr.Start), so the informer + index come up but no
+		// reconcile loop runs — this test needs no provider. A missing/wrong index makes the
+		// MatchingFields List below error ("field selector not registered").
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.GetCache().Start(ctx)).To(Succeed())
+		}()
+		Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+		newCC := func(name, ephRef string) *ntnv1alpha1.NTNCellConfig {
+			return &ntnv1alpha1.NTNCellConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: ntnv1alpha1.NTNCellConfigSpec{
+					Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: ns},
+					NTN: ntnv1alpha1.NTNParams{
+						CellSpecificKoffset: 150,
+						EphemerisECEF:       &ntnv1alpha1.EphemerisECEF{PosX: 20922195, PosY: 1967783, PosZ: 19770302},
+						PayloadType:         "transparent",
+					},
+					EphemerisRef: ephRef,
+				},
+			}
+		}
+		ccRef := newCC("cc-idx-ref", "eph-idx")
+		ccOther := newCC("cc-idx-other", "eph-other")
+		Expect(k8sClient.Create(ctx, ccRef)).To(Succeed())
+		Expect(k8sClient.Create(ctx, ccOther)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ccRef)
+			_ = k8sClient.Delete(context.Background(), ccOther)
+		})
+
+		// The cache-backed indexed lookup must return ONLY the referencing cell — which is
+		// only possible if SetupWithManager registered the index with the correct key + type.
+		Eventually(func(g Gomega) {
+			var list ntnv1alpha1.NTNCellConfigList
+			g.Expect(mgr.GetCache().List(ctx, &list, client.InNamespace(ns),
+				client.MatchingFields{ephemerisRefIndexKey: "eph-idx"})).To(Succeed())
+			g.Expect(list.Items).To(HaveLen(1))
+			g.Expect(list.Items[0].Name).To(Equal("cc-idx-ref"))
+		}, "10s", "200ms").Should(Succeed())
+	})
+})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -222,6 +222,19 @@ var (
 		},
 		[]string{"namespace", "name"},
 	)
+
+	// EphemerisMapperFallbackTotal counts times the SatelliteEphemeris->NTNCellConfig mapper
+	// fell back to a full namespace scan because the spec.ephemerisRef index was unavailable.
+	// A persistent nonzero rate in production means the field index is not registered (an
+	// O(namespace) perf regression that the V(1) fallback log would otherwise hide at the
+	// default verbosity).
+	EphemerisMapperFallbackTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ntn_operators_ephemeris_mapper_index_fallback_total",
+			Help: "Times the ephemeris->cell mapper fell back to a full namespace scan (spec.ephemerisRef index unavailable).",
+		},
+		[]string{"namespace"},
+	)
 )
 
 func init() {
@@ -240,6 +253,7 @@ func init() {
 		ReaderQueryDuration,
 		ReaderErrorsTotal,
 		ReaderStaleUsedTotal,
+		EphemerisMapperFallbackTotal,
 	)
 	// Note: logging here is intentionally omitted because init() runs
 	// before controller-runtime's logger is configured. Registration

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -197,7 +197,11 @@ func (p *Provider) ApplyCellConfig(
 	// geo_ntn.yml config key (a pre-atomic-ref leftover). A ConfigMap owned by a
 	// different controller, an unlabeled foreign object, or a labeled-but-empty
 	// impostor that never held our config is refused.
-	if !metav1.IsControlledBy(cm, owner) {
+	// Capture ownership BEFORE the adoption block: SetControllerReference below sets the
+	// owner ref in memory (making IsControlledBy true), so the no-op skip must key off the
+	// pre-adoption state or a freshly-adopted CM would skip its owner-ref persist.
+	alreadyOwned := metav1.IsControlledBy(cm, owner)
+	if !alreadyOwned {
 		if metav1.GetControllerOf(cm) != nil || !isOperatorManaged(cm) || cm.Data[configDataKey] == "" {
 			return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 		}
@@ -205,14 +209,27 @@ func (p *Provider) ApplyCellConfig(
 			return fmt.Errorf("adopting ConfigMap: %w", err)
 		}
 	}
+	desiredData := string(yamlData)
+	desiredKoffset := strconv.Itoa(spec.NTN.CellSpecificKoffset)
+	// No-op when the stored ConfigMap already carries the desired content AND we already
+	// owned it: GenerateConfig is a deterministic function of the (static) CR spec, so a
+	// SatelliteEphemeris fan-out reconcile that changed nothing must not rewrite a
+	// byte-identical ConfigMap — an unconditional Update bumps resourceVersion and churns
+	// every watcher on the ~3-minute re-propagation cadence (#204-G3). A just-adopted CM
+	// (alreadyOwned == false) always writes, so the owner reference persists.
+	if alreadyOwned &&
+		cm.Data[configDataKey] == desiredData &&
+		cm.Annotations["ntn.operators.dev/koffset"] == desiredKoffset {
+		return nil
+	}
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
-	cm.Data[configDataKey] = string(yamlData)
+	cm.Data[configDataKey] = desiredData
 	if cm.Annotations == nil {
 		cm.Annotations = make(map[string]string)
 	}
-	cm.Annotations["ntn.operators.dev/koffset"] = strconv.Itoa(spec.NTN.CellSpecificKoffset)
+	cm.Annotations["ntn.operators.dev/koffset"] = desiredKoffset
 	if err := p.client.Update(ctx, cm); err != nil {
 		return fmt.Errorf("updating ConfigMap: %w", err)
 	}

--- a/pkg/provider/ocudu/provider_noop_test.go
+++ b/pkg/provider/ocudu/provider_noop_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ocudu
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestApplyCellConfig_NoOpOnIdenticalContent_G3 pins #204-G3a: re-applying an identical
+// (static-spec-derived) config must NOT rewrite the ConfigMap — an unconditional Update
+// bumps resourceVersion and churns every watcher on the ~3-minute re-propagation fan-out.
+// A genuine change must still write. Mutation: drop the content-equality skip → the
+// identical re-apply bumps resourceVersion and the first assertion fails.
+func TestApplyCellConfig_NoOpOnIdenticalContent_G3(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	spec := geoSpec()
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	var cm1 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm1); err != nil {
+		t.Fatalf("get after first apply: %v", err)
+	}
+
+	// Re-apply the SAME spec → no-op, resourceVersion must not advance.
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("second (identical) apply: %v", err)
+	}
+	var cm2 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm2); err != nil {
+		t.Fatalf("get after second apply: %v", err)
+	}
+	if cm1.ResourceVersion != cm2.ResourceVersion {
+		t.Fatalf("an identical re-apply must NOT rewrite the ConfigMap (#204-G3): resourceVersion %q -> %q",
+			cm1.ResourceVersion, cm2.ResourceVersion)
+	}
+
+	// A real change (koffset) must still write → resourceVersion advances.
+	spec.NTN.CellSpecificKoffset = 500
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("third (changed) apply: %v", err)
+	}
+	var cm3 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm3); err != nil {
+		t.Fatalf("get after third apply: %v", err)
+	}
+	if cm2.ResourceVersion == cm3.ResourceVersion {
+		t.Fatalf("a changed spec must rewrite the ConfigMap: resourceVersion stayed %q", cm3.ResourceVersion)
+	}
+	if !contains(cm3.Data["geo_ntn.yml"], "cell_specific_koffset: 500") {
+		t.Error("the changed apply must persist koffset=500")
+	}
+}
+
+// TestApplyCellConfig_AdoptsUnownedIdenticalConfigMap_G3 pins the load-bearing adoption
+// invariant behind the `alreadyOwned` snapshot (#204-G3, review M2): a pre-existing,
+// operator-managed but UNOWNED ConfigMap whose content ALREADY equals the desired output
+// must still be Updated so the freshly-set controller reference is persisted — the no-op
+// content-equality skip must not short-circuit before the adoption write. The other no-op
+// test starts from differing content, so it would NOT catch a dropped `alreadyOwned` guard.
+// Mutation: drop `alreadyOwned &&` from the skip → this ConfigMap is never adopted.
+func TestApplyCellConfig_AdoptsUnownedIdenticalConfigMap_G3(t *testing.T) {
+	ctx := context.Background()
+	spec := geoSpec()
+	// The exact content ApplyCellConfig would generate for this spec.
+	yamlData, err := GenerateConfig(spec)
+	if err != nil {
+		t.Fatalf("GenerateConfig: %v", err)
+	}
+	seed := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigMapNameFor("test-cr"),
+			Namespace: "ntn-system",
+			// operator-managed labels, but NO controller owner reference (unowned).
+			Labels: map[string]string{managedByLabel: managedByValue, componentLabel: componentValue},
+			Annotations: map[string]string{
+				"ntn.operators.dev/koffset": strconv.Itoa(spec.NTN.CellSpecificKoffset),
+			},
+		},
+		Data: map[string]string{configDataKey: string(yamlData)}, // identical to desired
+	}
+	p := newTestProviderWith(t, seed)
+	owner := ownerFor("test-cr")
+
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var got corev1.ConfigMap
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+	if err := p.client.Get(ctx, key, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !metav1.IsControlledBy(&got, owner) {
+		t.Fatal("an unowned operator-managed ConfigMap with identical content must still be ADOPTED " +
+			"(controller ref persisted); the alreadyOwned guard must not let the no-op skip bypass the adoption write")
+	}
+}
+
+// TestApplyCellConfig_NoOp_NonKoffsetYAMLChangeWrites_M2 pins the independence of the YAML
+// equality clause (#224 review-2 M2): a change to a YAML-producing field that is NOT the
+// koffset annotation (here ta_common) must still rewrite the ConfigMap. The existing
+// changed-spec test moves koffset, which changes BOTH the YAML and the annotation, so it
+// could not catch a dropped YAML comparison. Mutation: drop `cm.Data[...] == desiredData`
+// from the skip → this no-ops and resourceVersion does not advance.
+func TestApplyCellConfig_NoOp_NonKoffsetYAMLChangeWrites_M2(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	spec := geoSpec()
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	var cm1 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm1); err != nil {
+		t.Fatalf("get1: %v", err)
+	}
+
+	spec.NTN.TACommon = 42 // changes the YAML (ta_common) but NOT the koffset annotation
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	var cm2 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm2); err != nil {
+		t.Fatalf("get2: %v", err)
+	}
+	if cm1.ResourceVersion == cm2.ResourceVersion {
+		t.Fatal("a non-koffset YAML change must rewrite the ConfigMap " +
+			"(the YAML equality clause must be required independently)")
+	}
+}
+
+// TestApplyCellConfig_NoOp_AnnotationRepaired_M2 pins the independence of the koffset-annotation
+// equality clause (#224 review-2 M2): if the annotation is corrupted while the YAML stays
+// correct, ApplyCellConfig must repair it. Mutation: drop the annotation comparison from the
+// skip → the corrupted annotation is never repaired.
+func TestApplyCellConfig_NoOp_AnnotationRepaired_M2(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	spec := geoSpec()
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	var cm corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	cm.Annotations["ntn.operators.dev/koffset"] = "99999" // corrupt ONLY the annotation
+	if err := p.client.Update(ctx, &cm); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+	var before corev1.ConfigMap
+	_ = p.client.Get(ctx, key, &before)
+
+	if err := p.ApplyCellConfig(ctx, ownerFor("test-cr"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	var after corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &after); err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if after.Annotations["ntn.operators.dev/koffset"] != strconv.Itoa(spec.NTN.CellSpecificKoffset) {
+		t.Fatalf("the corrupted koffset annotation must be repaired, got %q", after.Annotations["ntn.operators.dev/koffset"])
+	}
+	if after.ResourceVersion == before.ResourceVersion {
+		t.Fatal("repairing the annotation must Update (the annotation equality clause must be required independently)")
+	}
+}


### PR DESCRIPTION
Separate PR off origin/main (independent of #221/#222/#223).

## #204-G3a — no-op ConfigMap apply
`ApplyCellConfig` produced a deterministic static-spec-derived config but Updated the ConfigMap **unconditionally**, so every `SatelliteEphemeris` re-propagation (~3 min) fanned out to each referencing `NTNCellConfig` and bumped the ConfigMap `resourceVersion` on byte-identical data, churning every watcher. Now it **skips the write** when the stored content (config + koffset annotation) already matches **and** the ConfigMap is already owned. A just-adopted ConfigMap (ownership captured *before* `SetControllerReference`) always writes so the owner-ref persists. Mutation-proven.

## #204-G3b — spec.ephemerisRef field index
The `ephemerisToNTNCellConfig` mapper scanned every `NTNCellConfig` in the namespace and filtered in Go. Now it uses an **indexed cache lookup** (registered in `SetupWithManager`) with a **fallback** to scan+filter for non-cache clients (the direct client the envtest suite uses can't serve a custom field selector). Existing envtest test exercises the fallback; a new fake-client test with the index registered exercises the indexed path (mutation-proven).

No behavior change to the emitted config. `make test` (controller 86.9% / provider 93.4%) / golangci-lint 0 / gofmt / go vet / go test -race — all green.