### PR TITLE
feat(ephemeris): bound & cancel pass prediction (horizon clamp + ctx) (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`passPrediction.horizon` is bounded and pass prediction is cancellable.** Pass prediction
   sweeps the whole horizon for every satellite × ground station, so an unbounded `horizon` could
   stall the reconcile (and, transitively, delay the runtime-push epoch). The horizon is now
-  clamped to a 7-day maximum at reconcile time (clamp, not reject — non-breaking; `MaxPassWindows`
-  already caps the stored output). That clamp bounds the per-reconcile compute. Separately,
-  `PredictPasses` now honours context cancellation between work items, so a long pass prediction
-  aborts promptly when the manager's context is cancelled (controller shutdown / leader loss)
-  rather than blocking graceful shutdown — the operator wires no per-reconcile timeout, so this is
-  a shutdown-responsiveness win, not a per-reconcile deadline (#233, part of #232).
+  clamped to a 7-day maximum at reconcile time; the clamp bounds the horizon dimension of one work
+  item's cost (total reconcile cost still scales with the selected satellites × ground stations,
+  whose stored output `MaxPassWindows` caps). A NEGATIVE horizon is now rejected as a config error
+  rather than silently defaulting to 24h. `PredictPasses` also takes a `context.Context` and honours
+  cancellation BETWEEN work items: a cancelled or timed-out call stops dispatching new items and
+  returns `ctx.Err()`, though an item already running finishes because the upstream
+  `sgp4.GeneratePasses` sweep takes no context — at the 7-day clamp a single item is ~20ms
+  (`BenchmarkPredictPasses_7d_*`), so a cancelled call returns within roughly that bound. The
+  reconcile treats such a cancellation as control flow (requeue), not a `PredictionFailed` error.
+  ⚠ `ephemeris.PredictPasses` now takes `ctx` as its first argument (source-breaking for any
+  external Go caller) (#233, part of #232).
 - **`/readyz` now gates on informer cache-sync (still leadership-agnostic).** It was
   `healthz.Ping`, which reports Ready as soon as the process serves — but controller-runtime
   starts the health server *before* the caches sync, so a broken new replica (RBAC, CRD
@@ -212,9 +217,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade notes
 
-- **`passPrediction.horizon` is clamped to 7 days.** A larger value is silently clamped (logged,
-  not rejected), so a spec relying on pass windows beyond 7 days will see them truncated. Realistic
-  contact-planning horizons are unaffected (`MaxPassWindows` already capped the output at 500).
+- **`passPrediction.horizon`: negative is rejected, over-7-days is clamped.** A horizon > 7 days is
+  clamped to 7 days (surfaced on the `PassesPredicted` condition message, not silently), so a spec
+  relying on windows beyond 7 days will see them truncated (`MaxPassWindows` already capped the
+  output at 500). A NEGATIVE horizon is now rejected with a config error instead of silently
+  defaulting to 24 hours. `ephemeris.PredictPasses` also gains a leading `context.Context` argument
+  (source-breaking for external Go callers).
 - **`NewSafeHTTPClient` no longer honors `HTTP_PROXY`/`HTTPS_PROXY`.** The GP fetch, NTNSlice
   metrics reader, and ground-station probe reach in-cluster or public endpoints directly; a
   deployment that previously relied on an egress proxy for those must expose the endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`passPrediction.horizon` is bounded and pass prediction is cancellable.** Pass prediction
+  sweeps the whole horizon for every satellite × ground station, so an unbounded `horizon` could
+  stall the reconcile (and, transitively, delay the runtime-push epoch). The horizon is now
+  clamped to a 7-day maximum at reconcile time (clamp, not reject — non-breaking; `MaxPassWindows`
+  already caps the stored output). That clamp bounds the per-reconcile compute. Separately,
+  `PredictPasses` now honours context cancellation between work items, so a long pass prediction
+  aborts promptly when the manager's context is cancelled (controller shutdown / leader loss)
+  rather than blocking graceful shutdown — the operator wires no per-reconcile timeout, so this is
+  a shutdown-responsiveness win, not a per-reconcile deadline (#233, part of #232).
 - **`/readyz` now gates on informer cache-sync (still leadership-agnostic).** It was
   `healthz.Ping`, which reports Ready as soon as the process serves — but controller-runtime
   starts the health server *before* the caches sync, so a broken new replica (RBAC, CRD
@@ -203,6 +212,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade notes
 
+- **`passPrediction.horizon` is clamped to 7 days.** A larger value is silently clamped (logged,
+  not rejected), so a spec relying on pass windows beyond 7 days will see them truncated. Realistic
+  contact-planning horizons are unaffected (`MaxPassWindows` already capped the output at 500).
 - **`NewSafeHTTPClient` no longer honors `HTTP_PROXY`/`HTTPS_PROXY`.** The GP fetch, NTNSlice
   metrics reader, and ground-station probe reach in-cluster or public endpoints directly; a
   deployment that previously relied on an egress proxy for those must expose the endpoints

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -435,6 +435,26 @@ const maxPropagatedStates = 128
 // propagation, so the epoch is fresh at push time.
 const propagationEpochLead = 5 * time.Minute
 
+// maxPassHorizon bounds passPrediction.horizon (clamped, not rejected). Pass prediction sweeps
+// the whole horizon per satellite × ground station, so an unbounded horizon can stall the
+// reconcile; 7 days is generous for contact-opportunity planning (LEO passes recur ~every 90 min
+// and MaxPassWindows caps the stored output at 500 regardless).
+const maxPassHorizon = 7 * 24 * time.Hour
+
+// effectivePassHorizon resolves the pass-prediction horizon: the 24h default when unset, else
+// the spec value clamped to maxPassHorizon. clamped reports whether the ceiling was applied (so
+// the caller can log it once).
+func effectivePassHorizon(raw time.Duration) (horizon time.Duration, clamped bool) {
+	switch {
+	case raw <= 0:
+		return 24 * time.Hour, false
+	case raw > maxPassHorizon:
+		return maxPassHorizon, true
+	default:
+		return raw, false
+	}
+}
+
 // propagationRefreshInterval is how often the orbit is re-propagated (from cached
 // OMMs, WITHOUT a GP fetch) to keep the runtime-push epoch fresh between GP
 // refreshes (#179). It must be shorter than propagationEpochLead minus the
@@ -1070,10 +1090,14 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 		return "", fmt.Errorf("invalid minElevation: %w", err)
 	}
 
-	// Parse horizon.
-	horizon := pp.Horizon.Duration
-	if horizon == 0 {
-		horizon = 24 * time.Hour
+	// Resolve the effective horizon (default when unset, clamped to maxPassHorizon otherwise):
+	// an unbounded horizon makes the O(horizon × satellites × ground stations) sweep — and thus
+	// the reconcile — arbitrarily long. Clamp rather than reject so it stays non-breaking and
+	// ratcheting-safe; MaxPassWindows already caps the stored output.
+	horizon, clamped := effectivePassHorizon(pp.Horizon.Duration)
+	if clamped {
+		log.Info("passPrediction.horizon exceeds maximum; clamping",
+			"horizon", pp.Horizon.Duration.String(), "max", maxPassHorizon.String())
 	}
 
 	// Build NORAD filter from SatelliteSelector.
@@ -1085,7 +1109,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// Run pass prediction from the CURRENT time, not fetchResult.FetchedAt: pass windows
 	// are "upcoming contact opportunities", and on a cached serve FetchedAt can be up to
 	// effectiveInterval (2–24h) in the past, which would start the window stale (#200-C3).
-	passes, err := ephemeris.PredictPasses(fetchResult.OMMs, stations, minEl, horizon, noradFilter, now)
+	passes, err := ephemeris.PredictPasses(ctx, fetchResult.OMMs, stations, minEl, horizon, noradFilter, now)
 	if err != nil {
 		return "", fmt.Errorf("computing passes: %w", err)
 	}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -334,7 +334,13 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ntnmetrics.GPDeepSpaceRejectedCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(len(trackedDeepSpace)))
 
 	// Step 7: Compute pass predictions if configured; clear stale data if disabled.
-	passNote, passFailNote := r.handlePassPrediction(ctx, eph, result, now)
+	passNote, passFailNote, passErr := r.handlePassPrediction(ctx, eph, result, now)
+	if passErr != nil {
+		// Context cancellation (shutdown / leader loss / per-reconcile timeout) from pass
+		// prediction: stop here and let controller-runtime requeue, rather than clearing status
+		// or running the remaining propagation and status write on a cancelled context.
+		return ctrl.Result{}, passErr
+	}
 
 	// Step 7b: Propagate tracked satellites to a NEAR-now epoch for the runtime
 	// ephemeris push (#176). The epoch is only a small lead ahead of now — enough
@@ -441,17 +447,21 @@ const propagationEpochLead = 5 * time.Minute
 // and MaxPassWindows caps the stored output at 500 regardless).
 const maxPassHorizon = 7 * 24 * time.Hour
 
-// effectivePassHorizon resolves the pass-prediction horizon: the 24h default when unset, else
-// the spec value clamped to maxPassHorizon. clamped reports whether the ceiling was applied (so
-// the caller can log it once).
-func effectivePassHorizon(raw time.Duration) (horizon time.Duration, clamped bool) {
+// effectivePassHorizon resolves the pass-prediction horizon: the 24h default when unset (0), a
+// rejection for a negative value (a config error, not "unset"), else the spec value clamped to
+// maxPassHorizon. clamped reports whether the ceiling was applied so the caller can surface it.
+func effectivePassHorizon(raw time.Duration) (horizon time.Duration, clamped bool, err error) {
 	switch {
-	case raw <= 0:
-		return 24 * time.Hour, false
+	case raw == 0:
+		return 24 * time.Hour, false, nil
+	case raw < 0:
+		// A negative horizon is a configuration error, not "unset". Reject it rather than silently
+		// defaulting to 24h, which would hide the misconfiguration and fail open.
+		return 0, false, fmt.Errorf("passPrediction.horizon must be positive, got %s", raw)
 	case raw > maxPassHorizon:
-		return maxPassHorizon, true
+		return maxPassHorizon, true, nil
 	default:
-		return raw, false
+		return raw, false, nil
 	}
 }
 
@@ -1007,15 +1017,23 @@ func (r *SatelliteEphemerisReconciler) reportOrbitRegime(
 // the caller emits them at most once per change after the status write persists.
 func (r *SatelliteEphemerisReconciler) handlePassPrediction(
 	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, result ephemeris.GPFetchResult, now time.Time,
-) (passNote, passFailNote string) {
+) (passNote, passFailNote string, err error) {
 	if eph.Spec.PassPrediction == nil || len(eph.Spec.PassPrediction.GroundStations) == 0 {
 		// Pass prediction not configured; clear stale pass windows and condition.
 		eph.Status.NextPassWindows = nil
 		meta.RemoveStatusCondition(&eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
-		return "", ""
+		return "", "", nil
 	}
-	note, err := r.predictPasses(ctx, eph, result, now)
+	var note string
+	note, err = r.predictPasses(ctx, eph, result, now)
 	if err != nil {
+		// Context cancellation is control flow (controller shutdown, leader loss, or a per-reconcile
+		// timeout), NOT a pass-prediction failure. Propagate it to Reconcile — which requeues —
+		// without clearing pass windows, recording a PredictionFailed condition/event, or doing any
+		// further work.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", "", err
+		}
 		logf.FromContext(ctx).Error(err, "pass prediction failed")
 		eph.Status.NextPassWindows = nil // clear stale pass data
 		// Gate on the failure EPISODE (Status/Reason/Generation, ignoring the varying
@@ -1033,11 +1051,11 @@ func (r *SatelliteEphemerisReconciler) handlePassPrediction(
 			ObservedGeneration: eph.Generation,
 		})
 		if failEpisode {
-			return "", err.Error()
+			return "", err.Error(), nil
 		}
-		return "", ""
+		return "", "", nil
 	}
-	return note, ""
+	return note, "", nil
 }
 
 // predictPasses resolves ground stations and computes pass windows. It sets the
@@ -1094,10 +1112,9 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// an unbounded horizon makes the O(horizon × satellites × ground stations) sweep — and thus
 	// the reconcile — arbitrarily long. Clamp rather than reject so it stays non-breaking and
 	// ratcheting-safe; MaxPassWindows already caps the stored output.
-	horizon, clamped := effectivePassHorizon(pp.Horizon.Duration)
-	if clamped {
-		log.Info("passPrediction.horizon exceeds maximum; clamping",
-			"horizon", pp.Horizon.Duration.String(), "max", maxPassHorizon.String())
+	horizon, clamped, err := effectivePassHorizon(pp.Horizon.Duration)
+	if err != nil {
+		return "", err
 	}
 
 	// Build NORAD filter from SatelliteSelector.
@@ -1130,6 +1147,14 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	log.Info("Pass prediction completed", "passCount", len(windows), "stationCount", len(stations))
 
 	msg := fmt.Sprintf("Computed %d passes over %d ground stations", len(windows), len(stations))
+	if clamped {
+		// Surface the horizon clamp on the durable PassesPredicted condition message (visible in
+		// status) instead of a per-reconcile log line, so an over-long horizon does not re-log on
+		// every ~3-minute re-propagation. The message still tracks the pass count, so it (and its
+		// event) can change when the count does — but the clamp suffix itself is stable and adds no
+		// extra churn.
+		msg += fmt.Sprintf("; passPrediction.horizon clamped to %s", maxPassHorizon)
+	}
 	changed := meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionPassesPredicted,
 		Status:             metav1.ConditionTrue,

--- a/internal/controller/satelliteephemeris_passcancel_test.go
+++ b/internal/controller/satelliteephemeris_passcancel_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestHandlePassPrediction_ContextCancelled_IsControlFlowNotFailure pins the round-2 review fix:
+// a context cancellation (controller shutdown, leader loss, per-reconcile timeout) surfaced by
+// pass prediction is CONTROL FLOW, not a PredictionFailed domain error. handlePassPrediction must
+// return it so Reconcile requeues, and must NOT clear the existing pass windows or record a
+// PredictionFailed condition. Mutation: treating the cancellation like any other error (the
+// pre-fix behaviour) clears NextPassWindows and sets PredictionFailed, so this fails.
+func TestHandlePassPrediction_ContextCancelled_IsControlFlowNotFailure(t *testing.T) {
+	sch := makeScheme(t)
+	gs := &ntnv1alpha1.GroundStationLifecycle{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-taipei", Namespace: "default"},
+		Spec: ntnv1alpha1.GroundStationLifecycleSpec{
+			Deployment: ntnv1alpha1.DeploymentSpec{Location: ntnv1alpha1.GeoLocation{Lat: "25.0330", Lon: "121.5654"}},
+		},
+	}
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-cancel", Namespace: "default", Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{Type: "CelesTrak", URL: "https://celestrak.org/x"},
+			PassPrediction: &ntnv1alpha1.PassPredictionSpec{
+				GroundStations: []string{"gs-taipei"},
+				MinElevation:   "10",
+				Horizon:        metav1.Duration{Duration: 24 * time.Hour},
+			},
+		},
+	}
+	// Pre-existing pass windows the cancellation path must NOT clear.
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{Satellite: "ISS", GroundStation: "gs-taipei"}}
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(gs).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := r.handlePassPrediction(ctx, eph,
+		ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMForTest()}}, time.Now())
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("a cancelled context must be returned as a control-flow error, got %v", err)
+	}
+	if len(eph.Status.NextPassWindows) != 1 {
+		t.Fatalf("cancellation must NOT clear pass windows; got %d, want the 1 pre-existing window",
+			len(eph.Status.NextPassWindows))
+	}
+	if c := meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted); c != nil &&
+		c.Reason == "PredictionFailed" {
+		t.Fatalf("cancellation must NOT record a PredictionFailed condition; got %+v", c)
+	}
+}

--- a/internal/controller/satelliteephemeris_passhorizon_test.go
+++ b/internal/controller/satelliteephemeris_passhorizon_test.go
@@ -15,26 +15,37 @@ import (
 	"time"
 )
 
-// TestEffectivePassHorizon pins #233: the pass-prediction horizon defaults when unset and is
-// clamped to maxPassHorizon otherwise, so an unbounded horizon cannot stall the reconcile.
-// Mutation: dropping the maxPassHorizon ceiling makes the 30-day case pass through, so this fails.
+// TestEffectivePassHorizon pins #233: the pass-prediction horizon defaults when unset (0), is
+// REJECTED when negative (a config error, not silently defaulted — round-2 review), and is clamped
+// to maxPassHorizon otherwise, so an unbounded horizon cannot stall the reconcile. Mutations:
+// dropping the maxPassHorizon ceiling lets the 30-day case through; treating negative as 24h (the
+// pre-fix behaviour) makes the negative case return no error — both fail here.
 func TestEffectivePassHorizon(t *testing.T) {
 	cases := []struct {
 		name        string
 		raw         time.Duration
 		want        time.Duration
 		wantClamped bool
+		wantErr     bool
 	}{
-		{"unset defaults to 24h", 0, 24 * time.Hour, false},
-		{"negative defaults to 24h", -time.Hour, 24 * time.Hour, false},
-		{"within bound is unchanged", 12 * time.Hour, 12 * time.Hour, false},
-		{"exactly at max is unchanged", maxPassHorizon, maxPassHorizon, false},
-		{"just over max is clamped", maxPassHorizon + time.Hour, maxPassHorizon, true},
-		{"30 days is clamped", 30 * 24 * time.Hour, maxPassHorizon, true},
+		{"unset defaults to 24h", 0, 24 * time.Hour, false, false},
+		{"negative is rejected", -time.Hour, 0, false, true},
+		{"one nanosecond negative is rejected", -time.Nanosecond, 0, false, true},
+		{"within bound is unchanged", 12 * time.Hour, 12 * time.Hour, false, false},
+		{"exactly at max is unchanged", maxPassHorizon, maxPassHorizon, false, false},
+		{"just over max is clamped", maxPassHorizon + time.Nanosecond, maxPassHorizon, true, false},
+		{"30 days is clamped", 30 * 24 * time.Hour, maxPassHorizon, true, false},
+		{"very large duration is clamped", 1<<62 - 1, maxPassHorizon, true, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, clamped := effectivePassHorizon(c.raw)
+			got, clamped, err := effectivePassHorizon(c.raw)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("effectivePassHorizon(%v) err = %v, wantErr %v", c.raw, err, c.wantErr)
+			}
+			if c.wantErr {
+				return // on error, horizon/clamped are not meaningful
+			}
 			if got != c.want || clamped != c.wantClamped {
 				t.Fatalf("effectivePassHorizon(%v) = (%v, %v), want (%v, %v)",
 					c.raw, got, clamped, c.want, c.wantClamped)

--- a/internal/controller/satelliteephemeris_passhorizon_test.go
+++ b/internal/controller/satelliteephemeris_passhorizon_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEffectivePassHorizon pins #233: the pass-prediction horizon defaults when unset and is
+// clamped to maxPassHorizon otherwise, so an unbounded horizon cannot stall the reconcile.
+// Mutation: dropping the maxPassHorizon ceiling makes the 30-day case pass through, so this fails.
+func TestEffectivePassHorizon(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         time.Duration
+		want        time.Duration
+		wantClamped bool
+	}{
+		{"unset defaults to 24h", 0, 24 * time.Hour, false},
+		{"negative defaults to 24h", -time.Hour, 24 * time.Hour, false},
+		{"within bound is unchanged", 12 * time.Hour, 12 * time.Hour, false},
+		{"exactly at max is unchanged", maxPassHorizon, maxPassHorizon, false},
+		{"just over max is clamped", maxPassHorizon + time.Hour, maxPassHorizon, true},
+		{"30 days is clamped", 30 * 24 * time.Hour, maxPassHorizon, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, clamped := effectivePassHorizon(c.raw)
+			if got != c.want || clamped != c.wantClamped {
+				t.Fatalf("effectivePassHorizon(%v) = (%v, %v), want (%v, %v)",
+					c.raw, got, clamped, c.want, c.wantClamped)
+			}
+		})
+	}
+}

--- a/pkg/ephemeris/pass_ordering_test.go
+++ b/pkg/ephemeris/pass_ordering_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ephemeris
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func TestPredictPasses_DeterministicOrdering(t *testing.T) {
 	stations := []GroundStation{{Latitude: 25.0330, Longitude: 121.5654, Altitude: 15}}
 	start := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
 
-	first, err := PredictPasses(omms, stations, 10.0, 24*time.Hour, nil, start)
+	first, err := PredictPasses(context.Background(), omms, stations, 10.0, 24*time.Hour, nil, start)
 	if err != nil {
 		t.Fatalf("predict: %v", err)
 	}
@@ -51,7 +52,7 @@ func TestPredictPasses_DeterministicOrdering(t *testing.T) {
 
 	// 1. Byte-identical across repeated runs (determinism).
 	for i := range 8 {
-		again, err := PredictPasses(omms, stations, 10.0, 24*time.Hour, nil, start)
+		again, err := PredictPasses(context.Background(), omms, stations, 10.0, 24*time.Hour, nil, start)
 		if err != nil {
 			t.Fatalf("predict run %d: %v", i, err)
 		}

--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -57,10 +57,14 @@ type PassResult struct {
 // error (it does not silently degrade). It filters by minElevation, limits results to
 // MaxPassWindows, and uses concurrent workers.
 // The startTime parameter sets the prediction window start; pass time.Time{} to use time.Now().
-// ctx cancellation is honoured between work items (each item is one satellite × ground station
-// over the whole horizon), so a cancelled/timed-out caller aborts promptly and PredictPasses
-// returns ctx.Err(); the caller (the reconcile) should also bound the horizon to keep any single
-// work item small.
+//
+// ctx cancellation is honoured BETWEEN work items (each item is one satellite × ground station over
+// the whole horizon): a cancelled or timed-out call stops dispatching new items and returns
+// ctx.Err(), but an item already running finishes, because the upstream sgp4.GeneratePasses sweep
+// takes no context. The caller MUST bound the horizon (see the reconcile's 7-day clamp) so a single
+// item stays small — at the 7-day clamp one item is ~20ms (BenchmarkPredictPasses_7d_*), so a
+// cancelled call returns within roughly that bound. This is coarse-grained, between-item, not
+// mid-sweep cancellation; finer granularity would need a context-aware GeneratePasses upstream.
 func PredictPasses(
 	ctx context.Context,
 	omms []sgp4.OMM,
@@ -126,7 +130,7 @@ func PredictPasses(
 				if ctx.Err() != nil {
 					return // cancelled/timed-out: stop pulling new work items
 				}
-				passes, err := predictSingle(item.omm, item.station, start, stop, minElevation)
+				passes, err := predictSingleFn(item.omm, item.station, start, stop, minElevation)
 				mu.Lock()
 				if err != nil && firstErr == nil {
 					firstErr = err
@@ -221,6 +225,11 @@ func lessPass(a, b PassResult) bool {
 	}
 	return a.LOS.Before(b.LOS)
 }
+
+// predictSingleFn is the per-work-item predictor the worker pool calls. It is a package var (not a
+// direct call) so tests can substitute a counting/blocking implementation and prove that a cancelled
+// context stops the pool from dispatching further work items.
+var predictSingleFn = predictSingle
 
 // predictSingle computes pass windows for a single satellite over a single ground station.
 func predictSingle(

--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ephemeris
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -56,7 +57,12 @@ type PassResult struct {
 // error (it does not silently degrade). It filters by minElevation, limits results to
 // MaxPassWindows, and uses concurrent workers.
 // The startTime parameter sets the prediction window start; pass time.Time{} to use time.Now().
+// ctx cancellation is honoured between work items (each item is one satellite × ground station
+// over the whole horizon), so a cancelled/timed-out caller aborts promptly and PredictPasses
+// returns ctx.Err(); the caller (the reconcile) should also bound the horizon to keep any single
+// work item small.
 func PredictPasses(
+	ctx context.Context,
 	omms []sgp4.OMM,
 	stations []GroundStation,
 	minElevation float64,
@@ -117,6 +123,9 @@ func PredictPasses(
 	for range numWorkers {
 		wg.Go(func() {
 			for item := range workCh {
+				if ctx.Err() != nil {
+					return // cancelled/timed-out: stop pulling new work items
+				}
 				passes, err := predictSingle(item.omm, item.station, start, stop, minElevation)
 				mu.Lock()
 				if err != nil && firstErr == nil {
@@ -128,6 +137,12 @@ func PredictPasses(
 		})
 	}
 	wg.Wait()
+
+	// A cancelled/timed-out context takes precedence over partial results: the caller
+	// (reconcile) will requeue, and partial pass windows would falsely converge status.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	if firstErr != nil && len(allPasses) == 0 {
 		return nil, firstErr

--- a/pkg/ephemeris/pass_predictor_cancel_test.go
+++ b/pkg/ephemeris/pass_predictor_cancel_test.go
@@ -13,6 +13,8 @@ package ephemeris
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,5 +38,58 @@ func TestPredictPasses_ContextCancelled(t *testing.T) {
 	}
 	if passes != nil {
 		t.Errorf("no partial pass windows should be returned on cancellation, got %d", len(passes))
+	}
+}
+
+// TestPredictPasses_CancelStopsDispatchingQueuedWork proves the per-worker ctx.Err() check does
+// real work — it stops the pool from dispatching QUEUED items once the context is cancelled. The
+// pre-cancel test above passes even with that check removed (the final return catches ctx.Err),
+// so it cannot pin the between-item guarantee. Here 32 items are queued but only 8 (one per worker)
+// are in flight when the context is cancelled; the remaining 24 must never reach predictSingleFn.
+// Mutation: remove the worker's `if ctx.Err() != nil { return }` and all 32 run, so calls != 8.
+func TestPredictPasses_CancelStopsDispatchingQueuedWork(t *testing.T) {
+	const workers = 8
+	omms := make([]sgp4.OMM, 32)
+	for i := range omms {
+		o := issOMM()
+		o.NoradCatID = 40000 + i
+		omms[i] = o
+	}
+	stations := []GroundStation{montrealStation}
+
+	var calls atomic.Int64
+	release := make(chan struct{})
+	var firstBatch sync.WaitGroup
+	firstBatch.Add(workers)
+
+	orig := predictSingleFn
+	defer func() { predictSingleFn = orig }()
+	predictSingleFn = func(_ sgp4.OMM, _ GroundStation, _, _ time.Time, _ float64) ([]PassResult, error) {
+		if n := calls.Add(1); n <= workers {
+			firstBatch.Done() // this in-flight worker has started its single item
+			<-release         // hold it here until the test has cancelled the context
+		}
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var result error
+	go func() {
+		_, result = PredictPasses(ctx, omms, stations, 10, 24*time.Hour, nil, time.Now())
+		close(done)
+	}()
+
+	firstBatch.Wait() // all 8 workers are now blocked inside predictSingleFn (8 items in flight)
+	cancel()          // cancel while 24 items are still queued
+	close(release)    // let the 8 in-flight items complete; workers then see ctx.Err and stop
+	<-done
+
+	if !errors.Is(result, context.Canceled) {
+		t.Fatalf("cancelled PredictPasses must return context.Canceled, got %v", result)
+	}
+	if got := calls.Load(); got != workers {
+		t.Fatalf("after cancel, only the %d in-flight items may run; the %d queued items must not be "+
+			"dispatched, but predictSingleFn was called %d times", workers, len(omms)-workers, got)
 	}
 }

--- a/pkg/ephemeris/pass_predictor_cancel_test.go
+++ b/pkg/ephemeris/pass_predictor_cancel_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+)
+
+// TestPredictPasses_ContextCancelled pins #233: a cancelled/timed-out context aborts the sweep
+// and PredictPasses returns ctx.Err() rather than running the full O(horizon × sats × stations)
+// work and returning partial windows. Mutation: removing the ctx.Err() checks makes it return
+// (passes, nil), so this fails.
+func TestPredictPasses_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before any work runs
+
+	passes, err := PredictPasses(ctx,
+		[]sgp4.OMM{issOMM()}, []GroundStation{montrealStation},
+		10, 24*time.Hour, nil, time.Now())
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("a cancelled context must return context.Canceled; got passes=%d err=%v", len(passes), err)
+	}
+	if passes != nil {
+		t.Errorf("no partial pass windows should be returned on cancellation, got %d", len(passes))
+	}
+}

--- a/pkg/ephemeris/pass_predictor_mask_test.go
+++ b/pkg/ephemeris/pass_predictor_mask_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ephemeris
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -151,7 +152,7 @@ func TestPredictPasses_MaskConformance(t *testing.T) {
 	start := time.Now().UTC()
 	horizon := 72 * time.Hour
 
-	masked, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
+	masked, err := PredictPasses(context.Background(), []sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
 	if err != nil {
 		t.Fatalf("PredictPasses(mask=%.0f): %v", mask, err)
 	}
@@ -196,11 +197,11 @@ func TestPredictPasses_MaskWindowSubset(t *testing.T) {
 	start := time.Now().UTC()
 	horizon := 72 * time.Hour
 
-	full, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, 0, horizon, nil, start)
+	full, err := PredictPasses(context.Background(), []sgp4.OMM{omm}, []GroundStation{gs}, 0, horizon, nil, start)
 	if err != nil {
 		t.Fatalf("full: %v", err)
 	}
-	masked, err := PredictPasses([]sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
+	masked, err := PredictPasses(context.Background(), []sgp4.OMM{omm}, []GroundStation{gs}, mask, horizon, nil, start)
 	if err != nil {
 		t.Fatalf("masked: %v", err)
 	}

--- a/pkg/ephemeris/pass_predictor_rounding_test.go
+++ b/pkg/ephemeris/pass_predictor_rounding_test.go
@@ -11,6 +11,7 @@ You may obtain a copy of the License at
 package ephemeris
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -23,13 +24,15 @@ import (
 // not a silent degradation to 0°-horizon passes (NaN mask comparisons are all false).
 func TestPredictPasses_RejectsInvalidMask(t *testing.T) {
 	for _, mask := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -1, 90.1, 1000} {
-		_, err := PredictPasses([]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, mask, 24*time.Hour, nil, time.Time{})
+		_, err := PredictPasses(context.Background(),
+			[]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, mask, 24*time.Hour, nil, time.Time{})
 		if err == nil {
 			t.Errorf("PredictPasses(minElevation=%v) must error (invalid mask), got nil", mask)
 		}
 	}
 	// A valid mask still works.
-	_, err := PredictPasses([]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, 10, 24*time.Hour, nil, time.Time{})
+	_, err := PredictPasses(context.Background(),
+		[]sgp4.OMM{issOMM()}, []GroundStation{montrealStation}, 10, 24*time.Hour, nil, time.Time{})
 	if err != nil {
 		t.Fatalf("a valid mask must not error: %v", err)
 	}
@@ -122,7 +125,7 @@ func TestConservativePassWindow_CollapsesSubSecondWindow(t *testing.T) {
 // sub-second bisection (refineMaskCrossing, ~200ms tol) that the rounding then cleans up.
 // Mutation: remove the ceil/floor in predictSingle → AOS/LOS carry sub-second nanos.
 func TestPredictPasses_WholeSecondWindow_P2_1(t *testing.T) {
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation, taipeiStation},
 		10, // above the horizon, so the mask trim + bisection actually run

--- a/pkg/ephemeris/pass_predictor_test.go
+++ b/pkg/ephemeris/pass_predictor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ephemeris
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -84,7 +85,7 @@ var montrealStation = GroundStation{
 }
 
 func TestPredictPasses_SingleSatellite(t *testing.T) {
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation},
 		0, // all passes above horizon
@@ -115,7 +116,7 @@ func TestPredictPasses_SingleSatellite(t *testing.T) {
 }
 
 func TestPredictPasses_MinElevationFilter(t *testing.T) {
-	allPasses, err := PredictPasses(
+	allPasses, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation},
 		0, // no filter
@@ -127,7 +128,7 @@ func TestPredictPasses_MinElevationFilter(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	filteredPasses, err := PredictPasses(
+	filteredPasses, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation},
 		30, // high threshold
@@ -154,7 +155,7 @@ func TestPredictPasses_NoradFilter(t *testing.T) {
 	omms := []sgp4.OMM{issOMM(), onewebOMM()}
 
 	// Filter to ISS only.
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		omms,
 		[]GroundStation{montrealStation},
 		0,
@@ -174,7 +175,7 @@ func TestPredictPasses_NoradFilter(t *testing.T) {
 }
 
 func TestPredictPasses_MultipleStations(t *testing.T) {
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation, taipeiStation},
 		0,
@@ -197,7 +198,8 @@ func TestPredictPasses_MultipleStations(t *testing.T) {
 
 func TestPredictPasses_EmptyInputs(t *testing.T) {
 	// No OMMs.
-	passes, err := PredictPasses(nil, []GroundStation{montrealStation}, 0, 24*time.Hour, nil, time.Time{})
+	passes, err := PredictPasses(context.Background(),
+		nil, []GroundStation{montrealStation}, 0, 24*time.Hour, nil, time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -206,7 +208,7 @@ func TestPredictPasses_EmptyInputs(t *testing.T) {
 	}
 
 	// No stations.
-	passes, err = PredictPasses([]sgp4.OMM{issOMM()}, nil, 0, 24*time.Hour, nil, time.Time{})
+	passes, err = PredictPasses(context.Background(), []sgp4.OMM{issOMM()}, nil, 0, 24*time.Hour, nil, time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -216,7 +218,7 @@ func TestPredictPasses_EmptyInputs(t *testing.T) {
 }
 
 func TestPredictPasses_NoradFilterMatchesNone(t *testing.T) {
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation},
 		0,
@@ -233,7 +235,7 @@ func TestPredictPasses_NoradFilterMatchesNone(t *testing.T) {
 }
 
 func TestPredictPasses_SortedByAOS(t *testing.T) {
-	passes, err := PredictPasses(
+	passes, err := PredictPasses(context.Background(),
 		[]sgp4.OMM{issOMM()},
 		[]GroundStation{montrealStation},
 		0,

--- a/pkg/ephemeris/propagator_bench_test.go
+++ b/pkg/ephemeris/propagator_bench_test.go
@@ -102,3 +102,41 @@ func BenchmarkPredictPasses_10Sats2Stations(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkPredictPasses_7d_1Sat1Station and _7d_10Sats2Stations measure the WORST-CASE horizon
+// (the 7-day maxPassHorizon clamp). Because ctx cancellation is honoured only BETWEEN work items,
+// a single item's wall-clock cost is the upper bound on how long a cancelled PredictPasses can
+// take to return, so these numbers justify the coarse-grained cancellation design.
+func BenchmarkPredictPasses_7d_1Sat1Station(b *testing.B) {
+	omm := benchOMM()
+	stations := []GroundStation{{Name: "taipei", Latitude: 25.033, Longitude: 121.565, Altitude: 15}}
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := PredictPasses(context.Background(), []sgp4.OMM{omm}, stations, 10.0, 7*24*time.Hour, nil, start)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPredictPasses_7d_10Sats2Stations(b *testing.B) {
+	omms := make([]sgp4.OMM, 10)
+	for i := range omms {
+		omm := benchOMM()
+		omm.NoradCatID = 56700 + i
+		omm.MeanAnomaly = float64(i * 36)
+		omms[i] = omm
+	}
+	stations := []GroundStation{
+		{Name: "taipei", Latitude: 25.033, Longitude: 121.565, Altitude: 15},
+		{Name: "hsinchu", Latitude: 24.796, Longitude: 120.997, Altitude: 50},
+	}
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := PredictPasses(context.Background(), omms, stations, 10.0, 7*24*time.Hour, nil, start); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/ephemeris/propagator_bench_test.go
+++ b/pkg/ephemeris/propagator_bench_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ephemeris
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func BenchmarkPredictPasses_SingleSatSingleStation(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := PredictPasses(
+		_, err := PredictPasses(context.Background(),
 			[]sgp4.OMM{omm}, stations, 10.0, horizon, nil, start,
 		)
 		if err != nil {
@@ -93,7 +94,7 @@ func BenchmarkPredictPasses_10Sats2Stations(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := PredictPasses(
+		_, err := PredictPasses(context.Background(),
 			omms, stations, 10.0, 24*time.Hour, nil, start,
 		)
 		if err != nil {


### PR DESCRIPTION
## What

Bounds the pass-prediction horizon and makes pass prediction respond to context cancellation, so an unbounded or slow prediction cannot stall the reconcile or block graceful shutdown.

## Design (revised after round-2 review)

- **Horizon clamp.** `passPrediction.horizon` is clamped to 7 days at reconcile time. This bounds the *horizon dimension* of a single satellite × ground-station work item; total reconcile cost still scales with the selected fleet × stations (whose stored output `MaxPassWindows` caps at 500). A **negative** horizon is now **rejected** as a config error (it previously became 24h silently); `0` still means "unset → 24h default".
- **Cancellation is between work items, not mid-sweep.** The upstream `sgp4.GeneratePasses` takes no `context`, so an item already running finishes; `PredictPasses` checks `ctx.Err()` before dispatching each next item and returns `ctx.Err()`. At the 7-day clamp a single item is **~20ms** (`BenchmarkPredictPasses_7d_*`), so a cancelled call returns within roughly that bound. This is coarse-grained; finer granularity would need a context-aware `GeneratePasses` upstream (a possible future upstream contribution).
- **Cancellation is control flow, not a domain failure.** `handlePassPrediction` returns `context.Canceled` / `DeadlineExceeded` to `Reconcile` (which requeues) instead of clearing pass windows, recording a `PredictionFailed` condition, and continuing to propagate.
- **Clamp is surfaced durably.** The clamp is added to the `PassesPredicted` condition message (generation/episode-stable) rather than logged on every ~3-minute re-propagation.

## Breaking change

`ephemeris.PredictPasses` now takes `ctx context.Context` as its first argument (source-breaking for any external Go caller). Internal call sites are updated.

## Tests (mutation-proven)

- `TestPredictPasses_CancelStopsDispatchingQueuedWork`: 32 items, 8 in flight when the context is cancelled; only those 8 run (the 24 queued items are never dispatched). Removing the worker's `ctx.Err()` check makes all 32 run.
- `TestHandlePassPrediction_ContextCancelled_IsControlFlowNotFailure`: a cancelled context is returned as an error and does **not** clear windows or set `PredictionFailed`.
- `TestEffectivePassHorizon`: negative → error; 0 → 24h; > 7d → clamped.
- `BenchmarkPredictPasses_7d_*`: worst-case single-item cost (~20ms).

`make test` (ephemeris 91.2%, controller 88.5%), `-race`, `golangci-lint` 0, no drift.