### PR TITLE
docs(audit): fix rollback cmd, runbook egress/reasons, chart egress help, stale-CRD + UL-sync wording (#202, #204-G4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disruptions only; not a node-failure guarantee); the `config/default` kustomize base is
   intentionally single-replica for dev/e2e. Corrected an earlier claim that a cache-sync-gated
   readyz would deadlock rollouts — only a *leadership*-gated one does.
+- **Docs/runbook corrections (audit follow-up).** `RELEASING.md`'s operator-only
+  rollback now uses `helm upgrade oci://ghcr.io/thc1006/ntn-operators --version
+  <prev> --reuse-values --set crd.enable=false`; the previous
+  `helm rollback … --set crd.enable=false` fails with `unknown flag: --set`
+  (`helm rollback` takes no `--set`), and a local `dist/chart` path ignores
+  `--version` (would redeploy current sources, not roll back). In the NOC runbook
+  (`docs/runbooks/alerts.md`): the gNB-reachability check now uses an ephemeral
+  debug container in the operator Pod (shares its netns → governed by the
+  operator's NetworkPolicy; a bare labelled `kubectl run` pod would be adopted and
+  killed by the operator ReplicaSet) with IPv6-safe endpoint parsing; the "all
+  alerts are namespaced" claim is corrected (`NTNControllerReconcileErrors` is
+  labelled by `controller` only); log commands use a release-independent label
+  selector with `--tail=-1 --prefix=true` (the selector default is 10 lines); and
+  the `GPDataFetched=False` reason list is completed
+  (`FetcherSetupFailed`/`InsecureURL`). The chart's
+  `extraEgress` help no longer implies it can *restrict* egress — NetworkPolicy
+  egress rules are additive, so a port must be left out of
+  `prometheusPorts`/`gnbPorts` to be CIDR-scoped. The README no longer states
+  stale-CRD writes are unconditionally "silently dropped" (strict server-side
+  field validation rejects them). The `runtimeEphemerisPushMarker` comment no
+  longer claims "NR max 240 s" (the `ntnUlSyncValidityDur` enum caps at 900 s)
+  or that the re-push cadence is always under `ntn-UlSyncValidityDur`.
 
 ### Upgrade notes
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,12 @@ helm install ntn-operators dist/chart \
 > helm upgrade ntn-operators dist/chart --namespace ntn-operators-system --set crd.enable=false
 > ```
 >
-> Skipping this leaves a new operator running against last release's CRDs; the
-> apiserver silently drops fields the old schema doesn't know, so v0.6+ features
-> that depend on new spec fields (e.g. the runtime NTN push) go quietly inert.
+> Skipping this leaves a new operator running against last release's CRDs. Writes
+> carrying fields the old schema doesn't know are then either **rejected** (strict
+> server-side field validation — the default for `kubectl` 1.25+)
+> or **silently pruned** (lenient validation / older clients), so v0.6+ features
+> that depend on new spec fields (e.g. the runtime NTN push) either fail to apply
+> or go quietly inert.
 > To let Helm own the CRD lifecycle instead, install with `--set crd.enable=true`
 > (the default) and omit `make install` — then `helm upgrade` updates both
 > together.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,12 +101,21 @@ narrowed an `Enum`), CRs already persisted under the newer schema can be
 rejected on their next write, and fields the old schema doesn't know are
 dropped — a silent data loss.
 
-Prefer an **operator-only rollback** that leaves the CRDs forward:
+Prefer an **operator-only rollback** that leaves the CRDs forward. Note that
+`helm rollback` cannot do this: it replays a stored revision's manifests verbatim
+(re-applying that revision's CRD templates) and accepts no `--set`/`--reuse-values`
+(`helm rollback --set …` fails with `unknown flag: --set`). Roll the workload back
+with `helm upgrade` to the **previously released** chart, keeping `crd.enable=false`
+so the CRDs are untouched. Pull the previous version from the published **OCI chart**
+(or a saved `.tgz`) — a local `dist/chart` path ignores `--version` and would just
+re-deploy the *current* sources, not roll anything back:
 
 ```bash
 # CRDs stay at the newer (forward-compatible) schema; only the workload reverts.
-helm rollback ntn-operators <PREVIOUS_REVISION> \
-  --namespace ntn-operators-system --set crd.enable=false
+# --reuse-values preserves the live release config; --set overrides only crd.enable.
+helm upgrade ntn-operators oci://ghcr.io/thc1006/ntn-operators \
+  --version <PREVIOUS_CHART_VERSION> --namespace ntn-operators-system \
+  --reuse-values --set crd.enable=false
 # (Option A / make-install users manage CRDs out-of-band, so their rollback
 #  never touches CRDs either — just roll the operator image.)
 ```

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -161,9 +161,14 @@ networkPolicy:
   ## distinct gNB port in use; set to [] if no NTNCellConfig configures a runtime push.
   gnbPorts:
     - 8001
-  ## Advanced: extra egress rules appended verbatim to spec.egress. Use to
-  ## restrict the Prometheus/gNB reachability to specific namespaces or CIDRs,
-  ## e.g. scope the gNB port to an external RAN subnet:
+  ## Advanced: extra egress rules appended verbatim to spec.egress. NetworkPolicy
+  ## egress rules are additive (OR'd), so these only *add* reachability — they
+  ## cannot narrow the port-only rules above (prometheusPorts/gnbPorts emit
+  ## rules with no `to:`, i.e. those ports to ALL destinations). To CIDR/namespace-
+  ## scope a port, leave it OUT of prometheusPorts/gnbPorts and express the port
+  ## AND its destination together here, so no broad port-only rule exists to OR
+  ## against — e.g. to scope the gNB port to an external RAN subnet set
+  ## `gnbPorts: []` and:
   ##   extraEgress:
   ##     - to:
   ##         - ipBlock:

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -5,17 +5,23 @@ Operational response for the alerts shipped in the chart's `PrometheusRule`
 `--set prometheus.enable=true`). One section per alert:
 **Fires when → Impact → Diagnose → Mitigate → Escalate**.
 
-All alerts are `severity: warning` and namespaced — the alert labels
-(`namespace`, and one of `ephemeris` / `config` / `slice` / `controller`) point
-at the exact CR. Assume `NS=<namespace>` and the operator lives in
-`ntn-operators-system` unless you deploy it elsewhere.
+All alerts are `severity: warning`. Most are namespaced — the labels
+(`namespace`, and one of `ephemeris` / `config` / `slice`) point at the exact CR.
+The exception is `NTNControllerReconcileErrors`, which aggregates
+`sum by (controller)` over `controller_runtime_reconcile_errors_total` (a metric
+with no `namespace` label), so it carries only `controller`. Assume
+`NS=<namespace>` and the operator lives in `ntn-operators-system` unless you
+deploy it elsewhere; the operator Deployment is `<release>-controller-manager`
+(the commands below assume a release named `ntn-operators`).
 
 First moves for any alert:
 
 ```bash
 # Which CR, and what does it say about itself?
 kubectl describe <kind> <name> -n "$NS"     # conditions + Events are the fastest signal
-kubectl logs deploy/ntn-operators-controller-manager -n ntn-operators-system --since=30m | grep -iE 'error|warn'
+# -l is release-independent (deploy/<release>-controller-manager works too).
+# --tail=-1 overrides the selector default of 10 lines; --prefix tags each pod:
+kubectl logs -l control-plane=controller-manager -n ntn-operators-system --tail=-1 --prefix=true --since=30m | grep -iE 'error|warn'
 ```
 
 Metric → alert map:
@@ -50,7 +56,8 @@ dropped sync.
 ```bash
 kubectl describe satelliteephemeris <ephemeris> -n "$NS"
 # Conditions to read:
-#   GPDataFetched=False  → the fetch itself is failing (reason: RateLimited / AuthFailed / FetchFailed)
+#   GPDataFetched=False  → the fetch itself is failing (reason: RateLimited / AuthFailed /
+#                          FetchFailed / FetcherSetupFailed / InsecureURL — full set under NTNGPFetchNotReady)
 #   EphemerisEpochStale=True with the offending NORAD IDs in the message
 #   GPDataParsed / PassesPredicted → whether anything downstream still ran
 ```
@@ -107,9 +114,17 @@ sum by (namespace, config, reason) (increase(ntn_operators_ephemeris_push_errors
 ```bash
 kubectl describe ntncellconfig <config> -n "$NS"
 #   Condition EphemerisPushed (Status/Reason/Message) + Event "EphemerisPushFailed"
-# For ProviderPushFailed, test gNB reachability from a debug pod:
+# For ProviderPushFailed, test gNB reachability AS THE OPERATOR SEES IT: attach an
+# ephemeral debug container to the operator Pod. It shares the Pod's network namespace,
+# so it is governed by the operator's NetworkPolicy — a real test of the operator's egress.
+# (Do NOT `kubectl run` a pod carrying the operator's labels to mimic it: the operator
+#  ReplicaSet would adopt that pod by selector and delete it as an excess replica.)
 ENDPOINT=$(kubectl get ntncellconfig <config> -n "$NS" -o jsonpath='{.spec.provider.remoteControl.endpoint}')
-kubectl run netcheck --rm -it --image=nicolaka/netshoot -n "$NS" -- nc -vz ${ENDPOINT%:*} ${ENDPOINT##*:}
+HOST=${ENDPOINT%:*}; HOST=${HOST#[}; HOST=${HOST%]}   # strip [ ] so [IPv6]:port works with nc
+PORT=${ENDPOINT##*:}
+POD=$(kubectl get pod -n ntn-operators-system -l control-plane=controller-manager \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl debug -n ntn-operators-system -it "$POD" --image=nicolaka/netshoot -- nc -vz "$HOST" "$PORT"
 ```
 
 **Mitigate.**
@@ -258,7 +273,7 @@ Label: `controller`. **Impact:** that controller is not converging CRs to their
 desired state — changes stall. **Diagnose:**
 
 ```bash
-kubectl logs deploy/ntn-operators-controller-manager -n ntn-operators-system --since=20m \
+kubectl logs -l control-plane=controller-manager -n ntn-operators-system --tail=-1 --prefix=true --since=20m \
   | grep -i 'error' | grep '<controller>'
 ```
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -875,8 +875,11 @@ func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
 // epoch is a monotonic 1:1 proxy for the propagated ECEF — each re-propagation
 // yields a new epoch and a new state — so a same-epoch reconcile dedups without
 // hashing the payload. Refreshing epoch/ephemeris/TA is SI-change-free per TS
-// 38.331, and the re-push cadence is bounded by the SatelliteEphemeris
-// re-propagation interval, well under ntn-UlSyncValidityDuration (NR max 240 s).
+// 38.331. The re-push cadence is bounded by the SatelliteEphemeris re-propagation
+// interval (a few minutes) and is NOT guaranteed shorter than ntn-UlSyncValidityDur:
+// that field's enum spans 5..900 s (an earlier "NR max 240 s" note was wrong), so at
+// the low end the UE-side UL-sync validity can lapse between re-pushes — pairing the
+// two is a deployment-sizing concern this cadence does not enforce.
 func runtimeEphemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris, state *ntnv1alpha1.PropagatedState) string {
 	return fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
 		eph.Name, eph.Generation, state.NoradID, state.EpochUnixMs)


### PR DESCRIPTION
## What

Final audit-remediation PR (plan item **H**): docs/runbook + code-comment corrections from the round-2 review of **#202** (netpol/runbook/alert) plus **#204-G4** (3GPP claim). No behavioural code change — the only `.go` edit is a comment.

Each finding was re-verified against current `main` before adopting; two of #202's findings were **excluded because they are already fixed** (F2 push-error counter by #215; F5 never-fetched detection by #218's `gp_fetch_ready`), and two are **code/CI, not docs**, so they are split to **#228** (F7 CI never exercises the NetworkPolicy; the UL-sync validity-vs-cadence semantic).

## Fixes

| Finding | File | Correction |
|---|---|---|
| **F1** (P1) | `RELEASING.md` | `helm rollback … --set crd.enable=false` fails with `unknown flag: --set` (`helm rollback` takes no `--set`/`--reuse-values`). Replaced with `helm upgrade … --version <prev> --set crd.enable=false` for the operator-only, CRDs-forward rollback. |
| **F3** (P2) | `dist/chart/values.yaml` | `extraEgress` help implied it could *restrict* reachability. NetworkPolicy egress rules are additive (OR'd), so `extraEgress` only *adds*; to CIDR/namespace-scope a port you must leave it out of `prometheusPorts`/`gnbPorts` (those emit port-only, all-destination rules) and express port+scope together in `extraEgress`. |
| **F4** (P2) | `docs/runbooks/alerts.md` | `netcheck` debug pod ran in `$NS` (the CR namespace) and carries none of the operator's pod labels, so it is **not** selected by the operator's NetworkPolicy — a green `nc -vz` proved cluster reachability, not operator egress. Now runs in `ntn-operators-system` with an explicit caveat + how to bind it to the policy. |
| **F6-tail** (P2) | `docs/runbooks/alerts.md` | `GPDataFetched=False` reason list in the EpochStale section was incomplete; added `FetcherSetupFailed`/`InsecureURL` (full set already under `NTNGPFetchNotReady`). *(Headline "never produces AuthFailed" was refuted — it does; only the omitted-reasons tail stood.)* |
| **F8** (P3) | `README.md` | "apiserver silently drops fields the old schema doesn't know" is over-absolute: strict server-side field validation (kubectl 1.25+ default, typed clients) **rejects** unknown fields; silent pruning is only the lenient path. Reworded to cover both. |
| **F9** (P3) | `docs/runbooks/alerts.md` | "All alerts are … namespaced" is contradicted by `NTNControllerReconcileErrors`, which aggregates `sum by (controller)` over a metric with no `namespace` label. Corrected. |
| **F10** (P3) | `docs/runbooks/alerts.md` | Hard-coded `deploy/ntn-operators-controller-manager` is correct only for a release literally named `ntn-operators`. Switched the two log commands to a release-independent `-l control-plane=controller-manager` selector + noted the Deployment name. |
| **#204-G4** | `internal/controller/ntncellconfig_controller.go` | `runtimeEphemerisPushMarker` comment claimed "NR max 240 s" (the `ntnUlSyncValidityDur` enum caps at **900 s**) and that the re-push cadence is "well under" the validity — false for the low end of the enum (5 s vs a minute-scale cadence). Corrected; the deeper cadence-vs-validity sizing question is tracked in #228. |

## Verification

`gofmt` clean · `go vet` clean · `go build ./...` clean · `golangci-lint` (fresh cache) **0 issues** · `helm lint dist/chart` passes. Comment-only Go change → no test/CRD-regen needed.

## Deferred → #228

- **F7** — CI (`test-chart.yml`) deploys with `networkPolicy.enable` unset, and `helm lint` doesn't exercise `if`-gated templates, so the egress policy is never validated end-to-end.
- **G4 semantic** — whether the operator should clamp/warn when the re-push cadence exceeds a small `ntnUlSyncValidityDur`, or document it as a deployment-sizing responsibility (needs a TS 38.331 SIB19 epochTime/validity read).
