### PR TITLE
fix(ephemeris): correct GP-fetch retry-state accounting across error classes and the state cap (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GP-fetch retry ramp restarts on an episode change instead of leaking its count across error
+  classes.** The consecutive-failure counter is shared, but only the transient backoff branch
+  consumes it — a run of auth (or rate-limit) failures used to leave the count high and slam the
+  first following *transient* failure straight past the 1-minute ramp base (up to the whole refresh
+  interval), stranding fetch recovery long after the blip cleared. The ramp now restarts whenever
+  the retry episode changes — a new error class, or a new `retryKey` (a spec/interval edit) — while
+  a genuine same-episode transient run still ramps 1m, 2m, 4m … (#236, part of #232).
+- **Element-set epoch health is counted across the whole tracked set, not just the pre-cap subset.**
+  Unparseable / implausibly-future OMM EPOCHs were counted only inside the `maxPropagatedStates`
+  (128) propagation loop, yet the `SourceEpochRejected` condition reports them against the full
+  tracked count — so a larger-than-cap constellation under-reported rejections sitting beyond the
+  cap. The counting now runs in a full-set pre-pass, keeping numerator and denominator consistent
+  (#236, part of #232).
 - **Pass windows are computed from the current time, not the last fetch time.** On a cached
   re-propagation the fetch timestamp could be up to 24h in the past, which started AOS/LOS
   windows stale; they now start at reconcile time (#200-C3).

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -512,6 +512,56 @@ func fetchRetryDelay(fetchErr error, effectiveInterval time.Duration, failures i
 	}
 }
 
+// fetchErrClass buckets a failed fetch by its retry STRATEGY (mirrors fetchRetryDelay's switch).
+// It exists so applyFetchBackoff can tell when the retry EPISODE crossed a class boundary: only
+// the transient branch of fetchRetryDelay consumes the consecutive-failure count, so a run of one
+// class must not carry its count into the next.
+type fetchErrClass int
+
+const (
+	fetchErrTransient   fetchErrClass = iota // network/DNS/5xx/timeout/parse: the 1m,2m,4m… ramp
+	fetchErrRateLimited                      // HTTP 403 / Retry-After: honor the source's cadence
+	fetchErrAuth                             // bad credentials: bounded re-probe (maxAuthRetryBackoff)
+)
+
+// classifyFetchErrClass buckets err; a nil err classifies as transient (the zero value), which is
+// harmless because applyFetchBackoff is only ever called with a non-nil fetch error.
+func classifyFetchErrClass(err error) fetchErrClass {
+	switch {
+	case errors.Is(err, ephemeris.ErrRateLimited):
+		return fetchErrRateLimited
+	case errors.Is(err, ephemeris.ErrAuthFailed):
+		return fetchErrAuth
+	default:
+		return fetchErrTransient
+	}
+}
+
+// applyFetchBackoff advances the cache entry's consecutive-failure ramp after a failed fetch and
+// arms nextFetchAttempt. It RESTARTS the ramp (fetchFailures→0 before the ++) when the retry
+// EPISODE changes, so an accumulated count never leaks into a delay that was never meant to see it:
+//
+//   - New error class. Only fetchRetryDelay's transient branch reads fetchFailures; the auth and
+//     rate-limit branches return a fixed/interval-derived delay and IGNORE it. So without this a
+//     run of auth failures (each incrementing the count) would slam the FIRST following transient
+//     failure straight to 1m<<N — up to the whole refresh interval (24h) — instead of the 1-minute
+//     ramp base, stranding fetch recovery long after the transient blip cleared (#236).
+//   - New retryKey. A spec/interval edit is a fresh episode; cacheServe already bypasses the old
+//     backoff on a retryKey change, and the count must reset with it so the new episode's first
+//     transient failure also starts at the ramp base rather than inheriting the old episode's N.
+//
+// now is a parameter (production passes time.Now(), sampled AFTER the fetch returned so a 30s
+// client timeout does not eat the first 1-minute window) so the ramp is deterministically testable.
+func applyFetchBackoff(c *cachedFetch, fetchErr error, newRetryKey string, effectiveInterval time.Duration, now time.Time) {
+	if newRetryKey != c.retryKey || classifyFetchErrClass(fetchErr) != classifyFetchErrClass(c.lastFetchErr) {
+		c.fetchFailures = 0
+	}
+	c.fetchFailures++
+	c.nextFetchAttempt = now.Add(fetchRetryDelay(fetchErr, effectiveInterval, c.fetchFailures))
+	c.lastFetchErr = fetchErr
+	c.retryKey = newRetryKey
+}
+
 // cacheServeReason says WHY a reconcile is being served from cache without contacting the source.
 type cacheServeReason int
 
@@ -766,20 +816,34 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	omms := ephemeris.FilterOMMs(result.OMMs, norad)
 	epochMs := epoch.UnixMilli()
 
-	// I-17: count tracked element sets whose OWN epoch is stale — a data property
-	// independent of whether SGP4 propagation then succeeds.
+	// Count element-set epoch health across the ENTIRE tracked set — independent of SGP4 success
+	// AND of the maxPropagatedStates cap in the propagation loop below. The cap-bounded loop reaches
+	// only the first `cap` propagatable satellites, yet these counts are reported against the full
+	// len(omms) denominator; counting here keeps numerator and denominator consistent so a >cap
+	// constellation does not silently drop the epoch-health accounting for its tail (#236, I-17):
+	//   - staleEpochs: parseable + plausible but older than maxEpochAge — a drifting feed, still
+	//     propagated and merely surfaced (EphemerisEpochStale); the consumer owns the delivery gate.
+	//   - unparseable / futureEpochs: refused BEFORE SGP4 (reportSourceEpochRejected). The
+	//     propagation loop below repeats these two checks only to SKIP such satellites, not to count.
 	now := epoch.Add(-propagationEpochLead) // epoch is now+lead; recover ~now
-	staleEpochs := 0
+	staleEpochs, unparseableEpochs, futureEpochs := 0, 0, 0
 	for i := range omms {
-		if t, ok := parseOMMEpoch(omms[i].EpochStr); ok && now.Sub(t) > maxEpochAge {
+		t, ok := parseOMMEpoch(omms[i].EpochStr)
+		if !ok {
+			unparseableEpochs++
+			continue
+		}
+		if err := sourceEpochPlausible(now, t); err != nil {
+			futureEpochs++
+			continue
+		}
+		if now.Sub(t) > maxEpochAge {
 			staleEpochs++
 		}
 	}
 
 	states := make([]ntnv1alpha1.PropagatedState, 0, min(len(omms), maxPropagatedStates))
 	skippedByCap := 0
-	unparseableEpochs := 0 // refused BEFORE SGP4: OMM EPOCH could not be parsed
-	futureEpochs := 0      // refused BEFORE SGP4: OMM EPOCH implausibly far in the future
 	for i := range omms {
 		if len(states) >= maxPropagatedStates {
 			// The cap is reached; the remaining OMMs are NOT attempted. This is the
@@ -806,7 +870,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		// same epoch, so an element set we cannot parse fails PropagateToECEF below anyway.
 		t, ok := parseOMMEpoch(omms[i].EpochStr)
 		if !ok {
-			unparseableEpochs++
+			// Already counted in the full-set pre-pass above; here we only SKIP it from propagation.
 			logf.FromContext(ctx).Info("skipping satellite: source element epoch is unparseable",
 				"norad", omms[i].NoradCatID, "epochStr", omms[i].EpochStr)
 			continue
@@ -816,7 +880,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		// observable; the consumer owns the delivery gate (#200-C4). Rejecting staleness here
 		// would collapse a precise "EphemerisStale" diagnosis into a bare "PayloadMissing".
 		if err := sourceEpochPlausible(now, t); err != nil {
-			futureEpochs++
+			// Already counted in the full-set pre-pass above; here we only SKIP it from propagation.
 			logf.FromContext(ctx).Info("skipping satellite: implausible source element epoch",
 				"norad", omms[i].NoradCatID, "sourceEpoch", t.UTC(), "err", err.Error())
 			continue
@@ -1307,13 +1371,11 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 			// 3-minute propagation cadence and keep the pushed epoch alive for the whole
 			// outage. (Before this, the serve-cache cycle requeued at the 2–24h fetch backoff,
 			// so the epoch expired ~5 minutes in and SIB19 went stale for the rest of it.)
-			c.fetchFailures++
-			// Measure the backoff from when the failure ACTUALLY happened, not from the `now`
-			// captured before the fetch: a 30s HTTP timeout (the client's timeout is exactly
-			// 30s) would otherwise eat 30s of the first 1-minute transient backoff.
-			c.nextFetchAttempt = time.Now().Add(fetchRetryDelay(fetchErr, effectiveInterval, c.fetchFailures))
-			c.lastFetchErr = fetchErr
-			c.retryKey = retryInputKey(eph.Spec, effectiveInterval)
+			// Advance the fetch-retry ramp and arm nextFetchAttempt. applyFetchBackoff restarts
+			// the ramp when the retry episode changed (new error class or new retryKey), and takes
+			// now = time.Now() sampled HERE — after the fetch returned — so a 30s client timeout
+			// does not eat the first 1-minute transient window (#236, extends #221 review finding 2).
+			applyFetchBackoff(&c, fetchErr, retryInputKey(eph.Spec, effectiveInterval), effectiveInterval, time.Now())
 			r.ommCache.Store(req.NamespacedName, c)
 			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
 				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String(),

--- a/internal/controller/satelliteephemeris_retrystate_test.go
+++ b/internal/controller/satelliteephemeris_retrystate_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestApplyFetchBackoff_AuthThenTransientRestartsAtOneMinute pins #236: the consecutive-failure
+// counter is shared, but only fetchRetryDelay's TRANSIENT branch consumes it. A run of auth
+// failures (whose delay ignores the count) must not leave the count high and slam the FIRST
+// following transient failure past the 1-minute ramp base.
+func TestApplyFetchBackoff_AuthThenTransientRestartsAtOneMinute(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	const interval = 4 * time.Hour
+	const key = "same-credential-key"
+	c := &cachedFetch{}
+
+	// A run of auth failures: the counter climbs, but the auth delay is a bounded fixed probe.
+	for range 4 {
+		applyFetchBackoff(c, ephemeris.ErrAuthFailed, key, interval, base)
+	}
+	if got, want := c.nextFetchAttempt.Sub(base), min(interval, maxAuthRetryBackoff); got != want {
+		t.Fatalf("auth backoff = %v, want %v (auth delay must ignore the counter)", got, want)
+	}
+	if c.fetchFailures != 4 {
+		t.Fatalf("an auth run should still accumulate the counter: got %d, want 4", c.fetchFailures)
+	}
+
+	// Operator fixes credentials IN PLACE (same Secret → same retryKey), then a genuine transient
+	// blip. The transient ramp MUST restart at its 1-minute base, not inherit the 4 auth failures.
+	transient := errors.New("dial tcp: i/o timeout")
+	applyFetchBackoff(c, transient, key, interval, base)
+	if got := c.nextFetchAttempt.Sub(base); got != time.Minute {
+		t.Fatalf("transient backoff after an auth run = %v, want 1m — the ramp was not restarted "+
+			"on the class change (without the reset fetchFailures=5 → 1m<<4 = 16m)", got)
+	}
+	if c.fetchFailures != 1 {
+		t.Fatalf("a class change must restart the ramp: fetchFailures = %d, want 1", c.fetchFailures)
+	}
+}
+
+// TestApplyFetchBackoff_RetryKeyChangeStartsNewEpisode pins #236: a spec/interval edit changes the
+// retryKey — cacheServe already bypasses the old backoff, and the counter must reset with it so the
+// new episode's first transient failure also starts at the ramp base (the class does NOT change
+// here, so this isolates the retryKey reset).
+func TestApplyFetchBackoff_RetryKeyChangeStartsNewEpisode(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	const interval = 4 * time.Hour
+	transient := errors.New("connection refused")
+	c := &cachedFetch{}
+
+	// Three transient failures on episode A: the ramp climbs 1m, 2m, 4m.
+	for i, want := range []time.Duration{time.Minute, 2 * time.Minute, 4 * time.Minute} {
+		applyFetchBackoff(c, transient, "keyA", interval, base)
+		if got := c.nextFetchAttempt.Sub(base); got != want {
+			t.Fatalf("episode-A step %d backoff = %v, want %v", i+1, got, want)
+		}
+	}
+
+	// A spec/interval edit changes the retryKey → a fresh episode. The ramp restarts at 1m.
+	applyFetchBackoff(c, transient, "keyB", interval, base)
+	if got := c.nextFetchAttempt.Sub(base); got != time.Minute {
+		t.Fatalf("a retryKey change must start a new episode at the 1m ramp base, got %v "+
+			"(without the reset fetchFailures=4 → 1m<<3 = 8m)", got)
+	}
+	if c.fetchFailures != 1 {
+		t.Fatalf("a retryKey change must restart the ramp: fetchFailures = %d, want 1", c.fetchFailures)
+	}
+}
+
+// TestApplyFetchBackoff_SameEpisodeRampAccumulates is the positive control: within ONE episode
+// (same error class AND same retryKey) the ramp must keep climbing. It guards against an
+// over-correction that resets on every call, which would peg the backoff at 1m forever and defeat
+// the polite-to-source exponential ramp.
+func TestApplyFetchBackoff_SameEpisodeRampAccumulates(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	const interval = 4 * time.Hour
+	transient := errors.New("i/o timeout")
+	c := &cachedFetch{}
+
+	for i, want := range []time.Duration{time.Minute, 2 * time.Minute, 4 * time.Minute, 8 * time.Minute} {
+		applyFetchBackoff(c, transient, "k", interval, base)
+		if got := c.nextFetchAttempt.Sub(base); got != want {
+			t.Fatalf("same-episode transient step %d = %v, want %v — the reset must be CONDITIONAL, "+
+				"not fire every call", i+1, got, want)
+		}
+	}
+	if c.fetchFailures != 4 {
+		t.Fatalf("same-episode ramp must accumulate: fetchFailures = %d, want 4", c.fetchFailures)
+	}
+}
+
+// TestPropagateStates_RejectedEpochBeyondCapIsReported pins #236: element-set epoch health is
+// reported against the FULL len(omms) denominator, but the pre-#236 counters were incremented only
+// inside the maxPropagatedStates-bounded propagation loop. A >cap constellation therefore
+// under-reported unparseable/future epochs sitting beyond the cap. The counting now runs in a
+// full-set pre-pass, so a beyond-cap rejection is still surfaced.
+func TestPropagateStates_RejectedEpochBeyondCapIsReported(t *testing.T) {
+	r := &SatelliteEphemerisReconciler{}
+
+	// maxPropagatedStates valid, propagatable satellites fill the cap ...
+	omms := make([]sgp4.OMM, 0, maxPropagatedStates+2)
+	for i := range maxPropagatedStates {
+		o := issOMMForTest()
+		o.NoradCatID = 25544 + i
+		omms = append(omms, o)
+	}
+	// ... then two element sets whose OMM EPOCH is UNPARSEABLE sit BEYOND the cap. The cap-bounded
+	// propagation loop breaks before reaching them, so before #236 they were invisible to
+	// reportSourceEpochRejected even though its denominator (len(omms)) counts them.
+	for i := range 2 {
+		bad := issOMMForTest()
+		bad.NoradCatID = 40000 + i
+		bad.EpochStr = "not-a-timestamp"
+		omms = append(omms, bad)
+	}
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-beyondcap", Namespace: "default"},
+	}
+	r.propagateStates(context.Background(), eph,
+		ephemeris.GPFetchResult{OMMs: omms}, time.Now().Add(propagationEpochLead))
+
+	// The cap is still enforced — only maxPropagatedStates states are emitted ...
+	if n := len(eph.Status.PropagatedStates); n != maxPropagatedStates {
+		t.Fatalf("expected the state list capped at %d, got %d", maxPropagatedStates, n)
+	}
+	// ... yet the two beyond-cap unparseable epochs are surfaced durably.
+	cond := meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionSourceEpochRejected)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatal("beyond-cap unparseable epochs must be surfaced via SourceEpochRejected=True — " +
+			"before #236 the cap-bounded loop skipped them, so the counter stayed 0 and this was False")
+	}
+	if !strings.Contains(cond.Message, "2 of 130") {
+		t.Fatalf("the condition must count BOTH beyond-cap rejections against the FULL 130-element "+
+			"denominator (128 valid + 2 unparseable), got message: %q", cond.Message)
+	}
+	if cond.Reason != "UnparseableSourceEpoch" {
+		t.Fatalf("unparseable-only rejections must use Reason=UnparseableSourceEpoch, got %q", cond.Reason)
+	}
+}
+
+// TestObtainOMMs_TransientAfterAuth_RestartsRampThroughWiring is the end-to-end companion to the
+// applyFetchBackoff helper tests: it drives the ACTUAL production path (obtainOMMs), so a future
+// change that reverts obtainOMMs to an inline `c.fetchFailures++` while keeping the helper would be
+// caught here. The cache is seeded mid-AUTH-episode with a high count; a transient fetch error must
+// restart the ramp to 1 (class change auth->transient) and arm nextFetchAttempt ~1 minute out.
+// Mutation: an inline `++` that ignores the episode reset leaves fetchFailures at 6, failing this.
+func TestObtainOMMs_TransientAfterAuth_RestartsRampThroughWiring(t *testing.T) {
+	sch := makeScheme(t)
+	const interval = 4 * time.Hour
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-wire", Namespace: "default", UID: "uid-wire", Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/x",
+				RefreshInterval: metav1.Duration{Duration: interval},
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(eph)
+	r := &SatelliteEphemerisReconciler{
+		Client: fake.NewClientBuilder().WithScheme(sch).Build(), Scheme: sch, Recorder: events.NewFakeRecorder(10),
+	}
+
+	// Seed the cache mid-AUTH-episode with a high consecutive-failure count and a valid served result.
+	r.ommCache.Store(key, cachedFetch{
+		result:        ephemeris.GPFetchResult{OMMs: []sgp4.OMM{issOMMForTest()}, FetchedAt: time.Now().Add(-time.Hour)},
+		fetchKey:      fetchInputKey(eph.Spec),
+		uid:           eph.UID,
+		fetchFailures: 5,
+		lastFetchErr:  ephemeris.ErrAuthFailed,
+		retryKey:      retryInputKey(eph.Spec, interval),
+	})
+
+	fetcher := &mockGPFetcher{err: errors.New("dial tcp: connection refused")} // a genuine transient error
+	before := time.Now()
+	outcome, res, err := r.obtainOMMs(context.Background(),
+		reconcile.Request{NamespacedName: key}, eph, fetcher, interval, time.Now())
+	if err != nil || res != nil {
+		t.Fatalf("a transient error over a valid cache must serve cache, not error/short-circuit; err=%v res=%v", err, res)
+	}
+	if !outcome.servedCacheOnError {
+		t.Fatalf("expected servedCacheOnError, got %+v", outcome)
+	}
+
+	got, ok := r.cachedOMMResult(key)
+	if !ok {
+		t.Fatal("cache entry missing after obtainOMMs")
+	}
+	if got.fetchFailures != 1 {
+		t.Fatalf("auth->transient through obtainOMMs must restart the ramp to 1, got %d "+
+			"(an inline ++ that ignores the episode reset would give 6)", got.fetchFailures)
+	}
+	if delay := got.nextFetchAttempt.Sub(before); delay < time.Minute || delay > time.Minute+5*time.Second {
+		t.Fatalf("the first transient backoff must be ~1 minute from fetch completion, got %s", delay)
+	}
+}


### PR DESCRIPTION
Closes #236 · part of EPIC #232. Two retry-state correctness gaps found in the round-4 review of the merged continuity PRs.

## 1. Shared consecutive-failure counter leaked across error classes

`fetchRetryDelay` only reads `fetchFailures` in its **transient** branch; the **auth** and **rate-limit** branches return a fixed / interval-derived delay and *ignore* it. So a run of auth failures (each `++`-ing the counter) left the count high and slammed the **first following transient failure** straight to `1m<<N` — up to the whole refresh interval (24h) — instead of the 1-minute ramp base. Concretely: bad credentials for a while → operator fixes the Secret **in place** (same name → same `retryKey`, so no bypass) → a genuine transient network blip now backs the *fetch* off for hours instead of retrying at 1m, 2m, 4m …, stranding recovery long after the blip cleared.

**Fix:** extract `applyFetchBackoff(c, err, newRetryKey, interval, now)`, which restarts the ramp (`fetchFailures→0`) when the retry **episode** changes:
- a **new error class** (only the transient branch consumes the count), or
- a **new `retryKey`** — a spec/interval edit; `cacheServe` already bypasses the old backoff on a `retryKey` change, so the count must reset with it.

`now` is a parameter (production passes `time.Now()` sampled *after* the fetch returned, preserving the "don't let a 30s client timeout eat the first 1-minute window" semantic), so the ramp is deterministically testable — which also satisfies the #235 note **without** threading `r.now()` through `obtainOMMs`.

## 2. Beyond-cap source-epoch rejections under-counted

Unparseable / implausibly-future OMM `EPOCH`s were counted only **inside** the `maxPropagatedStates` (128) propagation loop, yet `reportSourceEpochRejected` reports them against the full `len(omms)` denominator. So a **larger-than-cap constellation** reported "X of N rejected" while only ever scanning the pre-cap subset — the tail was invisible.

**Fix:** fold the unparseable/future counting into the existing **full-set** stale-epoch pre-pass; the propagation loop repeats the two checks only to *skip* such satellites, not to count. Numerator and denominator are now consistent.

## Tests (all mutation-proven)

| Test | Mutation that makes it fail |
|---|---|
| `AuthThenTransientRestartsAtOneMinute` | drop the class-change reset → 16m, not 1m |
| `RetryKeyChangeStartsNewEpisode` | drop the retryKey-change reset → 8m, not 1m |
| `SameEpisodeRampAccumulates` (positive control) | reset on *every* call → ramp pegged at 1m |
| `RejectedEpochBeyondCapIsReported` | count only in-loop → beyond-cap rejections stay invisible (condition False) |

All four mutations were verified to fail with the fix reverted, then pass restored.

## Verification

`make test` (controller 88.5%, ephemeris 91.2%) · `-race` · `golangci-lint` fresh-cache **0** · `gofmt` · no CRD drift · image ref intact. Not in the paused SGP4→reconciler-wiring scope (retry accounting, not structural rewiring).