### PR TITLE
feat(ha): cache-sync-gated readyz + document active-passive HA; fix chart values README (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trusted host is refused. The cookie jar also uses the public-suffix list so a server cannot set
   an overly broad domain cookie. Mutation-tested.
 
+### Changed
+
+- **`/readyz` now gates on informer cache-sync (still leadership-agnostic).** It was
+  `healthz.Ping`, which reports Ready as soon as the process serves — but controller-runtime
+  starts the health server *before* the caches sync, so a broken new replica (RBAC, CRD
+  discovery, a wedged list/watch) could be counted Available and a rollout would then tear down
+  the healthy old replicas. `/readyz` now passes only once the caches have synced, wired via a
+  non-leader-election `Runnable` (`NeedLeaderElection()==false`) so every replica — leader or
+  standby — becomes Ready after its *own* cache sync, without gating on leadership (which would
+  deadlock rollouts: a standby could never become Ready). `/healthz` stays `healthz.Ping`.
+- **`passPrediction.minElevation` is constrained to `[0, 90]` degrees.** 0 is the
+  geometric horizon and 90 the zenith; a negative or `>90` mask is physically meaningless.
+  Enforced by an admission CEL rule plus a finite-value runtime range check. The value
+  pattern otherwise preserves the prior grammar (a trailing dot such as `"10."` stays
+  valid — only the leading `-` was removed). The bound is on the parsed **float64** value
+  (the pass pipeline is float64), so a literal within ~half a ULP above 90 rounds to 90 and
+  is accepted; `NaN`/`Inf` are rejected (#201-P3).
+
 ### Fixed
 
 - **Pass windows are computed from the current time, not the last fetch time.** On a cached
@@ -143,9 +161,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The mapper resolved referencing cells by scanning every `NTNCellConfig` in the namespace and
   filtering in Go; it now uses an indexed cache lookup (registered in `SetupWithManager`), with
   a fallback to the scan for non-cache clients (#204-G3).
-
-### Fixed
-
 - **Pass windows (`status.nextPassWindows`) are now conservative to the whole second.**
   AOS is rounded up and LOS down before storage, so the persisted window stays within the
   window the mask-trim computed — previously AOS/LOS carried ~200 ms of sub-second residual
@@ -154,16 +169,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (When mask-boundary evaluation succeeds that computed window is the usable ≥ minElevation
   interval; on the fail-open elevation-error path it is the wider 0°-horizon window — see
   the deferred narrow fail-closed proposal.)
-
-### Changed
-
-- **`passPrediction.minElevation` is constrained to `[0, 90]` degrees.** 0 is the
-  geometric horizon and 90 the zenith; a negative or `>90` mask is physically meaningless.
-  Enforced by an admission CEL rule plus a finite-value runtime range check. The value
-  pattern otherwise preserves the prior grammar (a trailing dot such as `"10."` stays
-  valid — only the leading `-` was removed). The bound is on the parsed **float64** value
-  (the pass pipeline is float64), so a literal within ~half a ULP above 90 rounds to 90 and
-  is accepted; `NaN`/`Inf` are rejected (#201-P3).
+- **Chart values docs corrected + HA design documented.** `dist/chart/README.md` listed
+  `podDisruptionBudget.enable` as `false` and `manager.affinity` as `{}`, but the `values.yaml`
+  defaults are `true` and a soft `podAntiAffinity`. Added `docs/high-availability.md` covering
+  the active-passive design (leader election, `LeaderElectionReleaseOnCancel`, PDB, anti-affinity,
+  cache-sync readiness, failover behavior). The Helm chart is the HA path — process-level
+  active-passive with **best-effort** node spreading (soft anti-affinity + PDB guard voluntary
+  disruptions only; not a node-failure guarantee); the `config/default` kustomize base is
+  intentionally single-replica for dev/e2e. Corrected an earlier claim that a cache-sync-gated
+  readyz would deadlock rollouts — only a *leadership*-gated one does.
 
 ### Upgrade notes
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,10 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
+	"net/http"
 	"os"
-
+	"sync/atomic"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -269,13 +272,24 @@ func main() {
 		setupLog.Error(err, "Failed to set up health check")
 		os.Exit(1)
 	}
-	// readyz is intentionally leadership-agnostic (healthz.Ping): under active-passive
-	// HA a NON-leader standby must still report Ready, or the Deployment never counts
-	// it Available and a rolling update deadlocks (the new pod can only become leader
-	// after the old releases the lease, but the old is not torn down until the new is
-	// Ready). A cache-sync- or leadership-gated readyz would break HA the same way,
-	// because a non-leader's cache/controllers do not start until it acquires the lease.
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// cachesSynced flips true once the manager's informer caches have synced; the
+	// runnable that sets it is non-leader-election, so it runs on EVERY replica
+	// (see cacheReadyRunnable). Register it before the readyz check that reads it.
+	var cachesSynced atomic.Bool
+	if err := mgr.Add(cacheReadyRunnable{ready: &cachesSynced}); err != nil {
+		setupLog.Error(err, "Failed to register cache-sync readiness runnable")
+		os.Exit(1)
+	}
+	// /readyz gates on informer cache-sync but NOT on leadership. controller-runtime
+	// starts the health server BEFORE the caches sync, so a bare healthz.Ping readyz
+	// reports Ready before (or without ever) syncing — a broken new replica would then
+	// be counted Available and the rollout would tear down the healthy old ones. Gating
+	// on cache-sync closes that. It stays leadership-AGNOSTIC on purpose: every replica
+	// syncs its cache before leader election (v0.24.1 internal.go: caches → non-leader
+	// runnables → leader election), so the standby becomes Ready without holding the
+	// lease. Gating on leadership INSTEAD would deadlock rollouts — the new pod can't win
+	// the lease until the old releases it, but the old is not removed until the new is Ready.
+	if err := mgr.AddReadyzCheck("readyz", cacheSyncReadyCheck(&cachesSynced)); err != nil {
 		setupLog.Error(err, "Failed to set up ready check")
 		os.Exit(1)
 	}
@@ -284,5 +298,38 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
+	}
+}
+
+// cacheReadyRunnable flips its flag true once the manager's caches have synced.
+// controller-runtime starts non-leader-election runnables only AFTER the caches
+// sync, and on EVERY replica regardless of leadership (v0.24.1 internal.go order:
+// HTTPServers → Webhooks → Caches(wait for sync) → non-leader runnables → leader
+// election). So Start running means the informer caches are synced — which is what
+// lets /readyz gate on cache-sync without gating on leadership.
+type cacheReadyRunnable struct {
+	ready *atomic.Bool
+}
+
+func (c cacheReadyRunnable) Start(ctx context.Context) error {
+	c.ready.Store(true)
+	<-ctx.Done()
+	return nil
+}
+
+// NeedLeaderElection must return false: a leader-election runnable runs only on the
+// elected leader, so a standby's flag would never flip and its /readyz would never
+// pass — deadlocking rollouts. false makes this a non-leader runnable that starts on
+// every replica once caches have synced.
+func (cacheReadyRunnable) NeedLeaderElection() bool { return false }
+
+// cacheSyncReadyCheck returns a readyz Checker that passes only once ready is set
+// (i.e. the manager's caches have synced). Leadership is deliberately not consulted.
+func cacheSyncReadyCheck(ready *atomic.Bool) healthz.Checker {
+	return func(_ *http.Request) error {
+		if ready.Load() {
+			return nil
+		}
+		return errors.New("informer caches not yet synced")
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCacheSyncReadyCheck pins that /readyz fails until caches sync and passes after.
+// Mutation guard: inverting the `ready.Load()` branch fails one of the two assertions.
+func TestCacheSyncReadyCheck(t *testing.T) {
+	var ready atomic.Bool
+	check := cacheSyncReadyCheck(&ready)
+
+	if err := check(nil); err == nil {
+		t.Fatal("readyz must FAIL before informer caches sync (ready=false)")
+	}
+	ready.Store(true)
+	if err := check(nil); err != nil {
+		t.Fatalf("readyz must PASS once caches sync (ready=true), got %v", err)
+	}
+}
+
+// TestCacheReadyRunnable_NeedLeaderElectionFalse is the load-bearing contract: if this
+// runnable needed leader election it would run only on the elected leader, so a standby's
+// readyz would never pass and rollouts would deadlock. It MUST be a non-leader runnable.
+func TestCacheReadyRunnable_NeedLeaderElectionFalse(t *testing.T) {
+	if (cacheReadyRunnable{}).NeedLeaderElection() {
+		t.Fatal("cacheReadyRunnable.NeedLeaderElection() must be false (non-leader runnable) " +
+			"or the standby never becomes Ready and rollouts deadlock")
+	}
+}
+
+// TestCacheReadyRunnable_StartSetsFlagThenBlocks proves Start flips the flag (so readyz
+// can pass) and then blocks until context cancel (so it does not exit and get restarted).
+func TestCacheReadyRunnable_StartSetsFlagThenBlocks(t *testing.T) {
+	var ready atomic.Bool
+	r := cacheReadyRunnable{ready: &ready}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	// Flag must be set essentially immediately (before Start blocks on ctx.Done).
+	deadline := time.Now().Add(2 * time.Second)
+	for !ready.Load() && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !ready.Load() {
+		t.Fatal("Start must set ready=true before blocking on ctx.Done")
+	}
+
+	// It must still be running (blocked) — done should not have fired yet.
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned before ctx cancel (err=%v); it must block", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned %v after ctx cancel, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after ctx cancel")
+	}
+}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/name: ntn-operators
+  # Single replica: this raw kustomize base is the dev / e2e deploy path (`make deploy`).
+  # Production HA (2 replicas + PDB + anti-affinity) is the Helm chart — see
+  # docs/high-availability.md.
   replicas: 1
   template:
     metadata:

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -38,7 +38,7 @@ This chart installs four Custom Resource Definitions:
 | `manager.podSecurityContext.runAsNonRoot` | bool | `true` | Run as non-root |
 | `manager.podSecurityContext.runAsUser` | int | `65532` | UID |
 | `manager.podSecurityContext.runAsGroup` | int | `65532` | GID |
-| `manager.affinity` | object | `{}` | Pod affinity rules |
+| `manager.affinity` | object | soft `podAntiAffinity` on `kubernetes.io/hostname` | Pod affinity rules; the default prefers spreading the replicas across nodes |
 | `manager.nodeSelector` | object | `{}` | Node selector |
 | `manager.tolerations` | list | `[]` | Pod tolerations |
 | `crd.enable` | bool | `true` | Install CRDs with the chart |
@@ -48,7 +48,7 @@ This chart installs four Custom Resource Definitions:
 | `metrics.port` | int | `8443` | Metrics server port |
 | `certManager.enable` | bool | `false` | Enable cert-manager integration |
 | `prometheus.enable` | bool | `false` | Create ServiceMonitor for Prometheus |
-| `podDisruptionBudget.enable` | bool | `false` | Create PodDisruptionBudget |
+| `podDisruptionBudget.enable` | bool | `true` | Create PodDisruptionBudget |
 | `podDisruptionBudget.minAvailable` | int | `1` | Minimum available pods |
 | `networkPolicy.enable` | bool | `false` | Create NetworkPolicy (requires CNI support) |
 

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -1,0 +1,99 @@
+# High Availability
+
+The operator runs **active-passive**: two replicas, one elected leader that runs the
+controllers, and a warm standby that takes over when the leader steps down. This document
+records the design and the deliberate choices behind it — several of which look like
+"missing hardening" but are correct for a leader-elected controller-runtime manager.
+
+## Topology
+
+| Knob | Value | Where |
+|------|-------|-------|
+| Replicas | 2 (chart) · 1 (raw kustomize) | `manager.replicas` (chart); `config/manager/manager.yaml` ships 1 for dev/e2e |
+| Leader election | on | `--leader-elect` (default true), `cmd/main.go` |
+| `LeaderElectionReleaseOnCancel` | `true` | `cmd/main.go` |
+| Lease / renew / retry | 15s / 10s / 2s (controller-runtime defaults) | `cmd/main.go` |
+| PodDisruptionBudget | `minAvailable: 1` | **chart only** (`podDisruptionBudget`) |
+| Pod anti-affinity | soft, `topologyKey: kubernetes.io/hostname` | **chart only** (`manager.affinity`) |
+| Readiness | cache-sync-gated, leadership-agnostic | `cmd/main.go` (`/readyz`) |
+
+Every replica starts its manager and **syncs its cache before leader election**; only the
+controllers (leader-election runnables) wait to start until this replica wins the lease. The
+standby is a warm manager with a synced cache — not an unstarted one. (Start order in
+controller-runtime v0.24.1: health server → webhooks → caches (wait for sync) → non-leader
+runnables → leader election → controllers.)
+
+## Readiness gates on cache-sync, not leadership
+
+`/readyz` reports Ready once this replica's informer caches have synced — **regardless of
+whether it is the leader**. `/healthz` is `healthz.Ping` (liveness: the process is up). Two
+separate properties, both load-bearing:
+
+- **Leadership-agnostic is mandatory.** A standby that is not the leader must still be Ready, or
+  the Deployment never counts it Available and a rolling update deadlocks: the new replica can
+  only become leader after the old one releases the lease, but the rollout will not tear down
+  the old replica until the new one is Ready. Gating `/readyz` on leadership would wedge every
+  rollout — so **never** do that.
+- **Cache-sync gating is safe and wanted.** controller-runtime starts the health server *before*
+  the caches sync, so a bare `healthz.Ping` `/readyz` reports Ready before (or without ever)
+  syncing — a broken new replica (RBAC, CRD discovery, a wedged list/watch) would then be counted
+  Available and the rollout would tear down the healthy old ones. Because every replica syncs its
+  cache *before* leader election, a readyz that waits for cache-sync does **not** wait on
+  leadership and does not deadlock. It is wired with a non-leader-election `Runnable`
+  (`NeedLeaderElection()==false`) that flips a flag once caches have synced; `/readyz` reads it.
+
+## Failover behavior
+
+- **Graceful (rollout, `kubectl delete pod`, SIGTERM):** the leader releases the lease on
+  shutdown (`LeaderElectionReleaseOnCancel`), so the standby can acquire it within a retry
+  period (~2s) instead of waiting out the full lease duration. This is safe only because
+  `main()` exits promptly after `mgr.Start()` returns — nothing runs on the critical path after
+  the lease is released (controller-runtime issue #1132).
+- **Ungraceful (node crash, SIGKILL, network partition):** the lease is not released; the
+  standby becomes *eligible* to take over after the lease expires — on the order of
+  `LeaseDuration` (15s). Tightening the lease trades faster failover for more apiserver load and
+  more spurious failovers under transient latency; the kube-scheduler defaults (15/10/2s) are a
+  good balance and are kept.
+
+Those `~2s` / `~15s` figures are **lease-handoff** timings, not an end-to-end recovery SLA:
+full recovery also includes the new leader's controller startup, work-queue processing, and the
+first successful reconcile (plus apiserver and any gNB-side latency), and is not guaranteed to
+complete within 2s/15s. Measure real RTO with fault injection rather than reading it off the
+lease settings.
+
+Kubernetes object reconciliation is level-based and convergent, so a reconcile cut off on the
+old leader is simply re-done by the new one — no partial-write recovery is needed for CR /
+ConfigMap state. The **external** runtime push (the WebSocket `ntn_config_update` to the gNB) is
+**at-least-once** across a crash or leader transition: a push can succeed on the old leader
+before it persists status, so the new leader may re-push. That is safe here because the push is
+a set-state command keyed by epoch (`runtimeEphemerisPushMarker`) — a duplicate delivers the
+same state — but the property callers must rely on is duplicate-tolerance, not exactly-once.
+
+## PodDisruptionBudget
+
+`minAvailable: 1` on two replicas permits a **voluntary** disruption (e.g. `kubectl drain`
+for a node upgrade) to evict exactly one replica at a time, keeping the leader or a ready
+standby up. It does **not** block involuntary disruptions (node crash) or Deployment rolling
+updates (which delete pods directly rather than via the eviction API). A PDB with
+`minAvailable: 1` on a single-replica Deployment would block all draining — which is why the
+PDB ships together with `replicas: 2`.
+
+## Deploy paths
+
+- **Helm chart (`dist/chart/`, recommended for production):** process-level active-passive
+  redundancy by default — `replicas: 2`, PDB enabled (`minAvailable: 1`), soft anti-affinity.
+  This is **best-effort** node spreading, not a node-failure guarantee: soft anti-affinity is a
+  scheduler *preference* (both replicas can land on one node if that's all that fits), and the
+  PDB only guards *voluntary* disruptions (drains/evictions) — surviving a node crash requires
+  the two replicas to actually be scheduled into independent nodes / failure domains. Use hard
+  anti-affinity and/or topology-spread constraints if you need that guarantee (at the cost of
+  schedulability on small clusters).
+- **Raw kustomize (`config/default`, `make deploy`):** a **single replica** — this is the
+  dev / e2e deploy path, intentionally not HA. Deploy the Helm chart for a highly-available
+  installation. (A single-replica base also keeps a `PodDisruptionBudget minAvailable: 1`
+  from blocking node drains, which it would on one replica.)
+
+## Logging
+
+The manager logs production JSON (`zap.Options{Development: false}`) — info level, sampling,
+error-level stacktraces — overridable with `--zap-devel` for local debugging.


### PR DESCRIPTION
Round-2 review of the HA setup (#205), verified against **controller-runtime v0.24.1 source** (`pkg/manager/internal.go` start order) and the WO-14 active-passive research. ⚠ The earlier version of this PR/body described a `config/`-HA-parity change (replicas:2 + `config/manager/pdb.yaml` + anti-affinity) that was **reverted** — the E2E asserts exactly one controller pod. This is the corrected scope.

## Code — `/readyz` now gates on cache-sync (still leadership-agnostic)

`cmd/main.go` previously used bare `healthz.Ping` for `/readyz`. controller-runtime starts the health server **before** the caches sync (v0.24.1 `internal.go`: HTTP servers → webhooks → caches (wait) → non-leader runnables → leader election), so `Ping` reports Ready pre-sync — a broken new replica (RBAC, CRD discovery, a wedged list/watch) is counted Available and a rollout tears down the healthy old ones.

**Fix:** a non-leader-election `Runnable` (`NeedLeaderElection() == false`) flips an atomic flag once caches have synced; `/readyz` reads it. Because **every** replica syncs its cache before leader election, this stays leadership-agnostic — the standby becomes Ready without holding the lease, so rollouts don't deadlock. (A *leadership*-gated readyz would deadlock — that's the real constraint, and it's what the docs previously conflated with cache-sync.) `/healthz` stays `healthz.Ping`.

3 mutation-proven tests (`cmd/main_test.go`): readyz fails-before / passes-after sync; `NeedLeaderElection()==false` (the deadlock guard); `Start` sets the flag then blocks. All three mutations verified to fail the suite.

## Docs

**`dist/chart/README.md`** — drift fix (unchanged from round-1, review-confirmed correct): `podDisruptionBudget.enable` `false`→`true`, `manager.affinity` `{}`→soft `podAntiAffinity`.

**`docs/high-availability.md`** — corrected the errors the review caught:
- **"Only the leader's cache starts" was wrong.** Every replica syncs its cache before leader election; only controllers (leader-election runnables) gate on leadership.
- **Topology table** now attributes `replicas: 2` / PDB / anti-affinity to the **chart only** (raw kustomize `config/` is single-replica); removed the reference to a non-existent `config/manager/pdb.yaml`, resolving the contradiction with the Deploy-paths section.
- **`~2s`/`~15s`** reframed as lease-handoff timings, **not** an end-to-end RTO (full recovery adds controller startup + first reconcile; measure with fault injection).
- **External WebSocket push** documented as **at-least-once** across crash/leader-transition (duplicate-tolerant because it's a set-state command keyed by epoch via `runtimeEphemerisPushMarker`), not blanket-idempotent.
- **"HA by default"** qualified: process-level active-passive with **best-effort** node spreading (soft anti-affinity is a scheduler preference; PDB guards voluntary disruptions only) — not a node-failure guarantee.

## Scope (this fixes the title/body mismatch)

**No `config/` change** in this PR. The raw kustomize base stays single-replica for dev/e2e (the E2E asserts exactly one controller pod). Production HA is the Helm chart.

## Verification

`make test` (cmd 11.6% / controllers 87.0% / all pkgs green) · `go test -race ./cmd` · `golangci-lint` fresh-cache **0 issues** · `gofmt`/`vet`/`build` clean · `helm lint` · `kubectl kustomize config/default` renders `replicas: 1`, no PDB, no anti-affinity (matches the docs).

## Deferred → #230

HA CI coverage (leader-kill failover timing, cache-sync rollout gate, PDB selection, external-push crash dedup, `helm template` HA assertions) — the chart-test workflow currently only lints/deploys. Also folds the #202 F7 NetworkPolicy-CI gap (#228).
