### PR TITLE
fix(ephemeris): stamp propagated epoch at propagation time, not reconcile-start (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The propagated ephemeris epoch is stamped at propagation time, not reconcile-start.** The
+  epoch was derived from the clock sampled at the top of the reconcile, but the fetch and pass
+  prediction run before propagation, so the delivered epoch was already aged by that compute —
+  eating into the `propagationEpochLead`. The clock is now re-sampled immediately before
+  propagation, so the epoch reflects the true propagation instant (the fetch/pass-prediction paths
+  keep the reconcile-start `now`, which is correct for their reconcile-relative windows) (#235,
+  part of #232).
 - **Pass windows are computed from the current time, not the last fetch time.** On a cached
   re-propagation the fetch timestamp could be up to 24h in the past, which started AOS/LOS
   windows stale; they now start at reconcile time (#200-C3).

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -76,12 +76,24 @@ type SatelliteEphemerisReconciler struct {
 	Fetcher                 ephemeris.GPFetcher          // CelesTrak fetcher
 	SpaceTrackFetcher       *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
 
+	// Now returns the current time; nil defaults to time.Now(). Injected in tests to make the
+	// propagation epoch — which is sampled at PROPAGATION time, not reconcile-start — deterministic.
+	Now func() time.Time
+
 	// ommCache holds the last real GP-fetch result per SatelliteEphemeris so the
 	// orbit can be re-propagated on a short cadence WITHOUT re-contacting the GP
 	// source (rate-limit etiquette; #179). Keyed by client.ObjectKey, evicted on
 	// CR deletion. In-memory only — a cold cache (e.g. after a restart) just forces
 	// one fetch on the next reconcile.
 	ommCache sync.Map
+}
+
+// now returns the injectable clock (r.Now) or time.Now() when unset.
+func (r *SatelliteEphemerisReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=satelliteephemeris,verbs=get;list;watch;create;update;patch;delete
@@ -187,7 +199,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// ~1–3 km/day from the element epoch (findings.md I-17). metav1.Duration
 	// serialises as a string, so both bounds are enforced here rather than via CEL.
 	effectiveInterval := r.clampRefreshInterval(ctx, eph)
-	now := time.Now()
+	now := r.now()
 
 	// Step 3: Can this reconcile be answered from cache WITHOUT contacting the source?
 	//   (a) inside the GP-refresh window — normal (#179), or
@@ -346,7 +358,11 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// an earlier version did) made OCUDU back-propagate hours from a position that
 	// was itself SGP4-propagated hours forward, compounding LEO error; a near-now
 	// epoch keeps OCUDU's internal propagation short and forward.
-	truncEvent := r.propagateStates(ctx, eph, result, now.Add(propagationEpochLead))
+	// #235: sample the epoch base at the ACTUAL propagation instant, not reconcile-start `now`.
+	// The fetch and pass prediction ran in between; a stale `now` would deliver an epoch already
+	// aged by that compute, eating into propagationEpochLead. (acquireOMMs and pass prediction
+	// keep the reconcile-start `now` — their windows are reconcile-relative, not epoch-critical.)
+	truncEvent := r.propagateStates(ctx, eph, result, r.now().Add(propagationEpochLead))
 
 	// Stamp the propagation-input digest these propagatedStates were computed under.
 	// Reaching here means the current spec's inputs were (re)propagated — from a fresh

--- a/internal/controller/satelliteephemeris_epochtime_test.go
+++ b/internal/controller/satelliteephemeris_epochtime_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestReconcile_EpochSampledAtPropagationTime pins #235: the propagated epoch is stamped from the
+// clock sampled at the ACTUAL propagation instant, not at reconcile-start. A fully fixed, injected
+// two-value clock returns the reconcile-start instant on its first read and the (later) propagation
+// instant on every subsequent read, so the stored epoch must equal EXACTLY propagation-time + lead.
+// Mutations that fail here: stamping from the reconcile-start `now` (== base + lead, not
+// propagationNow + lead); using a bare time.Now() instead of r.now() (would not equal the injected
+// propagation sample); adding/omitting the lead. The OMM epoch is fixed to base so the propagation
+// is a small, valid forward step and the test does not depend on the real wall clock.
+func TestReconcile_EpochSampledAtPropagationTime(t *testing.T) {
+	base := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	propagationNow := base.Add(time.Minute) // every clock read after the first
+	sch := makeScheme(t)
+
+	omm := issOMMForTest()
+	omm.EpochStr = base.Format("2006-01-02T15:04:05.000000") // element epoch = base → forward propagation
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-epochtime", Namespace: "default", Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: "eph-epochtime", Namespace: "default"}
+
+	var calls int
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50),
+		Fetcher: &mockGPFetcher{result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{omm}, SatelliteCount: 1, FetchedAt: base,
+		}},
+		// First read is the reconcile-start instant; every later read (including the one just before
+		// propagateStates) is the propagation instant. So the epoch is exact iff it re-sampled.
+		Now: func() time.Time {
+			calls++
+			if calls == 1 {
+				return base
+			}
+			return propagationNow
+		},
+	}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Status.PropagatedStates) == 0 {
+		t.Fatal("expected a propagated state")
+	}
+	epochMs := got.Status.PropagatedStates[0].EpochUnixMs
+	wantEpochMs := propagationNow.Add(propagationEpochLead).UnixMilli()
+	if epochMs != wantEpochMs {
+		t.Fatalf("epoch = %d, want EXACTLY the propagation-time sample + lead = %d "+
+			"(reconcile-start + lead would be %d)", epochMs, wantEpochMs, base.Add(propagationEpochLead).UnixMilli())
+	}
+	if calls < 2 {
+		t.Fatalf("clock sampled %d time(s); the epoch must come from a re-sample, so want at least 2", calls)
+	}
+}


### PR DESCRIPTION
Closes #235 · part of EPIC #232.

## Problem

The propagated ephemeris epoch was derived from the clock sampled at the **top** of the reconcile (`now := time.Now()`), but the fetch and pass prediction run *before* propagation. So the delivered epoch was already aged by that compute (fetch network latency + pass-prediction sweep), eating into the 5-minute `propagationEpochLead`.

## Fix

- Add an injectable clock (`SatelliteEphemerisReconciler.Now` + `now()` helper, `nil → time.Now()`; mirrors `NTNSliceReconciler`) so the epoch timing is deterministically testable.
- **Re-sample the clock immediately before `propagateStates`** and stamp the epoch from that instant. `acquireOMMs` and pass prediction keep the reconcile-start `now` (reconcile-relative windows, not epoch-critical). This also brings the producer's source-epoch staleness check closer to the consumer's push-time `now`.

## Test (mutation-proven)

`TestReconcile_EpochSampledAtPropagationTime` — a per-call-advancing clock proves the stored `EpochUnixMs` exceeds `reconcile-start + lead`. Mutation: reverting to the reconcile-start `now` makes it exactly `reconcile-start + lead`, so it fails.

## Scope note

The clock injection is **intentionally partial** — the fetch retry backoff (`nextFetchAttempt`) still uses `time.Now()`. Making that injectable belongs to #236 (retry state), which will need it to test the backoff deterministically. No unrelated default-clock behaviour changes; when `Now` is nil, clock reads still use `time.Now()`. Not in the paused SGP4→reconciler-wiring scope (timestamp precision, not structural rewiring).

## Verification

`make test` (controller 88.5%) · `-race` · `golangci-lint` fresh-cache **0** · `gofmt` · no CRD drift (`-race` run locally; CI runs `make test`) · image ref intact.