### PR TITLE
fix(failover): persist anti-flap min-dwell across restart + bound trigger admission to finite values (#220 H1/C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,14 +80,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   valid — only the leading `-` was removed). The bound is on the parsed **float64** value
   (the pass pipeline is float64), so a literal within ~half a ULP above 90 rounds to 90 and
   is accepted; `NaN`/`Inf` are rejected (#201-P3).
-- **NTNSlice anti-flap minimum-dwell now survives a controller restart or leader-election
-  handoff.** The post-switchback min-terrestrial-dwell clock (`LastSwitchback`) was in-memory
-  only, so a handoff reset it to "dwell satisfied" and a re-degradation within the dwell window
-  could fail over earlier than intended. It is now mirrored to a new
-  `NTNSlice.status.lastSwitchbackTime` and reloaded when the in-memory clock is absent (a cold
-  cache after restart). The other two flap clocks stay in-memory (their loss only delays a
-  switch, never advances one). This matters more now that rolling updates hand leadership over
-  routinely (#220 H1).
+- **NTNSlice anti-flap minimum-dwell survives a controller restart or leader-election handoff.**
+  The post-switchback min-terrestrial-dwell clock (`LastSwitchback`) was in-memory only, so a
+  handoff reset it to "dwell satisfied" and a re-degradation within the dwell window could fail
+  over earlier than intended. It is now mirrored to a new `NTNSlice.status.lastSwitchbackTime`
+  and **monotonically merged** with the in-memory clock: status is adopted when it is newer (a
+  cold cache after restart), and repaired when it is behind (self-healing a prior status write
+  that failed). A status value dated in the future (node clock skew / rollback) is ignored so it
+  cannot lock a degraded terrestrial. The other two flap clocks stay in-memory (their loss only
+  delays a switch, never advances one). This matters more now that rolling updates hand
+  leadership over routinely. **Scope:** durability holds once this version has recorded at least
+  one quality-driven switchback; a switchback recorded only by an older (pre-field) version is
+  not recoverable, and min-dwell accuracy across a handoff assumes the controller nodes have
+  synchronised clocks (#220 H1).
 
 ### Fixed
 
@@ -250,9 +255,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`failoverPolicy.triggers` validation is tightened to bounded-magnitude numbers.** The trigger
   value now admits at most 10 integer + 10 fraction digits and an optional 2-digit exponent, so
   overflowing forms like `1e9999` are rejected at admission. Realistic RSRP/latency/packet-loss
-  thresholds are unaffected. Because of CRD ratcheting (min K8s 1.31), an existing NTNSlice using
-  such an exotic value is not re-validated on an unrelated edit; the runtime already fail-closes
-  it. Correct any such trigger before editing `failoverPolicy.triggers`.
+  thresholds are unaffected. The CEL rule is scoped to the whole `failoverPolicy` object, so with
+  CRD ratcheting (min K8s 1.31) an existing NTNSlice carrying such an exotic value is re-validated
+  (and rejected) as soon as **any** part of `failoverPolicy` is edited — including
+  `switchbackDelay` — while edits outside `failoverPolicy` are ratcheted through. The runtime
+  already fail-closes the value regardless. Correct any such trigger before editing
+  `failoverPolicy`.
 
 ## [0.7.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   valid — only the leading `-` was removed). The bound is on the parsed **float64** value
   (the pass pipeline is float64), so a literal within ~half a ULP above 90 rounds to 90 and
   is accepted; `NaN`/`Inf` are rejected (#201-P3).
+- **NTNSlice anti-flap minimum-dwell now survives a controller restart or leader-election
+  handoff.** The post-switchback min-terrestrial-dwell clock (`LastSwitchback`) was in-memory
+  only, so a handoff reset it to "dwell satisfied" and a re-degradation within the dwell window
+  could fail over earlier than intended. It is now mirrored to a new
+  `NTNSlice.status.lastSwitchbackTime` and reloaded when the in-memory clock is absent (a cold
+  cache after restart). The other two flap clocks stay in-memory (their loss only delays a
+  switch, never advances one). This matters more now that rolling updates hand leadership over
+  routinely (#220 H1).
 
 ### Fixed
 
@@ -200,6 +208,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field validation rejects them). The `runtimeEphemerisPushMarker` comment no
   longer claims "NR max 240 s" (the `ntnUlSyncValidityDur` enum caps at 900 s)
   or that the re-push cadence is always under `ntn-UlSyncValidityDur`.
+- **The `failoverPolicy.triggers` admission rule rejects non-finite / overflowing values.** The
+  value regex now bounds the digit counts (≤10 integer, ≤10 fraction, optional ≤2-digit
+  exponent), so a form like `latency > 1e9999` — which parses to `+Inf` — is rejected at
+  admission instead of only at runtime (`ParseTrigger` already fail-closes `NaN`/`Inf`). The
+  admission rule now truly enforces the "finite number" its message promises and stays in
+  lockstep with the runtime parse (the `trigger_cel_test` agreement corpus now covers `1e9999`)
+  (#220 C4).
 
 ### Upgrade notes
 
@@ -232,6 +247,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check refuses to use the value, clears `status.nextPassWindows`, and reports
   `PassesPredicted=False`/`PredictionFailed`. Correct any out-of-range `minElevation` before
   upgrading (the default "10" is unaffected).
+- **`failoverPolicy.triggers` validation is tightened to bounded-magnitude numbers.** The trigger
+  value now admits at most 10 integer + 10 fraction digits and an optional 2-digit exponent, so
+  overflowing forms like `1e9999` are rejected at admission. Realistic RSRP/latency/packet-loss
+  thresholds are unaffected. Because of CRD ratcheting (min K8s 1.31), an existing NTNSlice using
+  such an exotic value is not re-validated on an unrelated edit; the runtime already fail-closes
+  it. Correct any such trigger before editing `failoverPolicy.triggers`.
 
 ## [0.7.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **after** the durable status write succeeds (the same "commit side-effects once status is
   durable" discipline as the failover counter/event), so a switchback whose write fails cannot
   leave a speculative timestamp that a later pass-ended forced switchback could launder into a
-  bogus dwell. A future-dated status value (node clock skew / rollback) is ignored by the reload
-  and healed by the next real switchback, so it cannot lock a degraded terrestrial. The other two
+  bogus dwell. A future-dated status value (a backward node-clock step or an external edit; the
+  controller only ever writes values `<= now`) is **cleared durably** when the reload observes it,
+  not merely ignored, so it cannot silently become valid history once the wall clock passes it and
+  block a legitimate failover with a ghost dwell. The in-memory anti-flap cache is also keyed by
+  object **UID** as well as name, so a same-name NTNSlice recreated with a new UID (a delete+create
+  the workqueue coalesced into one reconcile, hiding the intervening NotFound) does not inherit the
+  deleted object's counters or dwell clock. The other two
   flap clocks stay in-memory (their loss only delays a switch, never advances one). This matters
   more now that rolling updates hand leadership over routinely. **Scope:** durability holds once
   this version has recorded at least one quality-driven switchback; a switchback recorded only by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,14 +85,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handoff reset it to "dwell satisfied" and a re-degradation within the dwell window could fail
   over earlier than intended. It is now mirrored to a new `NTNSlice.status.lastSwitchbackTime`
   and **monotonically merged** with the in-memory clock: status is adopted when it is newer (a
-  cold cache after restart), and repaired when it is behind (self-healing a prior status write
-  that failed). A status value dated in the future (node clock skew / rollback) is ignored so it
-  cannot lock a degraded terrestrial. The other two flap clocks stay in-memory (their loss only
-  delays a switch, never advances one). This matters more now that rolling updates hand
-  leadership over routinely. **Scope:** durability holds once this version has recorded at least
-  one quality-driven switchback; a switchback recorded only by an older (pre-field) version is
-  not recoverable, and min-dwell accuracy across a handoff assumes the controller nodes have
-  synchronised clocks (#220 H1).
+  cold cache after restart), and repaired when it is behind. The in-memory clock is committed only
+  **after** the durable status write succeeds (the same "commit side-effects once status is
+  durable" discipline as the failover counter/event), so a switchback whose write fails cannot
+  leave a speculative timestamp that a later pass-ended forced switchback could launder into a
+  bogus dwell. A future-dated status value (node clock skew / rollback) is ignored by the reload
+  and healed by the next real switchback, so it cannot lock a degraded terrestrial. The other two
+  flap clocks stay in-memory (their loss only delays a switch, never advances one). This matters
+  more now that rolling updates hand leadership over routinely. **Scope:** durability holds once
+  this version has recorded at least one quality-driven switchback; a switchback recorded only by
+  an older (pre-field) version is not recoverable, and min-dwell accuracy across a handoff assumes
+  the controller nodes have synchronised clocks (#220 H1).
 
 ### Fixed
 
@@ -261,6 +264,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `switchbackDelay` — while edits outside `failoverPolicy` are ratcheted through. The runtime
   already fail-closes the value regardless. Correct any such trigger before editing
   `failoverPolicy`.
+- **`NTNSlice.status.lastSwitchbackTime` may be dropped on a downgrade.** A controller version
+  that predates this field does a full `/status` PUT with a Go struct that does not know the
+  field, so rolling the controller back can remove it. min-dwell durability is therefore not
+  guaranteed across a downgrade — the next quality-driven switchback on the (re-upgraded) new
+  version re-establishes it. Forward upgrades are unaffected.
 
 ## [0.7.0] - 2026-07-12
 

--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -176,7 +176,7 @@ type SatellitePathSpec struct {
 // floats, trailing-dot/underscore numbers, non-ASCII spaces) never used for
 // thresholds — the divergence test in pkg/slice enumerates them. maxItems=10
 // + maxLength keep the CEL cost within budget.
-// +kubebuilder:validation:XValidation:rule="self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)? *$'))",message="each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite number (e.g. 'rsrp < -120')"
+// +kubebuilder:validation:XValidation:rule="self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})? *$'))",message="each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite decimal (up to 10 integer and 10 fraction digits with an optional 2-digit exponent, e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected here and, defensively, at runtime"
 type FailoverPolicy struct {
 	// triggers defines conditions that initiate failover (OR logic).
 	// Format: "metric operator value" (e.g., "rsrp < -120").
@@ -289,6 +289,15 @@ type NTNSliceStatus struct {
 	// lastFailover is the timestamp of the last failover event.
 	// +optional
 	LastFailover *metav1.Time `json:"lastFailover,omitempty"`
+
+	// lastSwitchbackTime is when the slice last switched back to terrestrial from an
+	// available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+	// minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+	// the in-memory flap clock resets on handoff, and without this a re-degradation within
+	// the dwell window could switch to satellite earlier than the dwell intended. The other
+	// flap clocks stay in-memory (losing them only delays a switch, never advances one).
+	// +optional
+	LastSwitchbackTime *metav1.Time `json:"lastSwitchbackTime,omitempty"`
 
 	// failoverCount is the total number of failover events since creation.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -768,6 +768,10 @@ func (in *NTNSliceStatus) DeepCopyInto(out *NTNSliceStatus) {
 		in, out := &in.LastFailover, &out.LastFailover
 		*out = (*in).DeepCopy()
 	}
+	if in.LastSwitchbackTime != nil {
+		in, out := &in.LastSwitchbackTime, &out.LastSwitchbackTime
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -154,10 +154,12 @@ spec:
                 x-kubernetes-validations:
                 - message: each failoverPolicy.trigger must be 'metric op value' where
                     metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss,
-                    op is one of < <= > >=, and value is a finite number (e.g. 'rsrp
-                    < -120')
+                    op is one of < <= > >=, and value is a finite decimal (up to 10
+                    integer and 10 fraction digits with an optional 2-digit exponent,
+                    e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected
+                    here and, defensively, at runtime
                   rule: self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss)
-                    *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?
+                    *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})?
                     *$'))
               metricsSource:
                 description: |-
@@ -430,6 +432,16 @@ spec:
                 type: integer
               lastFailover:
                 description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              lastSwitchbackTime:
+                description: |-
+                  lastSwitchbackTime is when the slice last switched back to terrestrial from an
+                  available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+                  minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+                  the in-memory flap clock resets on handoff, and without this a re-degradation within
+                  the dwell window could switch to satellite earlier than the dwell intended. The other
+                  flap clocks stay in-memory (losing them only delays a switch, never advances one).
                 format: date-time
                 type: string
               sessionCount:

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -154,10 +154,12 @@ spec:
                 x-kubernetes-validations:
                 - message: each failoverPolicy.trigger must be 'metric op value' where
                     metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss,
-                    op is one of < <= > >=, and value is a finite number (e.g. 'rsrp
-                    < -120')
+                    op is one of < <= > >=, and value is a finite decimal (up to 10
+                    integer and 10 fraction digits with an optional 2-digit exponent,
+                    e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected
+                    here and, defensively, at runtime
                   rule: self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss)
-                    *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?
+                    *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})?
                     *$'))
               metricsSource:
                 description: |-
@@ -430,6 +432,16 @@ spec:
                 type: integer
               lastFailover:
                 description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              lastSwitchbackTime:
+                description: |-
+                  lastSwitchbackTime is when the slice last switched back to terrestrial from an
+                  available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+                  minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+                  the in-memory flap clock resets on handoff, and without this a re-degradation within
+                  the dwell window could switch to satellite earlier than the dwell intended. The other
+                  flap clocks stay in-memory (losing them only delays a switch, never advances one).
                 format: date-time
                 type: string
               sessionCount:

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -157,10 +157,12 @@ spec:
                 x-kubernetes-validations:
                 - message: each failoverPolicy.trigger must be 'metric op value' where
                     metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss,
-                    op is one of < <= > >=, and value is a finite number (e.g. 'rsrp
-                    < -120')
+                    op is one of < <= > >=, and value is a finite decimal (up to 10
+                    integer and 10 fraction digits with an optional 2-digit exponent,
+                    e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected
+                    here and, defensively, at runtime
                   rule: self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss)
-                    *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?
+                    *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})?
                     *$'))
               metricsSource:
                 description: |-
@@ -433,6 +435,16 @@ spec:
                 type: integer
               lastFailover:
                 description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              lastSwitchbackTime:
+                description: |-
+                  lastSwitchbackTime is when the slice last switched back to terrestrial from an
+                  available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+                  minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+                  the in-memory flap clock resets on handoff, and without this a re-degradation within
+                  the dwell window could switch to satellite earlier than the dwell intended. The other
+                  flap clocks stay in-memory (losing them only delays a switch, never advances one).
                 format: date-time
                 type: string
               sessionCount:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2315,7 +2315,7 @@ with terrestrial-satellite failover policy.
         <td>
           failoverPolicy defines when and how to switch between paths.<br/>
           <br/>
-            <i>Validations</i>:<li>self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)? *$')): each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite number (e.g. 'rsrp < -120')</li>
+            <i>Validations</i>:<li>self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})? *$')): each failoverPolicy.trigger must be 'metric op value' where metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss, op is one of < <= > >=, and value is a finite decimal (up to 10 integer and 10 fraction digits with an optional 2-digit exponent, e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected here and, defensively, at runtime</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -2892,6 +2892,20 @@ NTNSliceStatus defines the observed state of NTNSlice.
         <td>string</td>
         <td>
           lastFailover is the timestamp of the last failover event.<br/>
+          <br/>
+            <i>Format</i>: date-time<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>lastSwitchbackTime</b></td>
+        <td>string</td>
+        <td>
+          lastSwitchbackTime is when the slice last switched back to terrestrial from an
+available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+the in-memory flap clock resets on handoff, and without this a re-degradation within
+the dwell window could switch to satellite earlier than the dwell intended. The other
+flap clocks stay in-memory (losing them only delays a switch, never advances one).<br/>
           <br/>
             <i>Format</i>: date-time<br/>
         </td>

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -101,10 +101,12 @@ type NTNSliceReconciler struct {
 	// the recovery clock are intentionally NOT persisted: losing them on a restart or
 	// leader-election handoff only re-requires confirmation before the next switch — a
 	// DELAY (safe), never a spurious switch. The min-dwell clock (LastSwitchback) IS the
-	// exception — its loss ADVANCES a switch — so it is mirrored to
-	// .status.lastSwitchbackTime and reloaded here when the in-memory entry is absent
-	// (a cold cache after restart), so min-dwell survives a handoff. Guarded by flapMu;
-	// entries are released in handleSliceFinalizer on CR deletion so the map cannot leak.
+	// exception — its loss ADVANCES a switch — so it is mirrored to .status.lastSwitchbackTime
+	// and monotonically merged with it (adopt status when it is newer; repair status when it is
+	// behind). min-dwell therefore survives a restart/handoff ONCE this version has durably
+	// recorded at least one quality-driven switchback; a switchback recorded only by a pre-field
+	// (older) version is not recoverable. Guarded by flapMu; entries are released in
+	// handleSliceFinalizer on CR deletion so the map cannot leak.
 	flapMu    sync.Mutex
 	flapState map[types.NamespacedName]slice.AntiFlapState
 }
@@ -126,23 +128,36 @@ func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, st slice.A
 	r.flapState[key] = st
 }
 
-// seedLastSwitchbackFromStatus reloads the min-dwell clock from status when the in-memory
-// entry is absent (a cold cache after a restart or leader-election handoff). Without it, a
-// lost LastSwitchback reads as "dwell already satisfied" and a re-degradation within the
-// dwell window could fail over earlier than min-dwell intended. Only this clock is durable;
-// the other two are safe to lose (their loss only DELAYS a switch).
-func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(af *slice.AntiFlapState, ns *ntnv1alpha1.NTNSlice) {
-	if af.LastSwitchback.IsZero() && ns.Status.LastSwitchbackTime != nil {
-		af.LastSwitchback = ns.Status.LastSwitchbackTime.Time
+// seedLastSwitchbackFromStatus does a monotonic merge of the durable min-dwell clock into the
+// in-memory one: it adopts status.lastSwitchbackTime whenever that is NEWER than the in-memory
+// value — a cold cache after a restart/leader handoff (memory zero), or memory that lagged a
+// durable write. It never moves the clock backwards, and it ignores a status value dated in the
+// FUTURE (clock skew across nodes, or a rollback) so a bad timestamp cannot lock terrestrial
+// indefinitely. Only this clock is durable; the other two are safe to lose (their loss only
+// DELAYS a switch).
+func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(
+	af *slice.AntiFlapState, ns *ntnv1alpha1.NTNSlice, now time.Time,
+) {
+	p := ns.Status.LastSwitchbackTime
+	if p == nil || !p.After(af.LastSwitchback) || p.After(now) {
+		return
 	}
+	af.LastSwitchback = p.Time
 }
 
-// persistLastSwitchbackToStatus mirrors the min-dwell clock to status ONLY when it changes
-// (a new quality-driven switchback this reconcile), so it adds no status-write churn — a
-// switchback already writes status this cycle, and a steady reconcile leaves it untouched.
-func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, prev, next time.Time) {
-	if !next.Equal(prev) {
-		ns.Status.LastSwitchbackTime = &metav1.Time{Time: next}
+// persistLastSwitchbackToStatus mirrors the in-memory min-dwell clock into status whenever the
+// durable value is BEHIND memory (nil, or an older second). It compares monotonically at second
+// granularity — metav1.Time serialises whole seconds while memory keeps sub-second precision, so
+// a raw After() would rewrite the same second every reconcile. Because it self-heals from the
+// durable value (not from "did memory change this cycle"), a Status().Update() that failed on an
+// earlier switchback is repaired on any later reconcile; the write rides the reconcile's existing
+// (unconditional) status update, so it adds no extra API request.
+func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, latest time.Time) {
+	if latest.IsZero() {
+		return
+	}
+	if p := ns.Status.LastSwitchbackTime; p == nil || latest.Truncate(time.Second).After(p.Time) {
+		ns.Status.LastSwitchbackTime = &metav1.Time{Time: latest}
 	}
 }
 
@@ -342,7 +357,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		flapKey := client.ObjectKeyFromObject(ns)
 		af := r.loadFlapState(flapKey)
-		r.seedLastSwitchbackFromStatus(&af, ns)
+		r.seedLastSwitchbackFromStatus(&af, ns, now)
 		var newFlap slice.AntiFlapState
 		result, newFlap = slice.EvaluateFailoverWithAntiFlap(
 			ctx,
@@ -357,7 +372,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			af,
 		)
 		r.storeFlapState(flapKey, newFlap)
-		r.persistLastSwitchbackToStatus(ns, af.LastSwitchback, newFlap.LastSwitchback)
+		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback)
 	default:
 		// Metrics unreliable but satellite availability known: fail static —
 		// EvaluateSafeHold holds the current path yet still honors the orbital

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -145,18 +145,19 @@ func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(
 	af.LastSwitchback = p.Time
 }
 
-// persistLastSwitchbackToStatus mirrors the in-memory min-dwell clock into status whenever the
-// durable value is BEHIND memory (nil, or an older second). It compares monotonically at second
-// granularity — metav1.Time serialises whole seconds while memory keeps sub-second precision, so
-// a raw After() would rewrite the same second every reconcile. Because it self-heals from the
-// durable value (not from "did memory change this cycle"), a Status().Update() that failed on an
-// earlier switchback is repaired on any later reconcile; the write rides the reconcile's existing
-// (unconditional) status update, so it adds no extra API request.
-func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, latest time.Time) {
+// persistLastSwitchbackToStatus mirrors the in-memory min-dwell clock into status when the durable
+// value is BEHIND memory (nil, or an older second) OR is implausibly dated in the FUTURE. It
+// compares at second granularity — metav1.Time serialises whole seconds while memory keeps
+// sub-second precision, so a raw After() would rewrite the same second every reconcile. The
+// future case is HEALED here (overwritten by the current value): the seed ignores a future
+// timestamp, so without this a real switchback could never displace a poisoned future value and
+// durability would stay broken until wall-clock caught up. The write rides the reconcile's
+// existing (unconditional) status update, so it adds no extra API request.
+func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, latest, now time.Time) {
 	if latest.IsZero() {
 		return
 	}
-	if p := ns.Status.LastSwitchbackTime; p == nil || latest.Truncate(time.Second).After(p.Time) {
+	if p := ns.Status.LastSwitchbackTime; p == nil || latest.Truncate(time.Second).After(p.Time) || p.After(now) {
 		ns.Status.LastSwitchbackTime = &metav1.Time{Time: latest}
 	}
 }
@@ -232,6 +233,11 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// lazy default provider still holds the cache/series, so guarding on
 			// the raw field leaked the stale series (#183). No-op if no entry.
 			r.readerProvider().Evict(req.NamespacedName)
+			// Also drop the in-memory anti-flap state. The finalizer normally does this,
+			// but a force-deletion (finalizer bypassed) or namespace purge reaches NotFound
+			// without it — otherwise a same-name NTNSlice recreated (new UID) before a
+			// controller restart could inherit the deleted object's LastSwitchback.
+			r.dropFlapState(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -312,6 +318,14 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	var result slice.FailoverResult
+	// pendingFlap/pendingFlapKey defer the in-memory anti-flap commit until AFTER the Step-8
+	// status write succeeds — the same "commit side-effects only once the status is durable"
+	// discipline as the FailoverTotal counter and decision event below. Committing memory before
+	// the durable write would leave a SPECULATIVE LastSwitchback (from a switchback whose status
+	// write failed) that a later pass-ended forced switchback could launder into durable status
+	// as a dwell clock for a hand-back that never actually happened.
+	var pendingFlap *slice.AntiFlapState
+	var pendingFlapKey types.NamespacedName
 	switch {
 	case !satelliteKnown:
 		// I-13: satellite availability is unknown (transient ephemeris read error).
@@ -371,8 +385,8 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			afCfg,
 			af,
 		)
-		r.storeFlapState(flapKey, newFlap)
-		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback)
+		pendingFlap, pendingFlapKey = &newFlap, flapKey
+		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback, now)
 	default:
 		// Metrics unreliable but satellite availability known: fail static —
 		// EvaluateSafeHold holds the current path yet still honors the orbital
@@ -455,6 +469,15 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Step 8: Update status.
 	if err := r.Status().Update(ctx, ns); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Commit the anti-flap state to shared memory ONLY now that the transition is durable. A
+	// failed/stale status write therefore never leaves a speculative LastSwitchback in memory,
+	// so a subsequent forced switchback cannot persist a dwell clock for a hand-back that was
+	// never durably recorded. Under-counting a confirmation/recovery sample on a dropped write
+	// only DELAYS the next transition (fail-safe), matching the anti-flap design.
+	if pendingFlap != nil {
+		r.storeFlapState(pendingFlapKey, *pendingFlap)
 	}
 
 	// Emit the failover counter only after the status write persisted, so a

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -108,24 +108,42 @@ type NTNSliceReconciler struct {
 	// (older) version is not recoverable. Guarded by flapMu; entries are released in
 	// handleSliceFinalizer on CR deletion so the map cannot leak.
 	flapMu    sync.Mutex
-	flapState map[types.NamespacedName]slice.AntiFlapState
+	flapState map[types.NamespacedName]flapStateEntry
 }
 
-// loadFlapState returns the anti-flap state for a slice (zero value if absent).
-func (r *NTNSliceReconciler) loadFlapState(key types.NamespacedName) slice.AntiFlapState {
+// flapStateEntry pairs a slice's anti-flap state with the UID of the object it belongs to. A
+// same-name NTNSlice recreated with a NEW UID must not inherit the deleted object's counters or
+// min-dwell clock. The NotFound and finalizer cleanups usually drop the old entry first, but a
+// force-deletion (finalizer bypassed) whose DELETE the workqueue coalesces with the recreate's
+// CREATE is delivered as a single reconcile of the new object — the controller never observes the
+// intervening NotFound. Keying on UID as well as name closes that gap regardless of the cleanups.
+type flapStateEntry struct {
+	uid   types.UID
+	state slice.AntiFlapState
+}
+
+// loadFlapState returns the anti-flap state for the object identified by (key, uid), or the zero
+// value when no entry exists OR the stored entry belongs to a different object identity (a stale
+// entry left by a same-name predecessor, which is evicted here).
+func (r *NTNSliceReconciler) loadFlapState(key types.NamespacedName, uid types.UID) slice.AntiFlapState {
 	r.flapMu.Lock()
 	defer r.flapMu.Unlock()
-	return r.flapState[key]
+	entry, ok := r.flapState[key]
+	if !ok || entry.uid != uid {
+		delete(r.flapState, key)
+		return slice.AntiFlapState{}
+	}
+	return entry.state
 }
 
-// storeFlapState persists the updated anti-flap state for a slice.
-func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, st slice.AntiFlapState) {
+// storeFlapState persists the updated anti-flap state for the object identified by (key, uid).
+func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, uid types.UID, st slice.AntiFlapState) {
 	r.flapMu.Lock()
 	defer r.flapMu.Unlock()
 	if r.flapState == nil {
-		r.flapState = make(map[types.NamespacedName]slice.AntiFlapState)
+		r.flapState = make(map[types.NamespacedName]flapStateEntry)
 	}
-	r.flapState[key] = st
+	r.flapState[key] = flapStateEntry{uid: uid, state: st}
 }
 
 // seedLastSwitchbackFromStatus does a monotonic merge of the durable min-dwell clock into the
@@ -139,7 +157,22 @@ func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(
 	af *slice.AntiFlapState, ns *ntnv1alpha1.NTNSlice, now time.Time,
 ) {
 	p := ns.Status.LastSwitchbackTime
-	if p == nil || !p.After(af.LastSwitchback) || p.After(now) {
+	if p == nil {
+		return
+	}
+	if p.After(now) {
+		// A future-dated durable value is untrustworthy: the controller only ever writes values
+		// <= now, so a future one means a backward clock step (NTP, VM migration) or an external
+		// status edit. Refuse to enforce it AND clear it durably. Merely ignoring it (the old
+		// behaviour) left it in status to become valid "history" once the wall clock passed it,
+		// where the next reconcile would seed it as a min-dwell clock and block a legitimate
+		// failover with a ghost dwell. Clearing is fail-open, consistent with the anti-flap design;
+		// the nil write rides the reconcile's existing status update, and a real switchback simply
+		// re-persists a fresh value.
+		ns.Status.LastSwitchbackTime = nil
+		return
+	}
+	if !p.After(af.LastSwitchback) {
 		return
 	}
 	af.LastSwitchback = p.Time
@@ -148,11 +181,11 @@ func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(
 // persistLastSwitchbackToStatus mirrors the in-memory min-dwell clock into status when the durable
 // value is BEHIND memory (nil, or an older second) OR is implausibly dated in the FUTURE. It
 // compares at second granularity — metav1.Time serialises whole seconds while memory keeps
-// sub-second precision, so a raw After() would rewrite the same second every reconcile. The
-// future case is HEALED here (overwritten by the current value): the seed ignores a future
-// timestamp, so without this a real switchback could never displace a poisoned future value and
-// durability would stay broken until wall-clock caught up. The write rides the reconcile's
-// existing (unconditional) status update, so it adds no extra API request.
+// sub-second precision, so a raw After() would rewrite the same second every reconcile. The future
+// case is a secondary guard: the seed already clears a future-dated value durably before this runs,
+// so p is normally not in the future here; if one ever were, it is overwritten by the current
+// in-memory value. The write rides the reconcile's existing (unconditional) status update, so it
+// adds no extra API request.
 func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, latest, now time.Time) {
 	if latest.IsZero() {
 		return
@@ -172,13 +205,13 @@ func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSl
 func (r *NTNSliceReconciler) resetRecoveryStreak(key types.NamespacedName) {
 	r.flapMu.Lock()
 	defer r.flapMu.Unlock()
-	st, ok := r.flapState[key]
-	if !ok || (st.RecoveryObservedAt.IsZero() && st.ConsecutiveDegraded == 0) {
+	entry, ok := r.flapState[key]
+	if !ok || (entry.state.RecoveryObservedAt.IsZero() && entry.state.ConsecutiveDegraded == 0) {
 		return // nothing tracked, or already clear — do not create a spurious entry
 	}
-	st.RecoveryObservedAt = time.Time{}
-	st.ConsecutiveDegraded = 0
-	r.flapState[key] = st
+	entry.state.RecoveryObservedAt = time.Time{}
+	entry.state.ConsecutiveDegraded = 0
+	r.flapState[key] = entry // preserves the entry's UID
 }
 
 // dropFlapState releases a slice's anti-flap state (on deletion).
@@ -326,6 +359,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// as a dwell clock for a hand-back that never actually happened.
 	var pendingFlap *slice.AntiFlapState
 	var pendingFlapKey types.NamespacedName
+	var pendingFlapUID types.UID
 	switch {
 	case !satelliteKnown:
 		// I-13: satellite availability is unknown (transient ephemeris read error).
@@ -370,7 +404,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		flapKey := client.ObjectKeyFromObject(ns)
-		af := r.loadFlapState(flapKey)
+		af := r.loadFlapState(flapKey, ns.UID)
 		r.seedLastSwitchbackFromStatus(&af, ns, now)
 		var newFlap slice.AntiFlapState
 		result, newFlap = slice.EvaluateFailoverWithAntiFlap(
@@ -385,7 +419,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			afCfg,
 			af,
 		)
-		pendingFlap, pendingFlapKey = &newFlap, flapKey
+		pendingFlap, pendingFlapKey, pendingFlapUID = &newFlap, flapKey, ns.UID
 		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback, now)
 	default:
 		// Metrics unreliable but satellite availability known: fail static —
@@ -477,7 +511,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// never durably recorded. Under-counting a confirmation/recovery sample on a dropped write
 	// only DELAYS the next transition (fail-safe), matching the anti-flap design.
 	if pendingFlap != nil {
-		r.storeFlapState(pendingFlapKey, *pendingFlap)
+		r.storeFlapState(pendingFlapKey, pendingFlapUID, *pendingFlap)
 	}
 
 	// Emit the failover counter only after the status write persisted, so a

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -97,12 +97,14 @@ type NTNSliceReconciler struct {
 	defaultProvider     metricsReaderProvider
 
 	// flapState holds per-slice in-memory anti-flap state (the consecutive-degraded
-	// counter and the recovery/switchback clocks). It is intentionally NOT persisted
-	// to .status: per the Kubernetes API convention such transient history is
-	// best-effort, and losing it on a restart or leader-election handoff only
-	// re-requires confirmation before the next switch — a DELAY (safe), never a
-	// spurious switch. Guarded by flapMu; entries are released in
-	// handleSliceFinalizer on CR deletion so the map cannot leak.
+	// counter and the recovery/switchback clocks). The consecutive-degraded counter and
+	// the recovery clock are intentionally NOT persisted: losing them on a restart or
+	// leader-election handoff only re-requires confirmation before the next switch — a
+	// DELAY (safe), never a spurious switch. The min-dwell clock (LastSwitchback) IS the
+	// exception — its loss ADVANCES a switch — so it is mirrored to
+	// .status.lastSwitchbackTime and reloaded here when the in-memory entry is absent
+	// (a cold cache after restart), so min-dwell survives a handoff. Guarded by flapMu;
+	// entries are released in handleSliceFinalizer on CR deletion so the map cannot leak.
 	flapMu    sync.Mutex
 	flapState map[types.NamespacedName]slice.AntiFlapState
 }
@@ -122,6 +124,26 @@ func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, st slice.A
 		r.flapState = make(map[types.NamespacedName]slice.AntiFlapState)
 	}
 	r.flapState[key] = st
+}
+
+// seedLastSwitchbackFromStatus reloads the min-dwell clock from status when the in-memory
+// entry is absent (a cold cache after a restart or leader-election handoff). Without it, a
+// lost LastSwitchback reads as "dwell already satisfied" and a re-degradation within the
+// dwell window could fail over earlier than min-dwell intended. Only this clock is durable;
+// the other two are safe to lose (their loss only DELAYS a switch).
+func (r *NTNSliceReconciler) seedLastSwitchbackFromStatus(af *slice.AntiFlapState, ns *ntnv1alpha1.NTNSlice) {
+	if af.LastSwitchback.IsZero() && ns.Status.LastSwitchbackTime != nil {
+		af.LastSwitchback = ns.Status.LastSwitchbackTime.Time
+	}
+}
+
+// persistLastSwitchbackToStatus mirrors the min-dwell clock to status ONLY when it changes
+// (a new quality-driven switchback this reconcile), so it adds no status-write churn — a
+// switchback already writes status this cycle, and a steady reconcile leaves it untouched.
+func (r *NTNSliceReconciler) persistLastSwitchbackToStatus(ns *ntnv1alpha1.NTNSlice, prev, next time.Time) {
+	if !next.Equal(prev) {
+		ns.Status.LastSwitchbackTime = &metav1.Time{Time: next}
+	}
 }
 
 // resetRecoveryStreak clears the confirmation and recovery clocks for a slice while
@@ -319,6 +341,8 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		flapKey := client.ObjectKeyFromObject(ns)
+		af := r.loadFlapState(flapKey)
+		r.seedLastSwitchbackFromStatus(&af, ns)
 		var newFlap slice.AntiFlapState
 		result, newFlap = slice.EvaluateFailoverWithAntiFlap(
 			ctx,
@@ -330,9 +354,10 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			now,
 			hysteresisMargin,
 			afCfg,
-			r.loadFlapState(flapKey),
+			af,
 		)
 		r.storeFlapState(flapKey, newFlap)
+		r.persistLastSwitchbackToStatus(ns, af.LastSwitchback, newFlap.LastSwitchback)
 	default:
 		// Metrics unreliable but satellite availability known: fail static —
 		// EvaluateSafeHold holds the current path yet still honors the orbital

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -485,7 +485,7 @@ var _ = Describe("NTNSlice Controller", func() {
 			// (reset on re-degradation), not absolute time since failover. Seed the
 			// in-memory recovery clock so terrestrial has been recovered longer than
 			// the 60s delay — the precondition this test asserts.
-			reconciler.storeFlapState(typeNamespacedName, slice.AntiFlapState{
+			reconciler.storeFlapState(typeNamespacedName, ntnSlice.UID, slice.AntiFlapState{
 				RecoveryObservedAt: time.Date(2026, 4, 17, 11, 55, 0, 0, time.UTC),
 			})
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{

--- a/internal/controller/ntnslice_lastswitchback_persist_test.go
+++ b/internal/controller/ntnslice_lastswitchback_persist_test.go
@@ -12,18 +12,113 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/slice"
 	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
 )
+
+// TestReconcile_FailedSwitchbackThenPassEnded_NoGhostDwell is the transaction-boundary
+// regression (review Finding 1). A quality-switchback whose Status().Update() FAILS must not
+// leave a speculative LastSwitchback in shared memory: otherwise a later pass-ended FORCED
+// switchback (which must NOT start a dwell) launders that ghost timestamp into durable status,
+// wrongly blocking the next pass's failover. Because storeFlapState now commits only AFTER a
+// durable write, R2 sees an empty clock and persists nothing. Mutation: committing memory before
+// the write (the pre-fix order) makes R2 persist the ghost T1, so this fails.
+func TestReconcile_FailedSwitchbackThenPassEnded_NoGhostDwell(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:            []string{"rsrp < -100"},
+				SwitchbackDelay:     metav1.Duration{Duration: 60 * time.Second},
+				MinTerrestrialDwell: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+
+	var sliceStatusUpdates int
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, sub string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if _, ok := obj.(*ntnv1alpha1.NTNSlice); ok {
+					sliceStatusUpdates++
+					if sliceStatusUpdates == 1 { // R1's switchback write fails
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: "ntn.operators.dev", Resource: "ntnslices"},
+							obj.GetName(), fmt.Errorf("forced conflict"))
+					}
+				}
+				return c.SubResource(sub).Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	setPass := func(aos, los time.Time) {
+		eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+			Satellite: "ONEWEB-0012", GroundStation: "gs",
+			AOS: metav1.Time{Time: aos}, LOS: metav1.Time{Time: los},
+		}}
+		if err := cli.Status().Update(context.Background(), eph); err != nil {
+			t.Fatalf("seed pass window: %v", err)
+		}
+	}
+	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }}
+	key := client.ObjectKeyFromObject(nsObj)
+	// Terrestrial healthy long enough to switch back; satellite pass currently ACTIVE.
+	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
+	}}}
+	setPass(fixedNow.Add(-1*time.Hour), fixedNow.Add(1*time.Hour))
+
+	// R1: quality-switchback computed, but its status write is forced to CONFLICT.
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err == nil {
+		t.Fatal("R1 status update was expected to conflict")
+	}
+
+	// Pass ends → satellite unavailable → R2 does a FORCED (pass-ended) switchback.
+	setPass(fixedNow.Add(-2*time.Hour), fixedNow.Add(-1*time.Hour))
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("R2 reconcile: %v", err)
+	}
+
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType != string(slice.PathTerrestrial) {
+		t.Fatalf("R2 pass-ended switchback should land on terrestrial, got %q", updated.Status.ActivePathType)
+	}
+	if updated.Status.LastSwitchbackTime != nil {
+		t.Fatalf("a pass-ended forced switchback must NOT persist a dwell clock; the failed R1 "+
+			"quality-switchback left a GHOST LastSwitchback=%v", updated.Status.LastSwitchbackTime)
+	}
+}
 
 // baseSliceForDwell builds an NTNSlice with a min-dwell failover policy and a live
 // satellite pass, used by the LastSwitchback-persistence tests below.
@@ -199,6 +294,36 @@ func TestReconcile_MonotonicSeed_KeepsNewerMemory(t *testing.T) {
 	if updated.Status.LastSwitchbackTime == nil || !updated.Status.LastSwitchbackTime.Time.Equal(memClock) {
 		t.Fatalf("status must advance to the newer in-memory clock (%v), got %v",
 			memClock, updated.Status.LastSwitchbackTime)
+	}
+}
+
+// TestReconcile_FutureDurableTimestampHealedBySwitchback pins that a poisoned FUTURE durable
+// value (clock skew / rollback) is not stuck: a real quality-switchback must overwrite it rather
+// than be blocked by the monotonic "never go backward" rule (review P2). Mutation: dropping the
+// `p.After(now)` heal in persist leaves the future value in place, so the switchback's real time
+// cannot be recovered after a restart.
+func TestReconcile_FutureDurableTimestampHealedBySwitchback(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	// On satellite, terrestrial recovered; durable clock poisoned 1h into the future.
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType:     string(slice.PathSatellite),
+		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	})
+	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.LastSwitchbackTime == nil || !updated.Status.LastSwitchbackTime.Time.Equal(fixedNow) {
+		t.Fatalf("a real switchback must HEAL a future durable timestamp to now (%v), got %v",
+			fixedNow, updated.Status.LastSwitchbackTime)
 	}
 }
 

--- a/internal/controller/ntnslice_lastswitchback_persist_test.go
+++ b/internal/controller/ntnslice_lastswitchback_persist_test.go
@@ -130,19 +130,23 @@ func TestReconcile_Switchback_PersistsLastSwitchbackTime(t *testing.T) {
 	}
 }
 
-// TestReconcile_SteadyReconcile_DoesNotChurnLastSwitchbackTime proves the mirror only
-// fires when LastSwitchback CHANGES: an in-memory clock with no switchback this cycle must
-// NOT write status. Mutation: gating on !IsZero() instead of a change would write it here.
-func TestReconcile_SteadyReconcile_DoesNotChurnLastSwitchbackTime(t *testing.T) {
+// TestReconcile_SelfHealsDurableLastSwitchback pins the monotonic-merge robustness (review
+// Finding 1): when the in-memory min-dwell clock is AHEAD of the durable status (e.g. a prior
+// switchback's Status().Update() failed and left status behind memory), any later reconcile
+// must REPAIR status from memory — it must not treat "memory has a value, status is nil" as an
+// acceptable steady state. Mutation: the prior "write only when memory changed this cycle"
+// gate leaves status nil here (no switchback this cycle), so this fails.
+func TestReconcile_SelfHealsDurableLastSwitchback(t *testing.T) {
 	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
-	// On terrestrial, healthy; status.lastSwitchbackTime deliberately nil while the
-	// in-memory clock is set — a steady reconcile must not backfill/churn it.
+	// On terrestrial; in-memory clock set 30s ago (within the 60s dwell), status nil.
 	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
 		ActivePathType: string(slice.PathTerrestrial),
 	})
-	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: fixedNow.Add(-120 * time.Second)})
+	memClock := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: memClock})
+	// Terrestrial DEGRADED (would fail over if dwell were satisfied), satellite available.
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
-		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
 		Stale:   false, LastFreshAt: fixedNow,
 	}}}
 
@@ -153,8 +157,77 @@ func TestReconcile_SteadyReconcile_DoesNotChurnLastSwitchbackTime(t *testing.T) 
 	if err := r.Get(context.Background(), key, updated); err != nil {
 		t.Fatalf("re-get: %v", err)
 	}
-	if updated.Status.LastSwitchbackTime != nil {
-		t.Fatalf("a steady reconcile (no switchback this cycle) must not write "+
-			"status.lastSwitchbackTime; got %v (churn)", updated.Status.LastSwitchbackTime)
+	if updated.Status.LastSwitchbackTime == nil || !updated.Status.LastSwitchbackTime.Time.Equal(memClock) {
+		t.Fatalf("durable status must be REPAIRED from the ahead-of-status in-memory clock (%v), got %v",
+			memClock, updated.Status.LastSwitchbackTime)
+	}
+	if updated.Status.ActivePathType != string(slice.PathTerrestrial) {
+		t.Fatalf("in-memory min-dwell must still block the re-failover, got %q", updated.Status.ActivePathType)
+	}
+}
+
+// TestReconcile_MonotonicSeed_IgnoresFutureAndOlder pins two monotonicity properties (Findings
+// 1 & 3): the seed adopts status only when it is NEWER than memory (never downgrades), and it
+// ignores a FUTURE-dated status (clock skew / rollback) so a bad timestamp cannot lock
+// terrestrial. Here status is OLDER than memory AND memory is within dwell → the slice must
+// stay terrestrial and status must advance to the memory value.
+func TestReconcile_MonotonicSeed_KeepsNewerMemory(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	memClock := fixedNow.Add(-10 * time.Second)  // within 60s dwell
+	oldStatus := fixedNow.Add(-90 * time.Second) // outside dwell (would fail over if adopted)
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType:     string(slice.PathTerrestrial),
+		LastSwitchbackTime: &metav1.Time{Time: oldStatus},
+	})
+	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: memClock})
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType != string(slice.PathTerrestrial) {
+		t.Fatalf("seed must NOT downgrade to the older status clock (would satisfy dwell and fail over); got %q",
+			updated.Status.ActivePathType)
+	}
+	if updated.Status.LastSwitchbackTime == nil || !updated.Status.LastSwitchbackTime.Time.Equal(memClock) {
+		t.Fatalf("status must advance to the newer in-memory clock (%v), got %v",
+			memClock, updated.Status.LastSwitchbackTime)
+	}
+}
+
+// TestReconcile_FutureStatusTimestampIgnored pins the future-timestamp guard (Finding 3): a
+// status.lastSwitchbackTime dated in the future (clock skew / rollback) must be IGNORED by the
+// seed, so it cannot indefinitely lock a degraded terrestrial. Here memory is empty and status
+// is 1h in the future → min-dwell must NOT apply → the slice fails over. Mutation: seeding the
+// future value makes now.Sub(future) negative < dwell, wrongly holding terrestrial.
+func TestReconcile_FutureStatusTimestampIgnored(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType:     string(slice.PathTerrestrial),
+		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(1 * time.Hour)}, // implausible future
+	})
+	// no in-memory entry (cold cache); terrestrial DEGRADED; satellite available.
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType != string(slice.PathSatellite) {
+		t.Fatalf("a future-dated lastSwitchbackTime must NOT lock terrestrial; expected failover to satellite, got %q",
+			updated.Status.ActivePathType)
 	}
 }

--- a/internal/controller/ntnslice_lastswitchback_persist_test.go
+++ b/internal/controller/ntnslice_lastswitchback_persist_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// baseSliceForDwell builds an NTNSlice with a min-dwell failover policy and a live
+// satellite pass, used by the LastSwitchback-persistence tests below.
+func baseSliceForDwell(t *testing.T, fixedNow time.Time, status ntnv1alpha1.NTNSliceStatus) (
+	*NTNSliceReconciler, client.ObjectKey,
+) {
+	t.Helper()
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:            []string{"rsrp < -100"},
+				SwitchbackDelay:     metav1.Duration{Duration: 60 * time.Second},
+				MinTerrestrialDwell: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: status,
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+	// Live pass window: satellite available now.
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }}
+	return r, client.ObjectKeyFromObject(nsObj)
+}
+
+// TestReconcile_MinDwell_SeededFromStatus_BlocksEarlyRefailover is the H1 core: after a
+// controller restart the in-memory flap state is empty, but status.lastSwitchbackTime lets
+// the min-dwell clock be reloaded, so a re-degradation within the dwell window does NOT
+// fail over. Mutation: drop the status→af seed and this fails over to satellite instead.
+func TestReconcile_MinDwell_SeededFromStatus_BlocksEarlyRefailover(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	// On terrestrial, switched back 15s ago (well within the 60s min-dwell). No in-memory
+	// flap entry is seeded — this is the post-restart cold cache.
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType:     string(slice.PathTerrestrial),
+		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(-15 * time.Second)},
+	})
+	// Terrestrial DEGRADED (rsrp -110 < -100) and reliable; satellite available.
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType != string(slice.PathTerrestrial) {
+		t.Fatalf("min-dwell (reloaded from status.lastSwitchbackTime) must BLOCK the re-failover; "+
+			"want stay terrestrial, got %q — the LastSwitchback status seed was not applied",
+			updated.Status.ActivePathType)
+	}
+}
+
+// TestReconcile_Switchback_PersistsLastSwitchbackTime proves a quality-driven switchback
+// writes status.lastSwitchbackTime. Mutation: drop the persist and it stays nil.
+func TestReconcile_Switchback_PersistsLastSwitchbackTime(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	// On satellite; terrestrial has been healthy long enough for the switchback delay.
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType: string(slice.PathSatellite),
+	})
+	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	// Terrestrial HEALTHY (rsrp -80 does not fire), reliable; satellite available.
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType != string(slice.PathTerrestrial) {
+		t.Fatalf("expected a switchback to terrestrial, got %q", updated.Status.ActivePathType)
+	}
+	if updated.Status.LastSwitchbackTime == nil || !updated.Status.LastSwitchbackTime.Time.Equal(fixedNow) {
+		t.Fatalf("a switchback must persist status.lastSwitchbackTime=%v, got %v",
+			fixedNow, updated.Status.LastSwitchbackTime)
+	}
+}
+
+// TestReconcile_SteadyReconcile_DoesNotChurnLastSwitchbackTime proves the mirror only
+// fires when LastSwitchback CHANGES: an in-memory clock with no switchback this cycle must
+// NOT write status. Mutation: gating on !IsZero() instead of a change would write it here.
+func TestReconcile_SteadyReconcile_DoesNotChurnLastSwitchbackTime(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	// On terrestrial, healthy; status.lastSwitchbackTime deliberately nil while the
+	// in-memory clock is set — a steady reconcile must not backfill/churn it.
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType: string(slice.PathTerrestrial),
+	})
+	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: fixedNow.Add(-120 * time.Second)})
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.LastSwitchbackTime != nil {
+		t.Fatalf("a steady reconcile (no switchback this cycle) must not write "+
+			"status.lastSwitchbackTime; got %v (churn)", updated.Status.LastSwitchbackTime)
+	}
+}

--- a/internal/controller/ntnslice_lastswitchback_persist_test.go
+++ b/internal/controller/ntnslice_lastswitchback_persist_test.go
@@ -90,7 +90,7 @@ func TestReconcile_FailedSwitchbackThenPassEnded_NoGhostDwell(t *testing.T) {
 	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }}
 	key := client.ObjectKeyFromObject(nsObj)
 	// Terrestrial healthy long enough to switch back; satellite pass currently ACTIVE.
-	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
 	}}}
@@ -202,7 +202,7 @@ func TestReconcile_Switchback_PersistsLastSwitchbackTime(t *testing.T) {
 	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
 		ActivePathType: string(slice.PathSatellite),
 	})
-	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	// Terrestrial HEALTHY (rsrp -80 does not fire), reliable; satellite available.
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
@@ -238,7 +238,7 @@ func TestReconcile_SelfHealsDurableLastSwitchback(t *testing.T) {
 		ActivePathType: string(slice.PathTerrestrial),
 	})
 	memClock := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: memClock})
+	r.storeFlapState(key, "", slice.AntiFlapState{LastSwitchback: memClock})
 	// Terrestrial DEGRADED (would fail over if dwell were satisfied), satellite available.
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
@@ -274,7 +274,7 @@ func TestReconcile_MonotonicSeed_KeepsNewerMemory(t *testing.T) {
 		ActivePathType:     string(slice.PathTerrestrial),
 		LastSwitchbackTime: &metav1.Time{Time: oldStatus},
 	})
-	r.storeFlapState(key, slice.AntiFlapState{LastSwitchback: memClock})
+	r.storeFlapState(key, "", slice.AntiFlapState{LastSwitchback: memClock})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
 		Stale:   false, LastFreshAt: fixedNow,
@@ -309,7 +309,7 @@ func TestReconcile_FutureDurableTimestampHealedBySwitchback(t *testing.T) {
 		ActivePathType:     string(slice.PathSatellite),
 		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
 	})
-	r.storeFlapState(key, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
 	}}}
@@ -354,5 +354,92 @@ func TestReconcile_FutureStatusTimestampIgnored(t *testing.T) {
 	if updated.Status.ActivePathType != string(slice.PathSatellite) {
 		t.Fatalf("a future-dated lastSwitchbackTime must NOT lock terrestrial; expected failover to satellite, got %q",
 			updated.Status.ActivePathType)
+	}
+}
+
+// TestReconcile_FutureDurableTimestampClearedNotRevived pins Finding 1 (round-4): a future-dated
+// lastSwitchbackTime must be CLEARED durably, not merely ignored, so it cannot silently become
+// valid history once the wall clock passes it and block a legitimate failover with a ghost dwell.
+// The seed observes the future value while terrestrial is healthy (no switchback) and clears it;
+// after the clock advances past it, a real degradation must still fail over. Mutation: leaving the
+// future value in status (the old ignore-only behaviour) revives it, and now.Sub(revived) < dwell
+// wrongly holds terrestrial.
+func TestReconcile_FutureDurableTimestampClearedNotRevived(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType:     string(slice.PathTerrestrial),
+		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(30 * time.Second)}, // future (skew / rollback)
+	})
+	now := fixedNow
+	r.Now = func() time.Time { return now }
+
+	// Reconcile 1: terrestrial HEALTHY (no switchback) while the timestamp is still in the future.
+	// The seed must clear it durably.
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
+	}}}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	mid := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, mid); err != nil {
+		t.Fatalf("get after reconcile 1: %v", err)
+	}
+	if mid.Status.LastSwitchbackTime != nil {
+		t.Fatalf("a future-dated lastSwitchbackTime must be cleared, not left to revive; got %v",
+			mid.Status.LastSwitchbackTime)
+	}
+
+	// Advance past the former future timestamp but stay within the 60s min-dwell, then degrade
+	// terrestrial: the failover must NOT be blocked by a revived ghost dwell.
+	now = fixedNow.Add(35 * time.Second)
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: now,
+	}}}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	got := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get after reconcile 2: %v", err)
+	}
+	if got.Status.ActivePathType != string(slice.PathSatellite) {
+		t.Fatalf("a cleared future timestamp must not revive after the clock passes it; "+
+			"expected failover to satellite, got %q", got.Status.ActivePathType)
+	}
+}
+
+// TestReconcile_StaleFlapStateForDifferentUID_IsNotInherited pins Finding 2 (round-4): the
+// anti-flap cache is keyed by (name, UID), so a same-name slice recreated with a new UID — a
+// delete+create the workqueue coalesced into one reconcile, so the intervening NotFound was never
+// observed — does NOT inherit the deleted object's min-dwell clock. The reconciled object's UID
+// differs from the UID the stale entry was stored under, so the entry is evicted and the slice
+// starts from zero state. Mutation: keying on name alone loads the stale recent-switchback clock
+// and wrongly holds terrestrial (15s < 60s dwell).
+func TestReconcile_StaleFlapStateForDifferentUID_IsNotInherited(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
+		ActivePathType: string(slice.PathTerrestrial),
+	})
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
+	}}}
+	// Leftover state stored under a DIFFERENT (deleted predecessor's) UID, with a recent switchback
+	// that would block failover (15s < 60s dwell) if it were wrongly inherited. The reconciled
+	// object built by baseSliceForDwell has a different UID (empty), so this must be evicted.
+	r.storeFlapState(key, "uid-of-deleted-predecessor", slice.AntiFlapState{
+		LastSwitchback: fixedNow.Add(-15 * time.Second),
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &ntnv1alpha1.NTNSlice{}
+	if err := r.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if got.Status.ActivePathType != string(slice.PathSatellite) {
+		t.Fatalf("a recreated same-name slice must not inherit a deleted object's min-dwell clock; "+
+			"expected failover to satellite, got %q", got.Status.ActivePathType)
 	}
 }

--- a/internal/controller/ntnslice_three_state_test.go
+++ b/internal/controller/ntnslice_three_state_test.go
@@ -88,7 +88,7 @@ func TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown(t *test
 	// Seed a recovery/confirmation streak AND a dwell clock from an earlier (reliable)
 	// window, to prove the unreliable reconcile clears the former but keeps the latter.
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -109,7 +109,7 @@ func TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown(t *test
 	}
 
 	// H2: recovery + confirmation cleared, dwell preserved.
-	st := r.loadFlapState(key)
+	st := r.loadFlapState(key, nsObj.UID)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset on unreliable metrics (H2), got %v", st.RecoveryObservedAt)
 	}

--- a/internal/controller/ntnslice_trigger_admission_test.go
+++ b/internal/controller/ntnslice_trigger_admission_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// These run against the envtest API server, so they exercise the CRD's REAL CEL
+// x-kubernetes-validations for failoverPolicy.triggers — the bounded-magnitude value
+// regex (#220 C4) as evaluated by the apiserver on CREATE, not just a Go-side copy of
+// the regex compared against ParseTrigger. This closes the "the test never sends an
+// object to admission" gap: it proves an object with an overflowing trigger value is
+// actually rejected by the deployed CRD.
+var _ = Describe("NTNSlice failoverPolicy.triggers admission (CEL)", func() {
+	n := 0
+	mkSlice := func(trigger string) *ntnv1alpha1.NTNSlice {
+		n++
+		return &ntnv1alpha1.NTNSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("adm-trigger-%d", n), Namespace: "default"},
+			Spec: ntnv1alpha1.NTNSliceSpec{
+				Tenant: "acme-corp",
+				TerrestrialPath: ntnv1alpha1.PathSpec{
+					Provider: "chunghwa-telecom", APN: "internet", Priority: "primary",
+				},
+				SatellitePath: ntnv1alpha1.SatellitePathSpec{
+					PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+					EphemerisRef: "oneweb-constellation",
+				},
+				FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+					Triggers:        []string{trigger},
+					SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+				},
+			},
+		}
+	}
+
+	DescribeTable("bounds the trigger value to a finite magnitude at admission",
+		func(trigger string, accepted bool) {
+			s := mkSlice(trigger)
+			err := k8sClient.Create(ctx, s)
+			if accepted {
+				Expect(err).NotTo(HaveOccurred(), "trigger %q should be admitted", trigger)
+				DeferCleanup(func() { _ = k8sClient.Delete(ctx, s) })
+			} else {
+				Expect(err).To(HaveOccurred(), "trigger %q must be rejected by CEL admission", trigger)
+			}
+		},
+		Entry("normal negative rsrp", "rsrp < -120", true),
+		Entry("decimal packetLoss", "packetLoss > 5.25", true),
+		Entry("2-digit exponent stays finite", "latency > 1e99", true),
+		Entry("3-digit exponent is bounded out", "latency > 1e100", false),
+		Entry("overflowing exponent 1e9999 (=+Inf)", "latency > 1e9999", false),
+		Entry("11 integer digits bounded out", "rsrp < 12345678901", false),
+		Entry("non-finite NaN literal", "rsrp < NaN", false),
+	)
+})

--- a/internal/controller/ntnslice_trigger_admission_test.go
+++ b/internal/controller/ntnslice_trigger_admission_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
@@ -59,6 +60,12 @@ var _ = Describe("NTNSlice failoverPolicy.triggers admission (CEL)", func() {
 				DeferCleanup(func() { _ = k8sClient.Delete(ctx, s) })
 			} else {
 				Expect(err).To(HaveOccurred(), "trigger %q must be rejected by CEL admission", trigger)
+				// Assert it is an admission (Invalid) rejection that names failoverPolicy — so a
+				// reject cannot false-green on some unrelated validation error.
+				Expect(apierrors.IsInvalid(err)).To(BeTrue(),
+					"trigger %q must fail with an Invalid admission error, got %v", trigger, err)
+				Expect(err.Error()).To(ContainSubstring("failoverPolicy"),
+					"the rejection must reference failoverPolicy, got %v", err)
 			}
 		},
 		Entry("normal negative rsrp", "rsrp < -120", true),

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -154,10 +154,12 @@ spec:
                 x-kubernetes-validations:
                 - message: each failoverPolicy.trigger must be 'metric op value' where
                     metric is one of rsrp/latency/packetLoss/terrestrialRSRP/terrestrialLatency/terrestrialPacketLoss,
-                    op is one of < <= > >=, and value is a finite number (e.g. 'rsrp
-                    < -120')
+                    op is one of < <= > >=, and value is a finite decimal (up to 10
+                    integer and 10 fraction digits with an optional 2-digit exponent,
+                    e.g. 'rsrp < -120'); overflowing forms like '1e9999' are rejected
+                    here and, defensively, at runtime
                   rule: self.triggers.all(t, t.matches('^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss)
-                    *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?
+                    *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})?
                     *$'))
               metricsSource:
                 description: |-
@@ -430,6 +432,16 @@ spec:
                 type: integer
               lastFailover:
                 description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              lastSwitchbackTime:
+                description: |-
+                  lastSwitchbackTime is when the slice last switched back to terrestrial from an
+                  available satellite (a quality-driven hand-back). It is persisted so the anti-flap
+                  minimum-terrestrial-dwell survives a controller restart or leader-election handoff:
+                  the in-memory flap clock resets on handoff, and without this a re-degradation within
+                  the dwell window could switch to satellite earlier than the dwell intended. The other
+                  flap clocks stay in-memory (losing them only delays a switch, never advances one).
                 format: date-time
                 type: string
               sessionCount:

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -613,15 +613,17 @@ type AntiFlapConfig struct {
 	MinTerrestrialDwell time.Duration
 }
 
-// AntiFlapState is the per-slice, in-memory flap-suppression state. Losing it (a
-// controller restart or leader-election handoff) is MOSTLY safe: a reset re-requires N
-// consecutive confirmations and restarts the recovery clock, both of which only DELAY a
-// switch. The ONE exception is LastSwitchback: losing it drops the post-switchback
-// min-dwell, so a failover that dwell would have delayed can happen immediately — a reset
-// can ADVANCE (never fabricate) a failover on that single axis. This is an accepted
-// trade-off: a restart is rare and one early re-failover is bounded; making dwell durable
-// would require persisting LastSwitchback to status (tracked, deferred). The other two
-// clocks bias a restart toward holding, never toward a spurious flap.
+// AntiFlapState is the per-slice flap-suppression state. Two of its clocks are held only
+// in memory; losing them on a controller restart or leader-election handoff is safe because
+// a reset re-requires N consecutive confirmations (ConsecutiveDegraded) and restarts the
+// recovery clock (RecoveryObservedAt) — both of which only DELAY a switch, never advance one.
+// The ONE clock whose loss ADVANCES a switch is LastSwitchback: losing it drops the
+// post-switchback min-dwell, so a re-degradation within the dwell window could fail over
+// earlier than the dwell intended. That axis is therefore made durable — LastSwitchback is
+// mirrored to NTNSlice.status.lastSwitchbackTime by the controller and reloaded when the
+// in-memory clock is absent (a cold cache after restart), so min-dwell survives a handoff.
+// This matters more now that rolling updates hand leadership over routinely; the other two
+// clocks are intentionally NOT persisted (their loss only biases toward holding).
 type AntiFlapState struct {
 	// ConsecutiveDegraded counts consecutive reliable samples on which the
 	// terrestrial triggers fired. Reset to 0 by any healthy/unreliable sample.

--- a/pkg/slice/trigger_cel_test.go
+++ b/pkg/slice/trigger_cel_test.go
@@ -28,7 +28,7 @@ import (
 // test is the single behavioral source of truth: it proves the admission regex
 // agrees with the runtime ParseTrigger, so a trigger accepted at admission always
 // parses at runtime (no silent skip) and vice-versa — closing findings.md I-11.
-const triggerCELRegex = `^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)? *$` //nolint:lll // one line to stay byte-identical to the CRD CEL rule
+const triggerCELRegex = `^ *(rsrp|latency|packetLoss|terrestrialRSRP|terrestrialLatency|terrestrialPacketLoss) *(<=|>=|<|>) *[-+]?([0-9]{1,10}([.][0-9]{1,10})?|[.][0-9]{1,10})([eE][-+]?[0-9]{1,2})? *$` //nolint:lll // one line to stay byte-identical to the CRD CEL rule
 
 func TestTriggerCELRegexAgreesWithParseTrigger(t *testing.T) {
 	re := regexp.MustCompile(triggerCELRegex)
@@ -37,11 +37,13 @@ func TestTriggerCELRegexAgreesWithParseTrigger(t *testing.T) {
 		"rsrp < -120", "latency > 200", "packetLoss > 5", "rsrp <= -100",
 		"terrestrialRSRP >= -90", "terrestrialLatency < 50", "terrestrialPacketLoss > 0.5",
 		"rsrp<-120", "  latency  >  200  ", "packetLoss > 5.25", "rsrp > +3",
-		"latency >= 1e2", "packetLoss < .5",
-		// invalid — both must reject
+		"latency >= 1e2", "packetLoss < .5", "latency > 1e99",
+		// invalid — both must reject. `1e9999` is the C4 case: the prior regex accepted it
+		// while ParseTrigger rejects it as +Inf (a latent disagreement); the bounded
+		// exponent now rejects it at admission too, so both agree.
 		"", "rsrp", "rsrp < ", "< 5", "rsrp ! 5", "rsrp == 5", "rsrp <> 5",
 		"unknownMetric < 5", "RSRP < -120", "rsrp < abc", "rsrp < -120 extra",
-		"rsrp < 5 < 3", "latency > 200ms", "rsrp < NaN", "rsrp < Inf",
+		"rsrp < 5 < 3", "latency > 200ms", "rsrp < NaN", "rsrp < Inf", "latency > 1e9999",
 	}
 	for _, s := range corpus {
 		reMatch := re.MatchString(s)
@@ -66,10 +68,12 @@ func TestTriggerCELRegexKnownDivergences(t *testing.T) {
 	// Each is accepted by strconv.ParseFloat / strings.TrimSpace (so ParseTrigger
 	// accepts) but rejected by the ASCII-only, plain-decimal admission regex.
 	divergent := []string{
-		"rsrp < 0x1p4",     // 1. hex float
-		"rsrp < 5.",        // 2. trailing-dot float
-		"latency > 1_000",  // 3. underscore digit grouping
-		"rsrp <\u00a0-120", // 4. non-ASCII whitespace (NBSP) where a space is expected
+		"rsrp < 0x1p4",       // 1. hex float
+		"rsrp < 5.",          // 2. trailing-dot float
+		"latency > 1_000",    // 3. underscore digit grouping
+		"rsrp <\u00a0-120",   // 4. non-ASCII whitespace (NBSP) where a space is expected
+		"latency > 1e100",    // 5. finite but exponent > 2 digits \u2014 bounded to keep the value finite
+		"rsrp < 12345678901", // 6. finite but > 10 integer digits \u2014 bounded to keep the value finite
 	}
 	for _, s := range divergent {
 		if re.MatchString(s) {


### PR DESCRIPTION
## What

Makes the NTNSlice anti-flap **minimum-terrestrial-dwell** clock survive a controller restart or leader-election handoff, and tightens the `failoverPolicy` CEL admission.

`LastSwitchback` (the post-switchback dwell clock) was in-memory only, so a handoff reset it to "dwell satisfied" and a re-degradation within the dwell window could fail over earlier than intended. It is now mirrored to a new `NTNSlice.status.lastSwitchbackTime` and monotonically merged with the in-memory clock.

## Design

- **Durable min-dwell.** `status.lastSwitchbackTime` mirrors the in-memory clock; the seed adopts status when it is newer (cold cache after restart) and repairs status when it is behind. The recovery/confirmation clocks stay in-memory — losing them only *delays* a switch, never advances one.
- **Transaction boundary.** The in-memory clock is committed only *after* the durable status write succeeds, so a quality-switchback whose write fails cannot leave a speculative timestamp that a later pass-ended forced switchback launders into a bogus dwell.
- **Future-dated value (round-4, Finding 1).** A `status.lastSwitchbackTime` in the future (backward node-clock step / external edit; the controller only ever writes values `<= now`) is now **cleared durably** when observed, not merely ignored, so it cannot become valid history once the wall clock passes it and block a failover with a ghost dwell.
- **Object identity (round-4, Finding 2).** The in-memory cache is keyed by (name, UID). A same-name slice recreated with a new UID — a delete+create the workqueue coalesced into one reconcile, hiding the intervening NotFound — does not inherit the deleted object's counters or dwell clock. The `AntiFlapState` domain type is untouched (the UID lives in a private cache entry).
- **CEL admission (C4).** The numeric-trigger admission regex bounds integer/fraction/exponent digits (accepts `1e99`, rejects `1e100`, `1e9999`, 11-digit integers); runtime still rejects `NaN`/`Inf`. An envtest asserts a real API server rejects out-of-range values as `Invalid` pointing at `failoverPolicy`.

## Tests

Deterministic and mutation-proven (each notes the mutation that makes it fail): cold-cache seed blocks early re-failover; switchback persists; self-heal of a behind status; monotonic seed keeps newer memory; failed-switchback-then-pass-ended leaves no ghost dwell; a future value is ignored now **and** cleared-not-revived later; stale state under a different UID is not inherited; CEL admission accepts `1e99` and rejects `1e100` / 11-digit integers / `NaN`.

## Scope / known limits

- Durability holds once this version has recorded at least one quality-driven switchback; a switchback recorded only by a pre-field (older) version is not recoverable.
- Min-dwell accuracy across a handoff assumes the controller nodes have synchronised clocks.
- A downgrade to a pre-field version stops honoring `status.lastSwitchbackTime`.