### PR TITLE
docs: fix drift in SECURITY, CONTRIBUTING, and the sourceEpochUnixMs API comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing!
 ## Development Setup
 
 ```bash
-# Prerequisites: Go 1.25+, kubebuilder v4.13+, kubectl, Kind
+# Prerequisites: Go 1.26.5+, kubebuilder v4.13+, kubectl, Kind
 
 # Build & Test
 make generate    # Generate DeepCopy methods

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,8 @@ Include:
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.7.x   | Yes       |
+| < 0.7.0 | No        |
 
 ## Security Measures
 
@@ -33,7 +34,7 @@ This project implements the following security practices:
 - **SSRF prevention**: All outbound HTTP clients validate resolved IPs against private ranges at the TCP dial level, including redirect targets (see `pkg/netutil/safeclient.go`)
 - **Namespace isolation**: Controllers enforce that provider operations stay within the CR's own namespace
 - **CEL CRD validation**: Server-side validation rules (URL scheme, lat/lon range, credential requirements) without webhook infrastructure
-- **Secret management**: SpaceTrack credentials read from K8s Secrets with scoped RBAC (`secrets:get;list;watch`)
+- **Secret management**: SpaceTrack credentials read from K8s Secrets with a minimal RBAC of `secrets:get` only — an uncached, per-request read. The operator holds no `list` or `watch` on Secrets.
 - **Read-only filesystem**: Container runs with `readOnlyRootFilesystem: true`
 - **Non-root execution**: Container runs as UID 65532 (distroless nonroot)
 - **Minimal capabilities**: All Linux capabilities are dropped

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -168,8 +168,10 @@ type PropagatedState struct {
 	// future propagation target), this is the element-set age used by the runtime-push
 	// consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
 	// freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-	// this one. 0 means the source epoch could not be parsed (treated as unknown, not
-	// stale).
+	// this one. The producer no longer emits a state whose source epoch it could not parse
+	// (those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+	// here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+	// instant subject to the normal staleness bound, not as "unknown" or fresh.
 	// +optional
 	SourceEpochUnixMs int64 `json:"sourceEpochUnixMs,omitempty"`
 	// ecef is the propagated position/velocity in 3GPP codepoints. The provider

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -374,8 +374,10 @@ spec:
                         future propagation target), this is the element-set age used by the runtime-push
                         consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
                         freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
-                        stale).
+                        this one. The producer no longer emits a state whose source epoch it could not parse
+                        (those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+                        here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+                        instant subject to the normal staleness bound, not as "unknown" or fresh.
                       format: int64
                       type: integer
                   required:

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -374,8 +374,10 @@ spec:
                         future propagation target), this is the element-set age used by the runtime-push
                         consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
                         freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
-                        stale).
+                        this one. The producer no longer emits a state whose source epoch it could not parse
+                        (those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+                        here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+                        instant subject to the normal staleness bound, not as "unknown" or fresh.
                       format: int64
                       type: integer
                   required:

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -377,8 +377,10 @@ spec:
                         future propagation target), this is the element-set age used by the runtime-push
                         consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
                         freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
-                        stale).
+                        this one. The producer no longer emits a state whose source epoch it could not parse
+                        (those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+                        here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+                        instant subject to the normal staleness bound, not as "unknown" or fresh.
                       format: int64
                       type: integer
                   required:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3569,8 +3569,10 @@ this state was propagated FROM, in Unix milliseconds. Unlike epochUnixMs (the
 future propagation target), this is the element-set age used by the runtime-push
 consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
 freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-this one. 0 means the source epoch could not be parsed (treated as unknown, not
-stale).<br/>
+this one. The producer no longer emits a state whose source epoch it could not parse
+(those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+instant subject to the normal staleness bound, not as "unknown" or fresh.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -374,8 +374,10 @@ spec:
                         future propagation target), this is the element-set age used by the runtime-push
                         consumer to refuse pushing THIS satellite's drifting elements — a per-satellite
                         freshness bound, so a stale sibling in the same SatelliteEphemeris does not block
-                        this one. 0 means the source epoch could not be parsed (treated as unknown, not
-                        stale).
+                        this one. The producer no longer emits a state whose source epoch it could not parse
+                        (those satellites are skipped and surfaced via the SourceEpochRejected condition), so a 0
+                        here is the zero value of an omitted field; the consumer treats a 0 epoch as the 1970
+                        instant subject to the normal staleness bound, not as "unknown" or fresh.
                       format: int64
                       type: integer
                   required:


### PR DESCRIPTION
Fixes documentation that drifted out of sync with the code.

## Verified against the code and fixed

- **SECURITY.md — supported versions.** The table listed `0.1.x`; the current release is `v0.7.0`. Updated to `0.7.x: Yes`, `< 0.7.0: No`.
- **SECURITY.md — Secret RBAC.** It claimed `secrets:get;list;watch`. Both controllers actually declare `+kubebuilder:rbac:groups="",resources=secrets,verbs=get` (an uncached, per-request read), and the generated `config/rbac/role.yaml` grants `secrets: [get]` only. Corrected to `secrets:get`.
- **CONTRIBUTING.md — Go version.** Prerequisite said `Go 1.25+`; `go.mod` requires `go 1.26.5`. Updated to `Go 1.26.5+`.
- **`sourceEpochUnixMs` field comment.** It said `0` means the source epoch "could not be parsed (treated as unknown, not stale)". That is no longer true: the producer skips satellites whose epoch it cannot parse (surfaced via the `SourceEpochRejected` condition) instead of emitting a `0`, and the consumer now treats a `0` epoch as the 1970 instant subject to the normal staleness bound (the CHANGELOG's "0 no longer bypasses the freshness gate" change). Corrected the field doc and regenerated the four CRD copies (`config/crd`, `dist/chart`, `bundle`, `nephio`) and `docs/api-reference.md`. The `bundle-verify-sync` / `nephio-verify-sync` drift gates pass.

## Verified but intentionally not changed

- The README Grafana section already reads **"9 custom metrics"**, not "6" — the reported `all 6` text does not exist, so no change was needed.
- `docs/whitepaper/*` carries the same `Go 1.25` / `secrets:get;list;watch` drift, but that file is skip-worktree-pinned (co-founder content) and is left untouched here.

Docs + generated-CRD only; no controller logic changed.