### PR TITLE
fix(ephemeris): keep SIB19 alive through a sustained upstream outage (cache-fallback cadence + source-epoch sentinel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SIB19 now survives a sustained upstream outage, not just the first reconcile of one.**
+  Serving cached OMMs on a failed GP fetch (I-18) used to re-propagate ONCE (to
+  `now + 5 min`) and then set `RequeueAfter` to the **fetch** backoff — 2–24h for
+  rate-limit/auth failures, or the workqueue's exponential backoff for a transient one. The
+  controller filters its own status writes, so nothing else re-triggered it: the pushed epoch
+  expired ~5 minutes in and the consumer refused the state for the rest of the window
+  (continuity was ~4%, not 100%). The two cadences are now independent — the **fetch** is
+  throttled on the cache entry (`nextFetchAttempt`) while the **reconcile** keeps running on
+  the 3-minute propagation heartbeat, so the source is contacted once per backoff window and
+  the epoch is refreshed for the whole outage. A **fetcher/credential setup failure** (missing,
+  unreadable or mid-rotation Secret) now takes the same cache fallback instead of giving up
+  without propagating, reported distinctly as `FetcherSetupFailedServingCache`. Fixing the
+  credentials or lowering `refreshInterval` clears a stale backoff immediately, and an auth
+  backoff is capped so an in-place Secret fix recovers in minutes rather than up to 24h.
+  ⚠ **Scope:** the OMM cache is process-local and in-memory, so this preserves continuity for
+  the lifetime of a **warm** controller cache. After a restart or leader failover the cache is
+  cold, and if the upstream is still unavailable there is nothing to re-propagate from.
+- **`propagatedStates[].sourceEpochUnixMs == 0` no longer bypasses the freshness gate.** `0`
+  meant *both* "unparseable" *and* the legal instant `1970-01-01T00:00:00Z`, and the consumer
+  failed **open** on it — so a 1970-dated element set skipped the 7-day hard-stale check
+  entirely. The producer no longer emits a state whose epoch it could not parse (SGP4's own
+  `OMM.ToTLE` parses the same epoch, so such an element set fails propagation anyway), and the
+  consumer now validates unconditionally: a 1970 epoch is simply, and correctly, stale. Element
+  sets refused before propagation are surfaced by a new `SourceEpochRejected` condition
+  (`UnparseableSourceEpoch` / `FutureDatedSourceEpoch`), so a cell reporting
+  `EphemerisPayloadMissing` can be traced to a corrupt feed rather than a NORAD typo.
 - **Runtime ephemeris push is gated on propagation-input currency and per-satellite
   freshness.** The `NTNCellConfig` runtime push consumes `SatelliteEphemeris.status.propagatedStates`
   across a watch fan-out; it now refuses to push when those states were computed under

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -174,8 +174,9 @@ type SatelliteEphemerisStatus struct {
 	// propagatedStatesInputHash is a digest of the spec fields that determine WHICH
 	// orbital data is fetched and WHICH satellites are propagated (source type/url and the
 	// NORAD selector) — NOT the whole spec. It is stamped whenever the current
-	// propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-	// cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+	// propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+	// same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+	// .metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
 	// spec and refuses to push when it differs — i.e. the persisted states were computed
 	// under different propagation inputs (a source/selector edit whose re-propagate has
 	// not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit
@@ -241,6 +242,15 @@ const (
 	// derived from stale elements and drifting (SGP4 in-track error grows with
 	// age from the element epoch). False means all propagated epochs are fresh.
 	ConditionEphemerisEpochStale = "EphemerisEpochStale"
+	// ConditionSourceEpochRejected is True when one or more tracked element sets were
+	// REFUSED BEFORE propagation because their OMM EPOCH is unparseable or implausibly
+	// future-dated (a corrupt or spoofed feed — SGP4 would otherwise be driven backward from
+	// the bogus epoch). Such a satellite produces NO propagated state, so a cell selecting it
+	// reports a bare EphemerisPayloadMissing; this condition is what tells the operator the
+	// cause is bad source data rather than a NORAD typo or a deep-space rejection. False
+	// means every tracked element set has a parseable, plausibly-dated epoch. Distinct from
+	// EphemerisEpochStale, which covers merely OLD (but still propagated) element sets.
+	ConditionSourceEpochRejected = "SourceEpochRejected"
 	// ConditionRefreshIntervalClamped is True when spec.source.refreshInterval was
 	// outside [2h, 24h] and the controller clamped it (Reason BelowMinimum /
 	// AboveMaximum). False (Reason WithinBounds) means the controller evaluated the

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -381,8 +381,9 @@ spec:
                   propagatedStatesInputHash is a digest of the spec fields that determine WHICH
                   orbital data is fetched and WHICH satellites are propagated (source type/url and the
                   NORAD selector) — NOT the whole spec. It is stamped whenever the current
-                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+                  same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+                  .metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
                   spec and refuses to push when it differs — i.e. the persisted states were computed
                   under different propagation inputs (a source/selector edit whose re-propagate has
                   not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -381,8 +381,9 @@ spec:
                   propagatedStatesInputHash is a digest of the spec fields that determine WHICH
                   orbital data is fetched and WHICH satellites are propagated (source type/url and the
                   NORAD selector) — NOT the whole spec. It is stamped whenever the current
-                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+                  same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+                  .metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
                   spec and refuses to push when it differs — i.e. the persisted states were computed
                   under different propagation inputs (a source/selector edit whose re-propagate has
                   not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -384,8 +384,9 @@ spec:
                   propagatedStatesInputHash is a digest of the spec fields that determine WHICH
                   orbital data is fetched and WHICH satellites are propagated (source type/url and the
                   NORAD selector) — NOT the whole spec. It is stamped whenever the current
-                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+                  same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+                  .metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
                   spec and refuses to push when it differs — i.e. the persisted states were computed
                   under different propagation inputs (a source/selector edit whose re-propagate has
                   not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3331,8 +3331,9 @@ under the etcd object-size limit.<br/>
           propagatedStatesInputHash is a digest of the spec fields that determine WHICH
 orbital data is fetched and WHICH satellites are propagated (source type/url and the
 NORAD selector) — NOT the whole spec. It is stamped whenever the current
-propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+.metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
 spec and refuses to push when it differs — i.e. the persisted states were computed
 under different propagation inputs (a source/selector edit whose re-propagate has
 not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit

--- a/internal/controller/ephemeris_continuity_test.go
+++ b/internal/controller/ephemeris_continuity_test.go
@@ -13,6 +13,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -156,8 +157,8 @@ func TestFetchRetryDelay_PerErrorClass(t *testing.T) {
 	if got := fetchRetryDelay(ephemeris.ErrRateLimited, interval, 1); got < interval {
 		t.Errorf("rate-limited fetch delay must be at least the refresh interval, got %s", got)
 	}
-	if got := fetchRetryDelay(ephemeris.ErrAuthFailed, interval, 1); got != interval {
-		t.Errorf("auth-failed fetch delay = %s, want %s", got, interval)
+	if got := fetchRetryDelay(ephemeris.ErrAuthFailed, interval, 1); got != maxAuthRetryBackoff {
+		t.Errorf("auth-failed fetch delay must be capped for recovery = %s, want %s", got, maxAuthRetryBackoff)
 	}
 	// Transient ramps 1m, 2m, 4m … and is capped at the interval.
 	if got := fetchRetryDelay(errors.New("boom"), interval, 1); got != time.Minute {
@@ -171,39 +172,152 @@ func TestFetchRetryDelay_PerErrorClass(t *testing.T) {
 	}
 }
 
-// TestReconcile_ValidCache_MissingCredentialSecret_StillRepropagates: a reconcile the cache can
-// answer must not need the source Secret at all. The fetcher is left unconfigured so
-// fetcherForSource would ERROR if it ran — standing in for a Secret that is missing, briefly
-// unreadable, or mid-rotation. Continuity must survive it.
-func TestReconcile_ValidCache_MissingCredentialSecret_StillRepropagates(t *testing.T) {
+// TestReconcile_ExpiredCache_MissingSecret_KeepsPropagating is the REAL credential-outage
+// scenario, and the one my earlier test faked: it used a cache INSIDE the refresh window, so it
+// only proved the (easy) "cache answers before credentials are read" path and never exercised
+// the dangerous one.
+//
+// Here the SpaceTrack cache is EXPIRED (5h old vs a 4h window), so a fetch is genuinely due —
+// cacheServe returns none, fetcherForSource runs, and the referenced Secret is MISSING. The old
+// code set FetcherSetupFailed and returned RequeueAfter=1m WITHOUT propagating: the cache-on-
+// error fallback lived inside obtainOMMs, which a setup failure never reaches. The pushed epoch
+// then expired within ~2 minutes and SIB19 broke — on the very contract this PR claims to protect.
+// Setup failure must now go through the SAME any-age cache fallback as a fetch failure.
+func TestReconcile_ExpiredCache_MissingSecret_KeepsPropagating(t *testing.T) {
+	sch := makeScheme(t)
 	ctx := context.Background()
-	r, cli, key, _ := ephForContinuity(t, "eph-nocred")
-	r.Fetcher = nil // fetcherForSource would fail: "CelesTrak fetcher is not configured"
-	// Make the cache answerable WITHOUT a fetch by putting it inside the refresh window.
+	const ns = "default"
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-st", Namespace: ns, Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "SpaceTrack", URL: "https://www.space-track.org/gp",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+				// The Secret this points at is deliberately NEVER created.
+				Credentials: &ntnv1alpha1.SecretReference{Name: "spacetrack-creds", Key: "password"},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-st", Namespace: ns}
 	got := &ntnv1alpha1.SatelliteEphemeris{}
 	if err := cli.Get(ctx, key, got); err != nil {
 		t.Fatalf("get: %v", err)
 	}
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50),
+		// Non-nil so fetcherForSource gets PAST the "fetcher not configured" check and fails on
+		// the Secret read itself — the real-world failure.
+		SpaceTrackFetcher: ephemeris.NewSpaceTrackFetcher(&http.Client{}, "https://www.space-track.org"),
+	}
+	// EXPIRED cache (5h old vs the 4h window) → a fetch is genuinely due.
 	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
 		result: ephemeris.GPFetchResult{
-			OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now(), // FRESH
+			OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now().Add(-5 * time.Hour),
 		},
 		fetchKey: fetchInputKey(got.Spec),
 		uid:      got.UID,
 	})
 
-	if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
-		t.Fatalf("a cache-answerable reconcile must not need credentials: %v", err)
+	var lastEpoch int64
+	for cycle := 1; cycle <= 3; cycle++ {
+		if cycle > 1 {
+			time.Sleep(2 * time.Millisecond)
+		}
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		if err != nil {
+			t.Fatalf("cycle %d: %v", cycle, err)
+		}
+		if res.RequeueAfter != propagationRefreshInterval {
+			t.Fatalf("cycle %d: a setup failure with a usable cache must keep the PROPAGATION cadence "+
+				"(%s), got %s — the epoch would expire before the next reconcile",
+				cycle, propagationRefreshInterval, res.RequeueAfter)
+		}
+		after := &ntnv1alpha1.SatelliteEphemeris{}
+		if err := cli.Get(ctx, key, after); err != nil {
+			t.Fatalf("cycle %d: re-get: %v", cycle, err)
+		}
+		if len(after.Status.PropagatedStates) == 0 {
+			t.Fatalf("cycle %d: SIB19 continuity lost — a missing Secret must not stop re-propagation "+
+				"from a cache whose raw OMMs do not depend on credentials", cycle)
+		}
+		epoch := after.Status.PropagatedStates[0].EpochUnixMs
+		if epoch <= time.Now().UnixMilli() {
+			t.Fatalf("cycle %d: propagated epoch is already in the past — the consumer will refuse it", cycle)
+		}
+		if cycle > 1 && epoch <= lastEpoch {
+			t.Fatalf("cycle %d: epoch did not advance — the cache is not being re-propagated", cycle)
+		}
+		lastEpoch = epoch
+		// The degraded reason must name the SETUP failure, not be collapsed into the fetch one:
+		// the operator action is different (fix the Secret vs check the source).
+		cond := meta.FindStatusCondition(after.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched)
+		if cond == nil || cond.Reason != reasonSetupFailedServingCache {
+			t.Fatalf("cycle %d: expected GPDataFetched reason %q, got %+v", cycle, reasonSetupFailedServingCache, cond)
+		}
 	}
-	after := &ntnv1alpha1.SatelliteEphemeris{}
-	if err := cli.Get(ctx, key, after); err != nil {
-		t.Fatalf("re-get: %v", err)
+}
+
+// TestCacheServe_CredentialChangeClearsBackoff: the payload cache key deliberately excludes
+// credentials, but the BACKOFF was armed from them. Without separating the two, an operator who
+// FIXES the credential reference would still be suppressed by the old 2–24h auth backoff —
+// cacheServe would answer from cache and never even build the fetcher. A retry-input change must
+// invalidate the backoff so the next fetch goes through immediately.
+func TestCacheServe_CredentialChangeClearsBackoff(t *testing.T) {
+	sch := makeScheme(t)
+	now := time.Now()
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", UID: "u1"},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "SpaceTrack", URL: "https://st/gp",
+				Credentials: &ntnv1alpha1.SecretReference{Name: "old-creds", Key: "password"},
+			},
+		},
 	}
-	if cond := meta.FindStatusCondition(after.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched); cond != nil && cond.Reason == "FetcherSetupFailed" {
-		t.Fatal("credential/fetcher setup must be SKIPPED when the cache can answer, but got FetcherSetupFailed")
+	_ = sch
+	r := &SatelliteEphemerisReconciler{}
+	k := client.ObjectKeyFromObject(eph)
+	const interval = 4 * time.Hour
+	// Expired cache + an armed auth backoff built from the OLD credentials.
+	r.ommCache.Store(k, cachedFetch{
+		result:           ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMForTest()}, FetchedAt: now.Add(-5 * time.Hour)},
+		fetchKey:         fetchInputKey(eph.Spec),
+		uid:              eph.UID,
+		nextFetchAttempt: now.Add(2 * time.Hour),
+		retryKey:         retryInputKey(eph.Spec, interval),
+		lastFetchErr:     ephemeris.ErrAuthFailed,
+	})
+	if _, why := r.cacheServe(k, eph, now, interval); why != cacheServeBackoff {
+		t.Fatalf("with unchanged credentials the backoff must hold, got %v", why)
 	}
-	if len(after.Status.PropagatedStates) == 0 {
-		t.Error("a cache-answerable reconcile must still re-propagate (SIB19 continuity)")
+
+	// Operator points at a FIXED Secret. Payload identity is unchanged (same type+url), so the
+	// cached OMMs stay reusable — but the backoff must NOT.
+	eph.Spec.Source.Credentials.Name = "new-creds"
+	if _, why := r.cacheServe(k, eph, now, interval); why != cacheServeNone {
+		t.Fatalf("a credential change must invalidate the stale backoff so a fetch is attempted, got %v", why)
+	}
+	// Same for lowering the refresh interval (a retry-policy input).
+	eph.Spec.Source.Credentials.Name = "old-creds"
+	if _, why := r.cacheServe(k, eph, now, 2*time.Hour); why != cacheServeNone {
+		t.Fatalf("a refresh-interval change must invalidate the stale backoff, got %v", why)
+	}
+}
+
+// TestCadenceInvariant_EpochOutlivesTheReconcileGap is the static guard the sustained-outage
+// tests cannot give (they re-enter Reconcile immediately rather than waiting the real 3 minutes).
+// The whole continuity design rests on this: a state propagated to now+propagationEpochLead must
+// still clear the consumer's epochSkewMargin when the NEXT scheduled reconcile lands one
+// propagationRefreshInterval later. Without it, someone could shorten the lead (or lengthen the
+// cadence) and silently reintroduce the outage this PR fixes.
+func TestCadenceInvariant_EpochOutlivesTheReconcileGap(t *testing.T) {
+	const headroom = 60 * time.Second // deliberate slack for delivery + reconcile latency
+	if propagationRefreshInterval+epochSkewMargin+headroom > propagationEpochLead {
+		t.Fatalf("cadence invariant violated: propagationRefreshInterval(%s) + epochSkewMargin(%s) + "+
+			"headroom(%s) must be <= propagationEpochLead(%s), or a pushed epoch expires before the "+
+			"next scheduled re-propagation",
+			propagationRefreshInterval, epochSkewMargin, headroom, propagationEpochLead)
 	}
 }
 

--- a/internal/controller/ephemeris_continuity_test.go
+++ b/internal/controller/ephemeris_continuity_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// ephForContinuity builds a SatelliteEphemeris whose refresh window has already elapsed
+// against the seeded cache, so the next reconcile genuinely attempts an upstream fetch.
+func ephForContinuity(t *testing.T, name string) (*SatelliteEphemerisReconciler, client.Client, types.NamespacedName, *mockGPFetcher) {
+	t.Helper()
+	sch := makeScheme(t)
+	const ns = "default"
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: name, Namespace: ns}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	fetcher := &mockGPFetcher{}
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50), Fetcher: fetcher,
+	}
+	// Cache older than the 4h window → a fetch is due on the very first reconcile.
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now().Add(-5 * time.Hour),
+		},
+		fetchKey: fetchInputKey(got.Spec),
+		uid:      got.UID,
+	})
+	return r, cli, key, fetcher
+}
+
+// assertSustainedOutageKeepsPropagating is the property the whole I-18 "serve cache preserves
+// SIB19 continuity" claim rests on, and which NOTHING tested before: across a SUSTAINED
+// upstream outage the controller must
+//
+//	(a) contact the source only ONCE (the retry backoff must hold), while
+//	(b) STILL re-propagating on every reconcile so the pushed epoch never expires, and
+//	(c) requeueing on the 3-minute propagation cadence, not the 2–24h fetch backoff.
+//
+// The old code used the fetch backoff AS the reconcile cadence, so it re-propagated once to
+// now+5m and then slept for hours — the epoch expired ~5 minutes in and the consumer refused
+// the state for the rest of the outage. Continuity was ~4% (5min / 2h), not 100%.
+func assertSustainedOutageKeepsPropagating(t *testing.T, fetchErr error) {
+	t.Helper()
+	ctx := context.Background()
+	r, cli, key, fetcher := ephForContinuity(t, "eph-outage")
+	fetcher.err = fetchErr // upstream is DOWN for the whole test
+
+	var lastEpoch int64
+	for cycle := 1; cycle <= 3; cycle++ {
+		// Let the wall clock advance a little between cycles, so a re-propagated epoch is
+		// measurably NEWER than the previous one. Without this the three reconciles land in
+		// the same millisecond and "did the epoch advance?" cannot distinguish a fresh
+		// re-propagation from a frozen one.
+		if cycle > 1 {
+			time.Sleep(2 * time.Millisecond)
+		}
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		if err != nil {
+			t.Fatalf("cycle %d: a serve-cache reconcile must not return an error (it would "+
+				"override RequeueAfter with workqueue backoff): %v", cycle, err)
+		}
+		// (c) requeue on the PROPAGATION cadence, so the next cycle comes before the epoch dies.
+		if res.RequeueAfter != propagationRefreshInterval {
+			t.Fatalf("cycle %d: requeue must be the propagation cadence %s (the fetch is held back "+
+				"separately); got %s — the epoch would expire before the next reconcile",
+				cycle, propagationRefreshInterval, res.RequeueAfter)
+		}
+		// (a) the source must be contacted only on the FIRST cycle; the backoff holds after.
+		if fetcher.calls != 1 {
+			t.Fatalf("cycle %d: upstream must be contacted exactly once during the backoff "+
+				"(politeness), got %d calls", cycle, fetcher.calls)
+		}
+		// (b) states must be re-propagated to a FRESH epoch every cycle.
+		got := &ntnv1alpha1.SatelliteEphemeris{}
+		if err := cli.Get(ctx, key, got); err != nil {
+			t.Fatalf("cycle %d: get: %v", cycle, err)
+		}
+		if len(got.Status.PropagatedStates) == 0 {
+			t.Fatalf("cycle %d: SIB19 continuity lost — no propagated states while serving cache", cycle)
+		}
+		epoch := got.Status.PropagatedStates[0].EpochUnixMs
+		if epoch <= time.Now().UnixMilli() {
+			t.Fatalf("cycle %d: propagated epoch %d is already in the past — the consumer will refuse it", cycle, epoch)
+		}
+		if cycle > 1 && epoch <= lastEpoch {
+			t.Fatalf("cycle %d: epoch did not advance (%d <= %d) — the cache is not being re-propagated",
+				cycle, epoch, lastEpoch)
+		}
+		lastEpoch = epoch
+	}
+}
+
+// TestReconcile_RateLimitedServingCache_KeepsPropagating — RateLimited backs the fetch off to
+// >= effectiveInterval (>= 2h). Propagation must continue regardless.
+func TestReconcile_RateLimitedServingCache_KeepsPropagating(t *testing.T) {
+	assertSustainedOutageKeepsPropagating(t, ephemeris.ErrRateLimited)
+}
+
+// TestReconcile_AuthFailedServingCache_KeepsPropagating — AuthFailed backs the fetch off to
+// effectiveInterval (>= 2h). Propagation must continue regardless.
+func TestReconcile_AuthFailedServingCache_KeepsPropagating(t *testing.T) {
+	assertSustainedOutageKeepsPropagating(t, ephemeris.ErrAuthFailed)
+}
+
+// TestReconcile_GenericFailureServingCache_KeepsPropagating — a generic transient error used to
+// be RETURNED so the workqueue applied exponential backoff (ramping to ~1000s, far past the
+// 5-minute epoch lead). It must now also keep the propagation heartbeat.
+func TestReconcile_GenericFailureServingCache_KeepsPropagating(t *testing.T) {
+	assertSustainedOutageKeepsPropagating(t, errors.New("connection refused"))
+}
+
+// TestFetchRetryDelay_NeverStarvesPropagation pins the invariant that makes the above safe:
+// the FETCH backoff may be long (that is the point — politeness), but it is applied to the
+// FETCH, never to the reconcile. Here we just pin that each error class produces the intended
+// fetch delay, so a future edit cannot quietly turn it back into the reconcile cadence.
+func TestFetchRetryDelay_PerErrorClass(t *testing.T) {
+	const interval = 4 * time.Hour
+	if got := fetchRetryDelay(ephemeris.ErrRateLimited, interval, 1); got < interval {
+		t.Errorf("rate-limited fetch delay must be at least the refresh interval, got %s", got)
+	}
+	if got := fetchRetryDelay(ephemeris.ErrAuthFailed, interval, 1); got != interval {
+		t.Errorf("auth-failed fetch delay = %s, want %s", got, interval)
+	}
+	// Transient ramps 1m, 2m, 4m … and is capped at the interval.
+	if got := fetchRetryDelay(errors.New("boom"), interval, 1); got != time.Minute {
+		t.Errorf("first transient fetch delay = %s, want 1m", got)
+	}
+	if got := fetchRetryDelay(errors.New("boom"), interval, 3); got != 4*time.Minute {
+		t.Errorf("third transient fetch delay = %s, want 4m", got)
+	}
+	if got := fetchRetryDelay(errors.New("boom"), interval, 50); got != interval {
+		t.Errorf("transient fetch delay must cap at the refresh interval, got %s", got)
+	}
+}
+
+// TestReconcile_ValidCache_MissingCredentialSecret_StillRepropagates: a reconcile the cache can
+// answer must not need the source Secret at all. The fetcher is left unconfigured so
+// fetcherForSource would ERROR if it ran — standing in for a Secret that is missing, briefly
+// unreadable, or mid-rotation. Continuity must survive it.
+func TestReconcile_ValidCache_MissingCredentialSecret_StillRepropagates(t *testing.T) {
+	ctx := context.Background()
+	r, cli, key, _ := ephForContinuity(t, "eph-nocred")
+	r.Fetcher = nil // fetcherForSource would fail: "CelesTrak fetcher is not configured"
+	// Make the cache answerable WITHOUT a fetch by putting it inside the refresh window.
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	r.ommCache.Store(client.ObjectKeyFromObject(got), cachedFetch{
+		result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{issOMMForTest()}, SatelliteCount: 1, FetchedAt: time.Now(), // FRESH
+		},
+		fetchKey: fetchInputKey(got.Spec),
+		uid:      got.UID,
+	})
+
+	if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("a cache-answerable reconcile must not need credentials: %v", err)
+	}
+	after := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, after); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if cond := meta.FindStatusCondition(after.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched); cond != nil && cond.Reason == "FetcherSetupFailed" {
+		t.Fatal("credential/fetcher setup must be SKIPPED when the cache can answer, but got FetcherSetupFailed")
+	}
+	if len(after.Status.PropagatedStates) == 0 {
+		t.Error("a cache-answerable reconcile must still re-propagate (SIB19 continuity)")
+	}
+}
+
+// TestPushRuntime_SourceEpoch1970_IsStaleNotBypassed pins the sentinel-collision fix: 0 is a
+// LEGAL Unix ms (1970-01-01T00:00:00Z), not just "unparseable". The consumer used to fail OPEN
+// on 0 ("unknown → allow"), so a 1970-dated element set bypassed the entire 7-day freshness
+// gate. It must now simply be — correctly — stale.
+// Mutation: restore `if state.SourceEpochUnixMs != 0 {` around the check and this pushes.
+func TestPushRuntime_SourceEpoch1970_IsStaleNotBypassed(t *testing.T) {
+	ctx := context.Background()
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	eph.Status.PropagatedStates[0].SourceEpochUnixMs = 0 // 1970-01-01T00:00:00Z — 56 years stale
+	c := fake.NewClientBuilder().WithScheme(makeScheme(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(ctx, cc, &cc.Spec, mock)
+	if pushed || mock.RuntimeCalls != 0 {
+		t.Fatalf("a 1970 source epoch must be treated as STALE, not as 'unknown → allowed': pushed=%v calls=%d",
+			pushed, mock.RuntimeCalls)
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonEphemerisStale {
+		t.Fatalf("reason = %q, want %q", got, ephemerisReasonEphemerisStale)
+	}
+}
+
+// TestPropagateStates_UnparseableEpoch_ProducesNoState: the producer must not emit a state with
+// SourceEpochUnixMs = 0 for an epoch it could not parse — that is what made 0 ambiguous. (SGP4's
+// own ToTLE parses the same epoch, so such an element set fails propagation anyway.)
+func TestPropagateStates_UnparseableEpoch_ProducesNoState(t *testing.T) {
+	r := &SatelliteEphemerisReconciler{}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-badepoch", Namespace: "default"},
+	}
+	bad := issOMMForTest()
+	bad.EpochStr = "not-a-timestamp"
+	r.propagateStates(context.Background(), eph,
+		ephemeris.GPFetchResult{OMMs: []sgp4.OMM{bad}}, time.Now().Add(propagationEpochLead))
+
+	if n := len(eph.Status.PropagatedStates); n != 0 {
+		t.Fatalf("an unparseable source epoch must produce NO state (never a 0 sentinel), got %d", n)
+	}
+	if cond := meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionSourceEpochRejected); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatal("a refused element set must be surfaced durably via SourceEpochRejected=True, not only a log line")
+	}
+}
+
+// TestSourceEpochPlausible_ProducerAndConsumerAgree pins the shared-layer invariant: the
+// producer used to compare the future bound against the propagation TARGET epoch (now + 5m)
+// while the consumer compared against now, so a source epoch inside that 5-minute band was
+// propagated and hash-stamped yet permanently refused at the push. Both now use the same rule
+// against their own `now`, so there is exactly ONE boundary.
+func TestSourceEpochPlausible_ProducerAndConsumerAgree(t *testing.T) {
+	now := time.Now()
+	justInside := now.Add(maxSourceEpochFutureSkew - time.Millisecond)
+	exactly := now.Add(maxSourceEpochFutureSkew)
+	justOutside := now.Add(maxSourceEpochFutureSkew + time.Millisecond)
+
+	if err := sourceEpochPlausible(now, justInside); err != nil {
+		t.Errorf("epoch just inside the skew bound must be allowed: %v", err)
+	}
+	if err := sourceEpochPlausible(now, exactly); err != nil {
+		t.Errorf("epoch exactly at the skew bound must be allowed (strict After): %v", err)
+	}
+	if err := sourceEpochPlausible(now, justOutside); err == nil {
+		t.Error("epoch just past the skew bound must be rejected")
+	}
+	// The old 5-minute disagreement band: an epoch in (now+skew, now+skew+lead] must now be
+	// rejected by BOTH sides, not accepted by the producer and refused by the consumer.
+	band := now.Add(maxSourceEpochFutureSkew + propagationEpochLead/2)
+	if err := sourceEpochPlausible(now, band); err == nil {
+		t.Error("an epoch in the old producer/consumer disagreement band must be rejected by the shared rule")
+	}
+}
+
+// TestPropagationInputHash_DedupesNoradIDs: FilterOMMs applies the selector through a map, so
+// [25544] and [25544, 25544] select the same satellites and produce byte-identical output —
+// they must hash the same, or a duplicate ID triggers a needless EphemerisInputsStale +
+// re-propagation + runtime re-push.
+func TestPropagationInputHash_DedupesNoradIDs(t *testing.T) {
+	base := ntnv1alpha1.SatelliteEphemerisSpec{
+		Source:     ntnv1alpha1.EphemerisSource{Type: "CelesTrak", URL: "https://celestrak.org/x"},
+		Satellites: &ntnv1alpha1.SatelliteSelector{NoradIDs: []int{25544, 200}},
+	}
+	dup := *base.DeepCopy()
+	dup.Satellites.NoradIDs = []int{200, 25544, 25544, 200}
+	if propagationInputHash(base) != propagationInputHash(dup) {
+		t.Fatal("duplicate NORAD IDs select the same satellites and must hash identically")
+	}
+}

--- a/internal/controller/ephemeris_freshness.go
+++ b/internal/controller/ephemeris_freshness.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+)
+
+// SHARED LAYER for source-element-set (OMM EPOCH) validity.
+//
+// The SatelliteEphemeris producer and the NTNCellConfig runtime-push consumer each used to
+// carry their own copy of these bounds and their own comparison — and they had silently
+// drifted: the producer compared the future bound against the PROPAGATION TARGET epoch
+// (now + propagationEpochLead) while the consumer compared against time.Now(). A source epoch
+// inside that 5-minute band was therefore propagated and hash-stamped by the producer yet
+// permanently refused by the consumer: a state that could never be delivered. Both sides now
+// call the SAME function with their own "now", so the rule is single-sourced.
+//
+// There are deliberately TWO rules, because the two sides need different ones:
+//
+//   - PLAUSIBILITY (sourceEpochPlausible) — is this element set CORRUPT? Enforced by BOTH.
+//     The producer must refuse to propagate from it (SGP4 would be driven backward from a
+//     bogus epoch and write a wildly wrong ECEF into status — refusing only at the push
+//     stops delivery, not the propagation). The consumer re-checks as defense in depth.
+//
+//   - FRESHNESS (sourceEpochFresh) — is this element set too OLD to deliver? Enforced by the
+//     CONSUMER only. A stale-but-valid element set still propagates meaningfully (SGP4 just
+//     accumulates in-track error), so the producer deliberately still emits the state and
+//     merely COUNTS it (the EphemerisEpochStale condition, I-17) — that keeps a drifting feed
+//     observable. The delivery gate is the consumer's job (#200-C4).
+//
+// Applying freshness at the producer instead would collapse a precise "EphemerisStale"
+// diagnosis into a bare "EphemerisPayloadMissing" and silently drop satellites the operator
+// is still tracking.
+
+// maxEpochAge bounds how old a fetched element set's OWN epoch may be before its SGP4
+// propagation is unreliable (findings.md I-17). Independent of the refresh cadence — a
+// source can serve elements whose epoch is already stale. ~7 days keeps LEO in-track error
+// to at most a few km.
+const maxEpochAge = 7 * 24 * time.Hour
+
+// maxSourceEpochFutureSkew bounds how far into the future a source element-set epoch may be
+// before it is implausible (a corrupt or spoofed feed). Real OMM/TLE epochs are at or before
+// "now"; a far-future epoch would otherwise sail past the "older than maxEpochAge" check,
+// which only catches the PAST direction. Generous, so legitimate near-present epochs are
+// never rejected.
+const maxSourceEpochFutureSkew = 24 * time.Hour
+
+// sourceEpochPlausible reports whether a source element-set epoch could plausibly have come
+// from a real feed, evaluated at time now. Enforced on BOTH the producer (before SGP4) and
+// the consumer (before push) — see the file comment.
+func sourceEpochPlausible(now, src time.Time) error {
+	if src.After(now.Add(maxSourceEpochFutureSkew)) {
+		return fmt.Errorf("source element epoch %s is implausibly future-dated (more than %s ahead of %s)",
+			src.UTC().Format(time.RFC3339), maxSourceEpochFutureSkew, now.UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+// sourceEpochFresh reports whether a source element-set epoch is fresh enough to DELIVER to
+// the gNB, evaluated at time now. Enforced by the consumer only — see the file comment.
+//
+// NOTE ON THE ZERO VALUE: PropagatedState.SourceEpochUnixMs is a plain int64, so 0 would be
+// an ambiguous sentinel — it means BOTH "unparseable" and the perfectly legal instant
+// 1970-01-01T00:00:00Z. The consumer used to fail OPEN on 0 ("unknown, allow it"), which let
+// a 1970 epoch bypass the entire freshness gate. There is no escape hatch any more: the
+// producer never emits a state whose epoch it could not parse (and SGP4's own OMM.ToTLE
+// parses the same epoch, so such an element set fails propagation anyway), so a 0 can only be
+// a genuine 1970 epoch — which this rule then correctly reports as stale.
+func sourceEpochFresh(now, src time.Time) error {
+	if age := now.Sub(src); age > maxEpochAge {
+		return fmt.Errorf("source element epoch %s is %s old, beyond the %s freshness bound (drifting)",
+			src.UTC().Format(time.RFC3339), age.Round(time.Second), maxEpochAge)
+	}
+	return nil
+}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -88,18 +88,9 @@ const (
 // producer's refresh) rather than pushed and rejected in a tight loop.
 const epochSkewMargin = 10 * time.Second
 
-// maxSourceEpochFutureSkew bounds how far into the future a SOURCE element-set epoch may
-// be before it is treated as implausible (a corrupt or spoofed feed). Real OMM/TLE epochs
-// are at or before "now"; a far-future epoch would otherwise sail past the "older than
-// maxEpochAge" check, which only catches the PAST direction.
-//
-// It is enforced in TWO places, deliberately: the producer refuses to PROPAGATE from such
-// an element set (propagateStates — SGP4 would be driven backward from the bogus epoch,
-// writing a wildly wrong ECEF into status), and the consumer refuses to PUSH one if it
-// ever reaches status anyway (defense in depth). The consumer check alone cannot prevent
-// the backward propagation, only its delivery. Generous, so legitimate near-present epochs
-// are never rejected.
-const maxSourceEpochFutureSkew = 24 * time.Hour
+// The source-epoch bounds (maxEpochAge, maxSourceEpochFutureSkew) and the sourceEpochUsable
+// rule that applies them live in the shared layer (ephemeris_freshness.go), so this consumer
+// and the SatelliteEphemeris producer apply the IDENTICAL rule to their own "now".
 
 type ephemerisPushError struct {
 	reason string
@@ -645,29 +636,30 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 				eph.Name, state.EpochUnixMs),
 		)
 	}
-	// Hard-stale, per-satellite (#200-C4; #221 review finding 1): refuse to push the
-	// SELECTED satellite when its OWN source element-set epoch is beyond the freshness
-	// bound (drifting) or implausibly future-dated. Per-satellite, so a stale, cap-omitted,
-	// or unselected sibling in the same SatelliteEphemeris does NOT block this cell. A 0
-	// source epoch means the producer could not parse it (unknown, not stale) — allowed,
-	// matching the producer's stale-count which also skips unparseable epochs.
-	if state.SourceEpochUnixMs != 0 {
-		src := time.UnixMilli(state.SourceEpochUnixMs)
-		nowT := time.Now()
-		if nowT.Sub(src) > maxEpochAge {
-			return false, marker, newEphemerisPushError(
-				ephemerisReasonEphemerisStale,
-				fmt.Errorf("selected satellite %d source element epoch is older than %s (drifting); awaiting SatelliteEphemeris refresh",
-					state.NoradID, maxEpochAge),
-			)
-		}
-		if src.After(nowT.Add(maxSourceEpochFutureSkew)) {
-			return false, marker, newEphemerisPushError(
-				ephemerisReasonEphemerisStale,
-				fmt.Errorf("selected satellite %d source element epoch %s is implausibly future-dated; refusing",
-					state.NoradID, src.UTC()),
-			)
-		}
+	// Hard-stale, per-satellite (#200-C4): refuse to push the SELECTED satellite when its
+	// OWN source element-set epoch is beyond the freshness bound (drifting) or implausibly
+	// future-dated. Per-satellite, so a stale, cap-omitted, or unselected sibling in the
+	// same SatelliteEphemeris does NOT block this cell.
+	//
+	// Validated UNCONDITIONALLY — there is no "0 means unknown, allow it" escape any more.
+	// SourceEpochUnixMs is a plain int64, so 0 is an ambiguous sentinel: it means both
+	// "unparseable" AND the legal instant 1970-01-01T00:00:00Z, and the old fail-open let a
+	// 1970 epoch bypass the entire freshness gate. The producer no longer emits a state whose
+	// epoch it could not parse, so 0 can only be a genuine 1970 epoch — which is simply, and
+	// correctly, stale. Same rule, same bounds as the producer (shared layer).
+	nowT := time.Now()
+	src := time.UnixMilli(state.SourceEpochUnixMs)
+	if err := sourceEpochPlausible(nowT, src); err != nil {
+		return false, marker, newEphemerisPushError(
+			ephemerisReasonEphemerisStale,
+			fmt.Errorf("selected satellite %d: %w; refusing", state.NoradID, err),
+		)
+	}
+	if err := sourceEpochFresh(nowT, src); err != nil {
+		return false, marker, newEphemerisPushError(
+			ephemerisReasonEphemerisStale,
+			fmt.Errorf("selected satellite %d: %w; awaiting SatelliteEphemeris refresh", state.NoradID, err),
+		)
 	}
 
 	// Dedup on the propagated epoch (I-12): re-push whenever the SatelliteEphemeris

--- a/internal/controller/satelliteephemeris_cachefallback_test.go
+++ b/internal/controller/satelliteephemeris_cachefallback_test.go
@@ -87,10 +87,19 @@ func TestReconcile_FetchError_ServesCache(t *testing.T) {
 		uid:      got.UID,
 	})
 
-	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
-	// Generic transient error → returned so the workqueue applies exponential backoff.
-	if err == nil {
-		t.Fatal("a generic fetch error must be returned for workqueue backoff, got nil")
+	res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	// The serve-cache cycle must NOT return an error: returning one makes controller-runtime
+	// IGNORE RequeueAfter and fall back to the workqueue's exponential backoff, which ramps
+	// to ~1000s — far beyond the 5-minute propagationEpochLead, so the pushed epoch would
+	// expire between reconciles and SIB19 would go stale mid-outage. The fetch is instead
+	// held back internally (cachedFetch.nextFetchAttempt) while the reconcile keeps running
+	// on the propagation cadence.
+	if err != nil {
+		t.Fatalf("a serve-cache cycle must not return an error (it would override RequeueAfter with workqueue backoff): %v", err)
+	}
+	if res.RequeueAfter != propagationRefreshInterval {
+		t.Fatalf("a serve-cache cycle must requeue on the PROPAGATION cadence (%s) so the pushed epoch stays alive, got %s",
+			propagationRefreshInterval, res.RequeueAfter)
 	}
 
 	updated := &ntnv1alpha1.SatelliteEphemeris{}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -196,44 +196,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Consulted BEFORE fetcher/credential setup: a reconcile the cache can answer must not
 	// read the source Secret, so a transient Secret failure (or a credential rotation) cannot
 	// break SIB19 continuity.
-	var outcome ommFetchOutcome
-	var earlyResult *ctrl.Result
-	var earlyErr error
-	if c, why := r.cacheServe(req.NamespacedName, eph, now, effectiveInterval); why != cacheServeNone {
-		switch why {
-		case cacheServeWindow:
-			log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
-				"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
-			outcome = ommFetchOutcome{result: c.result, reusedCache: true}
-		case cacheServeBackoff:
-			log.V(1).Info("re-propagating from cached OMMs; upstream fetch suppressed by retry backoff",
-				"cacheAge", now.Sub(c.result.FetchedAt).String(),
-				"nextFetchAttempt", c.nextFetchAttempt.UTC().String(), "lastErr", c.lastFetchErr.Error())
-			outcome = ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: c.lastFetchErr}
-		case cacheServeNone:
-		}
-	} else {
-		// Step 3b: a real fetch is due → select the fetcher (loads credentials) and fetch.
-		fetcher, fetcherErr := r.fetcherForSource(ctx, eph)
-		if fetcherErr != nil {
-			meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
-				Type:               ntnv1alpha1.ConditionGPDataFetched,
-				Status:             metav1.ConditionFalse,
-				Reason:             "FetcherSetupFailed",
-				Message:            fetcherErr.Error(),
-				ObservedGeneration: eph.Generation,
-			})
-			// No usable GP data this cycle → readiness 0. Holds across a persistent
-			// setup failure so `gp_fetch_ready == 0` alerts even on a never-fetched cold
-			// start, where `gp_satellite_count == 0` cannot (absent series).
-			ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
-			if err := r.Status().Update(ctx, eph); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
-		}
-		outcome, earlyResult, earlyErr = r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
-	}
+	outcome, earlyResult, earlyErr := r.acquireOMMs(ctx, req, eph, effectiveInterval, now)
 	if earlyResult != nil {
 		// obtainOMMs only early-returns on no-usable-data outcomes: a refused insecure
 		// URL, or a fetch error with no cache to fall back on. Readiness 0 either way
@@ -244,6 +207,10 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	result := outcome.result
 	reusedCache := outcome.reusedCache
 	servedCacheOnError := outcome.servedCacheOnError
+	serveReason := outcome.serveReason
+	if serveReason == "" {
+		serveReason = reasonFetchFailedServingCache
+	}
 	cacheServeErr := outcome.cacheServeErr
 
 	// Step 6: Update status with new data.
@@ -270,7 +237,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// re-propagation that keeps serving the same stale cache.
 	serveCacheEpisode := servedCacheOnError && conditionEpisodeChanged(
 		meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionGPDataFetched),
-		metav1.ConditionFalse, "FetchFailedServingCache", eph.Generation)
+		metav1.ConditionFalse, serveReason, eph.Generation)
 
 	switch {
 	case servedCacheOnError:
@@ -278,7 +245,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:   ntnv1alpha1.ConditionGPDataFetched,
 			Status: metav1.ConditionFalse,
-			Reason: "FetchFailedServingCache",
+			Reason: serveReason,
 			Message: fmt.Sprintf("GP fetch failed (%s); serving %d satellites from cached OMMs — pass windows and runtime push preserved",
 				cacheServeErr.Error(), result.SatelliteCount),
 			ObservedGeneration: eph.Generation,
@@ -430,7 +397,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	switch {
 	case servedCacheOnError:
 		if serveCacheEpisode && r.Recorder != nil {
-			r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, "FetchFailedServingCache", "FetchFailedServingCache",
+			r.Recorder.Eventf(eph, nil, corev1.EventTypeWarning, serveReason, serveReason,
 				"GP fetch failed (%s); serving %d satellites from cached OMMs", cacheServeErr.Error(), result.SatelliteCount)
 		}
 	case !reusedCache:
@@ -508,7 +475,18 @@ type cachedFetch struct {
 	lastFetchErr error
 	// fetchFailures counts consecutive failures, for the transient-error backoff ramp.
 	fetchFailures int
+	// retryKey pins the backoff to the credential/interval inputs it was built from. The
+	// payload key (fetchKey) deliberately ignores those, so without this an operator who fixed
+	// the credentials would still be suppressed by the old backoff. See retryInputKey.
+	retryKey string
 }
+
+// maxAuthRetryBackoff bounds how long an auth failure suppresses the next login attempt. The
+// operator normally fixes credentials IN PLACE (same Secret name), which changes neither the
+// spec nor retryInputKey, so nothing would otherwise clear the backoff — and we do not watch
+// Secrets (that would need list/watch RBAC; the operator deliberately holds only secrets/get).
+// A bounded re-probe recovers within minutes while staying far below any rate budget.
+const maxAuthRetryBackoff = 15 * time.Minute
 
 // fetchRetryDelay is how long to suppress the next UPSTREAM fetch after a failure. It is the
 // FETCH cadence only — the reconcile keeps running on the propagation heartbeat regardless,
@@ -519,8 +497,13 @@ func fetchRetryDelay(fetchErr error, effectiveInterval time.Duration, failures i
 		// Honor the source's policy (and any Retry-After); never faster than the refresh floor.
 		return max(effectiveInterval, retryAfterFrom(fetchErr))
 	case errors.Is(fetchErr, ephemeris.ErrAuthFailed):
-		// Bad credentials will not fix themselves; hammering the login endpoint risks a lockout.
-		return effectiveInterval
+		// Bad credentials will not fix themselves, and hammering the login endpoint risks a
+		// lockout — but the refresh interval (up to 24h) is far too long to wait for RECOVERY
+		// once an operator fixes the Secret IN PLACE (same Secret name → no spec change → no
+		// retryKey change → the backoff would otherwise hold). Cap it: a few probes an hour is
+		// nowhere near Space-Track's ~30/min budget, and it bounds recovery to minutes. A
+		// credential-REFERENCE edit still clears the backoff immediately via retryKey.
+		return min(effectiveInterval, maxAuthRetryBackoff)
 	default:
 		// Transient (network/5xx): ramp 1m, 2m, 4m … capped at the refresh interval. Bounded
 		// exponent so the shift cannot overflow.
@@ -547,17 +530,132 @@ const (
 func (r *SatelliteEphemerisReconciler) cacheServe(
 	key client.ObjectKey, eph *ntnv1alpha1.SatelliteEphemeris, now time.Time, effectiveInterval time.Duration,
 ) (cachedFetch, cacheServeReason) {
-	c, ok := r.cachedOMMResult(key)
-	if !ok || c.fetchKey != fetchInputKey(eph.Spec) || c.uid != eph.UID {
+	c, ok := r.matchingCache(key, eph)
+	if !ok {
 		return cachedFetch{}, cacheServeNone
 	}
 	if now.Sub(c.result.FetchedAt) < effectiveInterval {
 		return c, cacheServeWindow
 	}
-	if now.Before(c.nextFetchAttempt) {
+	// Honor an armed fetch backoff — but ONLY while the retry inputs are unchanged. The
+	// payload cache key deliberately excludes credentials and the refresh interval (the same
+	// URL returns the same GP data whichever account fetched it), so without this an operator
+	// who FIXES the credentials, or lowers refreshInterval, would still be held down by the
+	// old 2–24h backoff: cacheServe would answer from cache and never even build the fetcher.
+	// A change to the retry inputs invalidates the backoff and lets the next fetch through.
+	if now.Before(c.nextFetchAttempt) && c.retryKey == retryInputKey(eph.Spec, effectiveInterval) {
 		return c, cacheServeBackoff
 	}
 	return cachedFetch{}, cacheServeNone
+}
+
+// acquireOMMs is the whole "where do this reconcile's OMMs come from" state machine, in one
+// place. Order matters, and it is the order that keeps SIB19 alive:
+//
+//  1. Cache can answer (inside the refresh window, or inside a failed fetch's retry backoff) →
+//     serve it WITHOUT contacting the source and WITHOUT reading the credential Secret.
+//  2. Otherwise a real fetch is due → build the fetcher (this is what reads the Secret).
+//     2a. Setup fails (Secret missing / unreadable / mid-rotation / wrong key) → fall back to a
+//     matching cache of ANY AGE. The raw OMMs do not depend on the credentials
+//     (fetchInputKey excludes them), so a Secret problem must not stop re-propagation. The
+//     refresh window governs whether to FETCH, not whether the payload is still propagatable.
+//     2b. Only a COLD cache (nothing to propagate) hard-fails.
+//  3. Fetcher built → obtainOMMs fetches, and on failure falls back to cache and arms the
+//     fetch backoff.
+//
+// Every path that yields usable OMMs returns a normal outcome, so the caller re-propagates and
+// requeues on the propagation heartbeat. earlyResult is non-nil only when there is nothing to
+// propagate at all.
+func (r *SatelliteEphemerisReconciler) acquireOMMs(
+	ctx context.Context, req ctrl.Request, eph *ntnv1alpha1.SatelliteEphemeris,
+	effectiveInterval time.Duration, now time.Time,
+) (ommFetchOutcome, *ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	switch c, why := r.cacheServe(req.NamespacedName, eph, now, effectiveInterval); why {
+	case cacheServeWindow:
+		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
+			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
+		return ommFetchOutcome{result: c.result, reusedCache: true}, nil, nil
+	case cacheServeBackoff:
+		log.V(1).Info("re-propagating from cached OMMs; upstream fetch suppressed by retry backoff",
+			"cacheAge", now.Sub(c.result.FetchedAt).String(),
+			"nextFetchAttempt", c.nextFetchAttempt.UTC().String(), "lastErr", c.lastFetchErr.Error())
+		// Only a FETCH failure ever arms nextFetchAttempt (a setup failure is retried every
+		// cycle — it is a cheap local Secret read, not an upstream call), so a backoff-serve is
+		// always replaying a fetch failure.
+		return ommFetchOutcome{
+			result: c.result, servedCacheOnError: true,
+			cacheServeErr: c.lastFetchErr, serveReason: reasonFetchFailedServingCache,
+		}, nil, nil
+	case cacheServeNone:
+	}
+
+	fetcher, fetcherErr := r.fetcherForSource(ctx, eph)
+	if fetcherErr == nil {
+		return r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
+	}
+
+	// 2a: setup failed but the cached payload is still propagatable.
+	if c, ok := r.matchingCache(req.NamespacedName, eph); ok {
+		log.Info("fetcher/credential setup failed; serving cached OMMs for SIB19 continuity",
+			"err", fetcherErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String())
+		return ommFetchOutcome{
+			result: c.result, servedCacheOnError: true,
+			cacheServeErr: fetcherErr, serveReason: reasonSetupFailedServingCache,
+		}, nil, nil
+	}
+
+	// 2b: cold cache — nothing to keep alive.
+	res, err := r.handleSetupFailure(ctx, eph, fetcherErr)
+	return ommFetchOutcome{}, &res, err
+}
+
+// handleSetupFailure is the cold-cache fetcher/credential failure path: no OMMs at all.
+func (r *SatelliteEphemerisReconciler) handleSetupFailure(
+	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, fetcherErr error,
+) (ctrl.Result, error) {
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type:               ntnv1alpha1.ConditionGPDataFetched,
+		Status:             metav1.ConditionFalse,
+		Reason:             "FetcherSetupFailed",
+		Message:            fetcherErr.Error(),
+		ObservedGeneration: eph.Generation,
+	})
+	// No usable GP data this cycle → readiness 0. Holds across a persistent setup failure so
+	// `gp_fetch_ready == 0` alerts even on a never-fetched cold start, where
+	// `gp_satellite_count == 0` cannot (absent series).
+	ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
+	if err := r.Status().Update(ctx, eph); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
+}
+
+// matchingCache returns the cache entry whose raw upstream payload belongs to THIS object and
+// THIS source, regardless of age. Used both for the age-aware cacheServe decision and for the
+// any-age fallback after a fetch or fetcher-SETUP failure.
+func (r *SatelliteEphemerisReconciler) matchingCache(
+	key client.ObjectKey, eph *ntnv1alpha1.SatelliteEphemeris,
+) (cachedFetch, bool) {
+	c, ok := r.cachedOMMResult(key)
+	if !ok || c.fetchKey != fetchInputKey(eph.Spec) || c.uid != eph.UID {
+		return cachedFetch{}, false
+	}
+	return c, true
+}
+
+// retryInputKey identifies the inputs that a FETCH RETRY decision depends on — the credential
+// reference and the effective refresh interval — as opposed to fetchInputKey, which identifies
+// the raw PAYLOAD (source type + url). Keeping them separate is what lets a cached payload stay
+// reusable across a credential change while the stale backoff built from the OLD credentials is
+// discarded.
+func retryInputKey(spec ntnv1alpha1.SatelliteEphemerisSpec, effectiveInterval time.Duration) string {
+	credName, credKey := "", ""
+	if spec.Source.Credentials != nil {
+		credName, credKey = spec.Source.Credentials.Name, spec.Source.Credentials.Key
+	}
+	return fmt.Sprintf("cred=%q/%q interval=%s", credName, credKey, effectiveInterval)
 }
 
 // fetchInputKey identifies WHAT RAW upstream payload a cached entry holds: the source type
@@ -680,7 +778,8 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 
 	states := make([]ntnv1alpha1.PropagatedState, 0, min(len(omms), maxPropagatedStates))
 	skippedByCap := 0
-	rejectedEpochs := 0 // element sets refused BEFORE SGP4: unparseable or implausibly future
+	unparseableEpochs := 0 // refused BEFORE SGP4: OMM EPOCH could not be parsed
+	futureEpochs := 0      // refused BEFORE SGP4: OMM EPOCH implausibly far in the future
 	for i := range omms {
 		if len(states) >= maxPropagatedStates {
 			// The cap is reached; the remaining OMMs are NOT attempted. This is the
@@ -707,7 +806,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		// same epoch, so an element set we cannot parse fails PropagateToECEF below anyway.
 		t, ok := parseOMMEpoch(omms[i].EpochStr)
 		if !ok {
-			rejectedEpochs++
+			unparseableEpochs++
 			logf.FromContext(ctx).Info("skipping satellite: source element epoch is unparseable",
 				"norad", omms[i].NoradCatID, "epochStr", omms[i].EpochStr)
 			continue
@@ -717,7 +816,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		// observable; the consumer owns the delivery gate (#200-C4). Rejecting staleness here
 		// would collapse a precise "EphemerisStale" diagnosis into a bare "PayloadMissing".
 		if err := sourceEpochPlausible(now, t); err != nil {
-			rejectedEpochs++
+			futureEpochs++
 			logf.FromContext(ctx).Info("skipping satellite: implausible source element epoch",
 				"norad", omms[i].NoradCatID, "sourceEpoch", t.UTC(), "err", err.Error())
 			continue
@@ -745,7 +844,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	eph.Status.PropagatedStates = states
 	truncEvent := r.reportStatesTruncated(eph, len(omms), skippedByCap)
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
-	r.reportSourceEpochRejected(eph, rejectedEpochs, len(omms))
+	r.reportSourceEpochRejected(eph, unparseableEpochs, futureEpochs, len(omms))
 	return truncEvent
 }
 
@@ -756,7 +855,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 // rejection or a NORAD typo (the deep-space case already gets a cross-CR hint; this one had
 // none — it only wrote a log line).
 func (r *SatelliteEphemerisReconciler) reportSourceEpochRejected(
-	eph *ntnv1alpha1.SatelliteEphemeris, rejected, total int,
+	eph *ntnv1alpha1.SatelliteEphemeris, unparseable, futureDated, total int,
 ) {
 	c := metav1.Condition{
 		Type:               ntnv1alpha1.ConditionSourceEpochRejected,
@@ -765,15 +864,32 @@ func (r *SatelliteEphemerisReconciler) reportSourceEpochRejected(
 		Message:            "Every tracked element set has a parseable, plausibly-dated epoch",
 		ObservedGeneration: eph.Generation,
 	}
-	if rejected > 0 {
+	// Distinct Reasons: "unparseable" and "implausibly future" are different corruptions and
+	// warrant different investigation, so an alert/automation must be able to tell them apart.
+	switch {
+	case unparseable > 0 && futureDated > 0:
 		c.Status = metav1.ConditionTrue
-		c.Reason = "ImplausibleSourceEpoch"
-		c.Message = fmt.Sprintf(
-			"%d of %d tracked element set(s) were REFUSED before propagation: the OMM EPOCH is unparseable "+
-				"or implausibly future-dated (more than %s ahead). They produce no propagated state, so a cell "+
-				"selecting one reports EphemerisPayloadMissing. Check the GP source for corrupt data.",
-			rejected, total, maxSourceEpochFutureSkew)
+		c.Reason = "SourceEpochRejected"
+		c.Message = fmt.Sprintf("%d of %d tracked element set(s) refused before propagation: %d with an "+
+			"unparseable OMM EPOCH, %d dated more than %s in the future.",
+			unparseable+futureDated, total, unparseable, futureDated, maxSourceEpochFutureSkew)
+	case unparseable > 0:
+		c.Status = metav1.ConditionTrue
+		c.Reason = "UnparseableSourceEpoch"
+		c.Message = fmt.Sprintf("%d of %d tracked element set(s) refused before propagation: the OMM EPOCH "+
+			"could not be parsed.", unparseable, total)
+	case futureDated > 0:
+		c.Status = metav1.ConditionTrue
+		c.Reason = "FutureDatedSourceEpoch"
+		c.Message = fmt.Sprintf("%d of %d tracked element set(s) refused before propagation: the OMM EPOCH is "+
+			"more than %s in the future (SGP4 would be driven backward from a bogus epoch).",
+			futureDated, total, maxSourceEpochFutureSkew)
+	default:
+		meta.SetStatusCondition(&eph.Status.Conditions, c)
+		return
 	}
+	c.Message += " They produce no propagated state, so a cell selecting one reports " +
+		"EphemerisPayloadMissing. Check the GP source for corrupt data."
 	meta.SetStatusCondition(&eph.Status.Conditions, c)
 }
 
@@ -1132,7 +1248,17 @@ type ommFetchOutcome struct {
 	reusedCache        bool
 	servedCacheOnError bool
 	cacheServeErr      error
+	// serveReason distinguishes WHY we are degraded onto cache. A failed upstream fetch and a
+	// failed fetcher/credential SETUP both keep SIB19 alive from cache, but they need
+	// different operator actions (check the source vs check the Secret), so they must not be
+	// collapsed into one reason.
+	serveReason string
 }
+
+const (
+	reasonFetchFailedServingCache = "FetchFailedServingCache"
+	reasonSetupFailedServingCache = "FetcherSetupFailedServingCache"
+)
 
 // obtainOMMs resolves the OMM data for this reconcile (Step 4b/5). It returns the
 // outcome plus an optional early Reconcile result: non-nil when the caller must
@@ -1179,13 +1305,17 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 			// outage. (Before this, the serve-cache cycle requeued at the 2–24h fetch backoff,
 			// so the epoch expired ~5 minutes in and SIB19 went stale for the rest of it.)
 			c.fetchFailures++
-			c.nextFetchAttempt = now.Add(fetchRetryDelay(fetchErr, effectiveInterval, c.fetchFailures))
+			// Measure the backoff from when the failure ACTUALLY happened, not from the `now`
+			// captured before the fetch: a 30s HTTP timeout (the client's timeout is exactly
+			// 30s) would otherwise eat 30s of the first 1-minute transient backoff.
+			c.nextFetchAttempt = time.Now().Add(fetchRetryDelay(fetchErr, effectiveInterval, c.fetchFailures))
 			c.lastFetchErr = fetchErr
+			c.retryKey = retryInputKey(eph.Spec, effectiveInterval)
 			r.ommCache.Store(req.NamespacedName, c)
 			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
 				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String(),
 				"nextFetchAttempt", c.nextFetchAttempt.UTC().String(), "consecutiveFailures", c.fetchFailures)
-			return ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: fetchErr}, nil, nil
+			return ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: fetchErr, serveReason: reasonFetchFailedServingCache}, nil, nil
 		}
 		// No cache to serve: nothing to keep fresh, so the fetch backoff IS the reconcile
 		// cadence here (the wipe path) — unchanged.

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -187,35 +187,53 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// ~1–3 km/day from the element epoch (findings.md I-17). metav1.Duration
 	// serialises as a string, so both bounds are enforced here rather than via CEL.
 	effectiveInterval := r.clampRefreshInterval(ctx, eph)
-
-	// Step 3: Select fetcher and load credentials if needed.
-	fetcher, fetcherErr := r.fetcherForSource(ctx, eph)
-	if fetcherErr != nil {
-		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
-			Type:               ntnv1alpha1.ConditionGPDataFetched,
-			Status:             metav1.ConditionFalse,
-			Reason:             "FetcherSetupFailed",
-			Message:            fetcherErr.Error(),
-			ObservedGeneration: eph.Generation,
-		})
-		// No usable GP data this cycle → readiness 0. Holds across a persistent
-		// setup failure so `gp_fetch_ready == 0` alerts even on a never-fetched cold
-		// start, where `gp_satellite_count == 0` cannot (absent series).
-		ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
-		if err := r.Status().Update(ctx, eph); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: time.Minute}, nil
-	}
-
-	// Step 4b: Obtain OMM data. Within the GP-refresh window, re-propagate from the
-	// cached OMMs of the last real fetch WITHOUT contacting the GP source — this is
-	// what keeps the runtime-push epoch fresh on a short cadence without re-hitting
-	// CelesTrak/SpaceTrack (their rate-limit etiquette is why the fetch is floored
-	// to effectiveInterval). Only fetch when the window has elapsed or the cache is
-	// cold (e.g. the first reconcile after a restart). (#179)
 	now := time.Now()
-	outcome, earlyResult, earlyErr := r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
+
+	// Step 3: Can this reconcile be answered from cache WITHOUT contacting the source?
+	//   (a) inside the GP-refresh window — normal (#179), or
+	//   (b) inside a failed fetch's retry backoff — degraded, but it is exactly what keeps
+	//       the runtime-push epoch alive through a long outage.
+	// Consulted BEFORE fetcher/credential setup: a reconcile the cache can answer must not
+	// read the source Secret, so a transient Secret failure (or a credential rotation) cannot
+	// break SIB19 continuity.
+	var outcome ommFetchOutcome
+	var earlyResult *ctrl.Result
+	var earlyErr error
+	if c, why := r.cacheServe(req.NamespacedName, eph, now, effectiveInterval); why != cacheServeNone {
+		switch why {
+		case cacheServeWindow:
+			log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
+				"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
+			outcome = ommFetchOutcome{result: c.result, reusedCache: true}
+		case cacheServeBackoff:
+			log.V(1).Info("re-propagating from cached OMMs; upstream fetch suppressed by retry backoff",
+				"cacheAge", now.Sub(c.result.FetchedAt).String(),
+				"nextFetchAttempt", c.nextFetchAttempt.UTC().String(), "lastErr", c.lastFetchErr.Error())
+			outcome = ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: c.lastFetchErr}
+		case cacheServeNone:
+		}
+	} else {
+		// Step 3b: a real fetch is due → select the fetcher (loads credentials) and fetch.
+		fetcher, fetcherErr := r.fetcherForSource(ctx, eph)
+		if fetcherErr != nil {
+			meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+				Type:               ntnv1alpha1.ConditionGPDataFetched,
+				Status:             metav1.ConditionFalse,
+				Reason:             "FetcherSetupFailed",
+				Message:            fetcherErr.Error(),
+				ObservedGeneration: eph.Generation,
+			})
+			// No usable GP data this cycle → readiness 0. Holds across a persistent
+			// setup failure so `gp_fetch_ready == 0` alerts even on a never-fetched cold
+			// start, where `gp_satellite_count == 0` cannot (absent series).
+			ntnmetrics.GPFetchReady.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(0)
+			if err := r.Status().Update(ctx, eph); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+		outcome, earlyResult, earlyErr = r.obtainOMMs(ctx, req, eph, fetcher, effectiveInterval, now)
+	}
 	if earlyResult != nil {
 		// obtainOMMs only early-returns on no-usable-data outcomes: a refused insecure
 		// URL, or a fetch error with no cache to fall back on. Readiness 0 either way
@@ -365,7 +383,8 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Stamp the propagation-input digest these propagatedStates were computed under.
 	// Reaching here means the current spec's inputs were (re)propagated — from a fresh
-	// fetch OR a valid same-generation cache. A fetch failure with NO matching cache
+	// fetch OR a valid cache entry for the SAME UPSTREAM FETCH IDENTITY (fetchInputKey;
+	// the cache is deliberately NOT generation-keyed). A fetch failure with NO matching cache
 	// early-returns via handleFetchError, which deliberately does NOT restamp, so the hash
 	// keeps pointing at the LAST inputs that actually produced states. The consumer blocks
 	// only when the live spec's propagation inputs differ from this — a source/selector
@@ -420,21 +439,20 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// I-18: on a serve-cache-on-error cycle, back off the FETCH retry exactly as the
-	// wipe path would (rate-limited → slow requeue; generic transient → return the
-	// error for workqueue exponential backoff) — while the status just persisted
-	// keeps SIB19 served from cache.
-	if servedCacheOnError {
-		_, requeueAfter, returnAsError := classifyFetchError(cacheServeErr, effectiveInterval)
-		if returnAsError {
-			return ctrl.Result{}, cacheServeErr
-		}
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
-	}
-
-	// Requeue on the short propagation cadence (not the GP-refresh interval) so the
-	// runtime-push epoch stays fresh for off-cycle consumers; the fetch itself
-	// stays gated to effectiveInterval by the cache check above (#179).
+	// Requeue on the short PROPAGATION cadence — on EVERY path that produced usable states,
+	// including a serve-cache-on-error cycle. The FETCH is held back separately by
+	// cachedFetch.nextFetchAttempt (armed in obtainOMMs), so running the reconcile every
+	// 3 minutes does NOT re-hit a rate-limited source: cacheServe answers from cache without
+	// contacting it.
+	//
+	// This is the fix for the outage-continuity bug. Previously a serve-cache cycle requeued
+	// at the FETCH backoff (classifyFetchError → 2–24h for RateLimited/AuthFailed, or an
+	// error for workqueue backoff that ramps to ~1000s). The cycle re-propagated the cached
+	// OMMs once to now+propagationEpochLead (5 min) and then nothing ran for hours — so the
+	// pushed epoch expired ~5 minutes in and the consumer refused it for the rest of the
+	// window. "Serving cache preserves SIB19 continuity" was therefore only true for ONE
+	// reconcile. The two cadences are now independent: fetch politeness is enforced on the
+	// fetch, and the epoch is kept alive on the propagation heartbeat.
 	return ctrl.Result{RequeueAfter: min(effectiveInterval, propagationRefreshInterval)}, nil
 }
 
@@ -475,6 +493,71 @@ type cachedFetch struct {
 	result   ephemeris.GPFetchResult
 	fetchKey string
 	uid      types.UID
+
+	// nextFetchAttempt suppresses the UPSTREAM FETCH until this instant after a failure —
+	// INDEPENDENTLY of the reconcile cadence. Previously the fetch backoff WAS the reconcile
+	// cadence (RequeueAfter = the 2–24h fetch backoff on a serve-cache cycle), which starved
+	// the propagation heartbeat: the served cache was re-propagated once to now+5m and then
+	// nothing ran for hours, so the pushed epoch expired ~5 minutes in and SIB19 went stale
+	// for the rest of the window. The reconcile now keeps running on the 3-minute propagation
+	// cadence (which re-propagates from cache and keeps the epoch fresh) while ONLY the fetch
+	// is held back to here — polite to the source AND continuous for the gNB.
+	nextFetchAttempt time.Time
+	// lastFetchErr is the failure that armed nextFetchAttempt, replayed on each backoff-serve
+	// so the degraded status/condition/event stays truthful about WHY we are on cache.
+	lastFetchErr error
+	// fetchFailures counts consecutive failures, for the transient-error backoff ramp.
+	fetchFailures int
+}
+
+// fetchRetryDelay is how long to suppress the next UPSTREAM fetch after a failure. It is the
+// FETCH cadence only — the reconcile keeps running on the propagation heartbeat regardless,
+// so this can be long without starving SIB19.
+func fetchRetryDelay(fetchErr error, effectiveInterval time.Duration, failures int) time.Duration {
+	switch {
+	case errors.Is(fetchErr, ephemeris.ErrRateLimited):
+		// Honor the source's policy (and any Retry-After); never faster than the refresh floor.
+		return max(effectiveInterval, retryAfterFrom(fetchErr))
+	case errors.Is(fetchErr, ephemeris.ErrAuthFailed):
+		// Bad credentials will not fix themselves; hammering the login endpoint risks a lockout.
+		return effectiveInterval
+	default:
+		// Transient (network/5xx): ramp 1m, 2m, 4m … capped at the refresh interval. Bounded
+		// exponent so the shift cannot overflow.
+		shift := min(max(failures-1, 0), 10)
+		return min(time.Minute<<shift, effectiveInterval)
+	}
+}
+
+// cacheServeReason says WHY a reconcile is being served from cache without contacting the source.
+type cacheServeReason int
+
+const (
+	cacheServeNone    cacheServeReason = iota
+	cacheServeWindow                   // inside the GP-refresh window — normal, healthy
+	cacheServeBackoff                  // a fetch failed and we are inside its retry backoff — degraded
+)
+
+// cacheServe decides whether this reconcile can be answered from the cached OMMs WITHOUT
+// contacting the upstream source. It is consulted BEFORE fetcher/credential setup, so a
+// reconcile the cache can answer never reads the source Secret — a transient Secret
+// unavailability (or a credential rotation) must not break SIB19 continuity, and the cache
+// key deliberately excludes credentials (the same URL returns the same GP data whichever
+// account fetched it).
+func (r *SatelliteEphemerisReconciler) cacheServe(
+	key client.ObjectKey, eph *ntnv1alpha1.SatelliteEphemeris, now time.Time, effectiveInterval time.Duration,
+) (cachedFetch, cacheServeReason) {
+	c, ok := r.cachedOMMResult(key)
+	if !ok || c.fetchKey != fetchInputKey(eph.Spec) || c.uid != eph.UID {
+		return cachedFetch{}, cacheServeNone
+	}
+	if now.Sub(c.result.FetchedAt) < effectiveInterval {
+		return c, cacheServeWindow
+	}
+	if now.Before(c.nextFetchAttempt) {
+		return c, cacheServeBackoff
+	}
+	return cachedFetch{}, cacheServeNone
 }
 
 // fetchInputKey identifies WHAT RAW upstream payload a cached entry holds: the source type
@@ -501,11 +584,9 @@ func (r *SatelliteEphemerisReconciler) cachedOMMResult(key client.ObjectKey) (ca
 // propagated state, so a malformed GP feed cannot bloat the status object.
 const maxSatelliteNameLen = 64
 
-// maxEpochAge bounds how old a fetched element set's OWN epoch may be before its
-// SGP4 propagation is flagged unreliable (findings.md I-17). Independent of the
-// refresh cadence — a source can serve elements whose epoch is already stale. ~7
-// days keeps LEO in-track error to at most a few km.
-const maxEpochAge = 7 * 24 * time.Hour
+// maxEpochAge and maxSourceEpochFutureSkew, and the sourceEpochUsable rule that applies
+// them, live in the shared layer (ephemeris_freshness.go) so the producer and the consumer
+// cannot drift apart.
 
 // parseOMMEpoch parses an OMM element-set epoch (ISO-8601, with or without a
 // fractional second or trailing Z), returning ok=false when unparseable.
@@ -555,7 +636,13 @@ func propagationInputHash(spec ntnv1alpha1.SatelliteEphemerisSpec) string {
 	if spec.Satellites != nil {
 		norad = append(norad, spec.Satellites.NoradIDs...)
 	}
+	// Canonicalize: sort AND de-duplicate. FilterOMMs applies the selector through a map, so
+	// [25544] and [25544, 25544] select exactly the same satellites and yield byte-identical
+	// propagated output — they must therefore hash the SAME. Without Compact, adding a
+	// duplicate NORAD ID changed the hash, which the consumer read as EphemerisInputsStale
+	// and answered with a needless re-propagation + runtime re-push.
 	sort.Ints(norad)
+	norad = slices.Compact(norad)
 	h := sha256.New()
 	// Quote the user-controlled strings (%q) so a crafted source.url can't embed the field
 	// delimiters and collide with a different spec's serialization. hash.Hash.Write never
@@ -593,6 +680,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 
 	states := make([]ntnv1alpha1.PropagatedState, 0, min(len(omms), maxPropagatedStates))
 	skippedByCap := 0
+	rejectedEpochs := 0 // element sets refused BEFORE SGP4: unparseable or implausibly future
 	for i := range omms {
 		if len(states) >= maxPropagatedStates {
 			// The cap is reached; the remaining OMMs are NOT attempted. This is the
@@ -605,22 +693,37 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 				"hint", "set spec.satellites.noradIDs to the satellites pushed at runtime")
 			break
 		}
-		// Parse the SOURCE element-set epoch BEFORE propagating (0 if unparseable →
-		// unknown, not stale). An implausibly FUTURE-dated epoch (corrupt or spoofed feed)
-		// must be rejected HERE, not only at the consumer: SGP4 would otherwise be driven
-		// backward from the bogus epoch down to the target, writing a wildly wrong ECEF
-		// into status. Refusing it at the push only stops delivery — it does not stop the
-		// propagation — so the guard belongs on the producer too (#221 review finding 3).
-		srcEpochMs := int64(0)
-		if t, ok := parseOMMEpoch(omms[i].EpochStr); ok {
-			if t.After(epoch.Add(maxSourceEpochFutureSkew)) {
-				logf.FromContext(ctx).Info("skipping satellite: source element epoch is implausibly future-dated",
-					"norad", omms[i].NoradCatID, "sourceEpoch", t.UTC(), "targetEpoch", epoch.UTC(),
-					"allowedSkew", maxSourceEpochFutureSkew.String())
-				continue
-			}
-			srcEpochMs = t.UnixMilli()
+		// Validate the SOURCE element-set epoch BEFORE propagating, using the SHARED rule
+		// against the SAME `now` the consumer will use (ephemeris_freshness.go). Previously
+		// this compared against the propagation TARGET epoch (now + 5m) while the consumer
+		// compared against now, so a source epoch inside that 5-minute band was propagated
+		// and hash-stamped here yet permanently refused at the push — a state that could
+		// never be delivered.
+		//
+		// An UNPARSEABLE epoch now SKIPS the satellite rather than emitting a state with
+		// SourceEpochUnixMs = 0. That 0 was an ambiguous sentinel (it also means the legal
+		// instant 1970-01-01T00:00:00Z), and the consumer's fail-open on it let a 1970 epoch
+		// bypass the whole freshness gate. Nothing is lost: SGP4's own OMM.ToTLE parses the
+		// same epoch, so an element set we cannot parse fails PropagateToECEF below anyway.
+		t, ok := parseOMMEpoch(omms[i].EpochStr)
+		if !ok {
+			rejectedEpochs++
+			logf.FromContext(ctx).Info("skipping satellite: source element epoch is unparseable",
+				"norad", omms[i].NoradCatID, "epochStr", omms[i].EpochStr)
+			continue
 		}
+		// PLAUSIBILITY only. A STALE (merely old) element set is deliberately still
+		// propagated and merely counted (EphemerisEpochStale, I-17) so a drifting feed stays
+		// observable; the consumer owns the delivery gate (#200-C4). Rejecting staleness here
+		// would collapse a precise "EphemerisStale" diagnosis into a bare "PayloadMissing".
+		if err := sourceEpochPlausible(now, t); err != nil {
+			rejectedEpochs++
+			logf.FromContext(ctx).Info("skipping satellite: implausible source element epoch",
+				"norad", omms[i].NoradCatID, "sourceEpoch", t.UTC(), "err", err.Error())
+			continue
+		}
+		srcEpochMs := t.UnixMilli()
+
 		ecef, err := ephemeris.PropagateToECEF(omms[i], epoch)
 		if err != nil {
 			continue // skip satellites whose SGP4 propagation fails / goes out of range
@@ -642,7 +745,36 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	eph.Status.PropagatedStates = states
 	truncEvent := r.reportStatesTruncated(eph, len(omms), skippedByCap)
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
+	r.reportSourceEpochRejected(eph, rejectedEpochs, len(omms))
 	return truncEvent
+}
+
+// reportSourceEpochRejected surfaces element sets the producer refused BEFORE SGP4 — an
+// unparseable or implausibly future-dated OMM EPOCH. Without a durable condition the guard is
+// invisible: the satellite simply has no propagated state, and a cell selecting it reports a
+// bare "EphemerisPayloadMissing" with no way to tell a corrupt feed from a deep-space
+// rejection or a NORAD typo (the deep-space case already gets a cross-CR hint; this one had
+// none — it only wrote a log line).
+func (r *SatelliteEphemerisReconciler) reportSourceEpochRejected(
+	eph *ntnv1alpha1.SatelliteEphemeris, rejected, total int,
+) {
+	c := metav1.Condition{
+		Type:               ntnv1alpha1.ConditionSourceEpochRejected,
+		Status:             metav1.ConditionFalse,
+		Reason:             "SourceEpochsPlausible",
+		Message:            "Every tracked element set has a parseable, plausibly-dated epoch",
+		ObservedGeneration: eph.Generation,
+	}
+	if rejected > 0 {
+		c.Status = metav1.ConditionTrue
+		c.Reason = "ImplausibleSourceEpoch"
+		c.Message = fmt.Sprintf(
+			"%d of %d tracked element set(s) were REFUSED before propagation: the OMM EPOCH is unparseable "+
+				"or implausibly future-dated (more than %s ahead). They produce no propagated state, so a cell "+
+				"selecting one reports EphemerisPayloadMissing. Check the GP source for corrupt data.",
+			rejected, total, maxSourceEpochFutureSkew)
+	}
+	meta.SetStatusCondition(&eph.Status.Conditions, c)
 }
 
 // reportStatesTruncated records status.truncatedSatelliteCount and the
@@ -1017,13 +1149,9 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 ) (ommFetchOutcome, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	fetchKey := fetchInputKey(eph.Spec)
-	if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
-		c.fetchKey == fetchKey && c.uid == eph.UID &&
-		now.Sub(c.result.FetchedAt) < effectiveInterval {
-		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
-			"cacheAge", now.Sub(c.result.FetchedAt).String(), "refreshInterval", effectiveInterval.String())
-		return ommFetchOutcome{result: c.result, reusedCache: true}, nil, nil
-	}
+	// (The cache-serve decision — refresh window OR fetch-retry backoff — is made by
+	// cacheServe BEFORE fetcher/credential setup, so obtainOMMs is only reached when a real
+	// upstream fetch is actually due.)
 
 	// Refuse a cleartext http:// source that resolves to a PUBLIC IP (I-21).
 	if ip, insecure := r.publicHTTPSource(ctx, eph.Spec.Source.URL); insecure {
@@ -1045,14 +1173,27 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 		// and break re-propagation during an upstream outage (#221 review finding 2).
 		if c, ok := r.cachedOMMResult(req.NamespacedName); ok &&
 			c.fetchKey == fetchKey && c.uid == eph.UID {
+			// ARM THE FETCH BACKOFF on the cache entry. This — not RequeueAfter — is what
+			// keeps us polite to the source, which frees the reconcile to keep running on the
+			// 3-minute propagation cadence and keep the pushed epoch alive for the whole
+			// outage. (Before this, the serve-cache cycle requeued at the 2–24h fetch backoff,
+			// so the epoch expired ~5 minutes in and SIB19 went stale for the rest of it.)
+			c.fetchFailures++
+			c.nextFetchAttempt = now.Add(fetchRetryDelay(fetchErr, effectiveInterval, c.fetchFailures))
+			c.lastFetchErr = fetchErr
+			r.ommCache.Store(req.NamespacedName, c)
 			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
-				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String())
+				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String(),
+				"nextFetchAttempt", c.nextFetchAttempt.UTC().String(), "consecutiveFailures", c.fetchFailures)
 			return ommFetchOutcome{result: c.result, servedCacheOnError: true, cacheServeErr: fetchErr}, nil, nil
 		}
+		// No cache to serve: nothing to keep fresh, so the fetch backoff IS the reconcile
+		// cadence here (the wipe path) — unchanged.
 		res, err := r.handleFetchError(ctx, eph, fetchErr, effectiveInterval)
 		return ommFetchOutcome{}, &res, err
 	}
 
+	// A successful fetch clears the backoff.
 	r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, fetchKey: fetchKey, uid: eph.UID})
 	return ommFetchOutcome{result: result}, nil, nil
 }

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -381,8 +381,9 @@ spec:
                   propagatedStatesInputHash is a digest of the spec fields that determine WHICH
                   orbital data is fetched and WHICH satellites are propagated (source type/url and the
                   NORAD selector) — NOT the whole spec. It is stamped whenever the current
-                  propagatedStates are (re)computed, from a fresh fetch or a valid same-generation
-                  cache. The NTNCellConfig runtime-push consumer recomputes the hash from the live
+                  propagatedStates are (re)computed, from a fresh fetch or a valid cache entry for the
+                  same upstream fetch identity (the OMM cache is keyed on source type+url, NOT on
+                  .metadata.generation). The NTNCellConfig runtime-push consumer recomputes the hash from the live
                   spec and refuses to push when it differs — i.e. the persisted states were computed
                   under different propagation inputs (a source/selector edit whose re-propagate has
                   not yet succeeded), WITHOUT falsely invalidating on a pass-prediction-only edit


### PR DESCRIPTION
> **Stacked on #221** (base = `fix/push-correctness`; needs `propagatedStatesInputHash` / `sourceEpochUnixMs` / `fetchInputKey`). Retarget to `main` once #221 merges.
> **Overlaps #222** — this subsumes #222's `obtainOMMs` cache-before-secret (#200-C2); sequence the merges.

## P1 — "serving cache preserves SIB19 continuity" was only true for ONE reconcile

Serving cached OMMs on a failed GP fetch (I-18) re-propagated to `now + propagationEpochLead` (**5 min**) and then set `RequeueAfter` to the **FETCH backoff**: `>= effectiveInterval` (**2–24h**) for RateLimited/AuthFailed, or returned the error so the workqueue backed off (ramping to ~1000s) for a transient one. Nothing re-propagated in between — `reconcileTriggerPredicate` deliberately filters the controller's own status writes, so `RequeueAfter` was the **only** trigger.

```
T+0m    fetch fails → propagate from cache to T+5m → RequeueAfter = 2h
T+3m    (no reconcile)
T+5m    pushed epoch EXPIRES
T+5m10s consumer refuses the state  ← SIB19 stale
T+2h    producer finally runs again
```

**Continuity was ~4%** (5 min of every 2h), not the 100% the design claims. Nothing caught it: the cache-fallback test ran **exactly one** reconcile and asserted neither the requeue nor epoch freshness over time.

**Root cause:** the reconcile cadence was being used to implement the fetch backoff, welding together two cadences that must be independent — upstream **politeness** (≥2h) and propagation **freshness** (must be < the 5-min epoch lead).

**Fix — decouple them.** `cachedFetch` gains `nextFetchAttempt` / `lastFetchErr` / `fetchFailures`; a failed fetch arms the backoff **on the cache entry** (`fetchRetryDelay`). The reconcile then requeues on the **propagation cadence** on every path that produced usable states, and `cacheServe` answers from cache **without touching the source** while the backoff holds. Upstream is contacted **once per backoff window**; the epoch is refreshed **every 3 minutes for the whole outage**. A serve-cache cycle also no longer returns an error — that made controller-runtime discard `RequeueAfter` in favour of the workqueue backoff.

## P1 — `SourceEpochUnixMs == 0` sentinel collision bypassed the hard-stale gate

`0` meant **both** "unparseable" **and** the legal instant `1970-01-01T00:00:00Z`, and the consumer failed **open** on it — so a 1970-dated element set bypassed the entire 7-day freshness gate.

I re-checked my earlier fail-open rationale layout-for-layout against `akhenakh/sgp4 v1.0.1` and **it was wrong**: there is nothing the dependency accepts that our `parseOMMEpoch` rejects (Go's `time.Parse` accepts a fractional second even when the layout omits it, and defaults to UTC). And `PropagateToECEF → ToTLE` parses the *same* epoch, so an element set we can't parse fails propagation anyway — the "unknown" state was **unreachable**, while the hole was real.

**Fix:** the producer never emits a state whose epoch it could not parse; the consumer validates **unconditionally**. A 1970 epoch is then simply — and correctly — **stale**. No pointer type, no CRD schema change needed.

## Shared layer — producer and consumer had silently drifted

The producer compared the future bound against the propagation **target** epoch (`now+5m`) while the consumer compared against `now`, so an epoch in that 5-minute band was propagated **and hash-stamped** yet **permanently refused** at the push — a state that could never be delivered.

New `ephemeris_freshness.go` single-sources the rules. **Two** rules, deliberately:
- **PLAUSIBILITY** (unparseable / implausibly-future) — enforced by **both**. The producer must refuse to run SGP4 *backward* from a bogus epoch, which a consumer check cannot prevent.
- **FRESHNESS** (too old) — stays the **consumer's** delivery gate. A merely stale element set still propagates meaningfully, so the producer keeps emitting *and counting* it (`EphemerisEpochStale`, I-17) so a drifting feed stays observable. Rejecting staleness at the producer would collapse a precise `EphemerisStale` diagnosis into a bare `PayloadMissing`.

## Also

- **Cache consulted before credential setup.** A missing / rotating / briefly-unreadable Secret used to short-circuit to `FetcherSetupFailed` *before* the cache was consulted, stranding re-propagation even though the cached raw OMMs were fine — and the cache key already excludes credentials on purpose. (Subsumes #200-C2.)
- **New `SourceEpochRejected` condition.** The refusal guard previously only wrote a log line, so a cell whose only satellite was refused reported a bare `EphemerisPayloadMissing` with no way to tell a corrupt feed from a NORAD typo.
- **Hash canonicalization.** `FilterOMMs` applies the selector through a map, so `[25544]` and `[25544, 25544]` produce byte-identical output but hashed *differently* → a needless `EphemerisInputsStale` + re-propagation + runtime re-push. Now de-duplicated. Also fixes the now-false "same-generation cache" wording in the API doc.

## Tests (mutation-proven)

Sustained-outage continuity for **RateLimited / AuthFailed / transient**: upstream contacted **exactly once** while the epoch is re-propagated and stays in the future **every cycle**, requeueing on the propagation cadence. Mutation-proven **in both directions** — restoring the fetch-backoff-as-reconcile-cadence makes the epoch expire (`got 4h0m0s — the epoch would expire before the next reconcile`), and removing the fetch backoff hammers the source (`upstream must be contacted exactly once, got 2 calls`).

Plus: 1970 epoch is stale-not-bypassed (mutation-proven); unparseable epoch → no state + `SourceEpochRejected`; producer/consumer agree on the plausibility boundary; valid cache + missing Secret still re-propagates; hash de-dupes NORAD; `fetchRetryDelay` per error class.

The existing cache-fallback test pinned the **old** contract (*"a generic fetch error must be returned for workqueue backoff"*) — that is exactly the starvation being fixed, so it now pins the new one.

`make test` (controller **87.8%** cov) / golangci-lint 0 / gofmt / go vet / go test -race / CRD drift-verify — all green.
