### PR TITLE
test(ephemeris): prove sustained-outage retry-window progression (#237)

### DIFF
--- a/internal/controller/ephemeris_continuity_test.go
+++ b/internal/controller/ephemeris_continuity_test.go
@@ -67,17 +67,24 @@ func ephForContinuity(t *testing.T, name string) (*SatelliteEphemerisReconciler,
 	return r, cli, key, fetcher
 }
 
-// assertSustainedOutageKeepsPropagating is the property the whole I-18 "serve cache preserves
-// SIB19 continuity" claim rests on, and which NOTHING tested before: across a SUSTAINED
+// assertSustainedOutageKeepsPropagating covers ONE facet of the I-18 "serve cache preserves
+// SIB19 continuity" claim: WITHIN a single fetch-retry backoff window, across a SUSTAINED
 // upstream outage the controller must
 //
-//	(a) contact the source only ONCE (the retry backoff must hold), while
+//	(a) contact the source only ONCE (the retry backoff must hold WITHIN the window), while
 //	(b) STILL re-propagating on every reconcile so the pushed epoch never expires, and
 //	(c) requeueing on the 3-minute propagation cadence, not the 2–24h fetch backoff.
 //
 // The old code used the fetch backoff AS the reconcile cadence, so it re-propagated once to
 // now+5m and then slept for hours — the epoch expired ~5 minutes in and the consumer refused
 // the state for the rest of the outage. Continuity was ~4% (5min / 2h), not 100%.
+//
+// This uses the real wall clock (a 2ms sleep to separate epochs), so it can only observe the
+// FIRST window — every cycle here sees calls==1. What happens as the outage OUTLASTS that
+// window — the fetch re-attempting once per window and the 1m→2m→4m ramp growing while
+// propagation stays continuous — is the OTHER facet, covered deterministically by
+// TestReconcile_SustainedOutage_AdvancesClockAcrossMultipleRetryWindows (which needs an
+// injected clock to jump past each nextFetchAttempt without sleeping for minutes).
 func assertSustainedOutageKeepsPropagating(t *testing.T, fetchErr error) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/controller/ephemeris_outage_progression_test.go
+++ b/internal/controller/ephemeris_outage_progression_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestReconcile_SustainedOutage_AdvancesClockAcrossMultipleRetryWindows is the SECOND facet of
+// the I-18 "serve cache preserves SIB19 continuity" claim (assertSustainedOutageKeepsPropagating
+// in ephemeris_continuity_test.go covers the first — the WITHIN-a-single-window behaviour, which
+// on a real clock can only ever observe calls==1). Here the outage OUTLASTS the initial 1-minute
+// backoff, so the property under test is the retry-window PROGRESSION: the controller must
+//
+//	(a) re-attempt the upstream fetch exactly ONCE per elapsed backoff window (not every
+//	    reconcile, not never), while the transient ramp GROWS 1m → 2m → 4m, and
+//	(b) keep re-propagating the cached OMMs to a fresh epoch on EVERY reconcile throughout — so the
+//	    fetch-retry state machine never BLOCKS the propagation heartbeat. (That the epoch is stamped
+//	    far enough ahead to stay valid BETWEEN propagations is a separate, constant-level property
+//	    locked by TestPropagationEpochLeadVsSkewMargin; this test cannot prove it, because its expected
+//	    epoch is derived from the same propagationEpochLead constant.)
+//
+// A single injected clock — shared by cacheServe's suppression gate AND obtainOMMs' backoff arm
+// (this is why #237 moved that arm from a bare time.Now() to r.now()) — is stepped to and across each
+// nextFetchAttempt, so the whole 7-minute progression runs in microseconds without sleeping.
+//
+// Mutations this pins:
+//   - obtainOMMs arming the backoff from a bare time.Now() instead of r.now(): the injected
+//     clock (2026-07-13) would never reach a real-wall-clock nextFetchAttempt, so the fetch
+//     would stay suppressed forever — the per-window calls==N assertion fails on window 2.
+//   - the transient ramp NOT consuming fetchFailures (a reset every cycle): the delay would
+//     stay 1m — the exact nextFetchAttempt and fetchFailures==N assertions fail.
+//   - dropping the suppression gate (re-fetch every reconcile): the held sub-cycle's
+//     calls-unchanged assertion fails.
+//   - propagation stalling under the outage (frozen/not-re-propagated cache): the fresh
+//     THIS-cycle-clock+lead epoch assertion fails.
+func TestReconcile_SustainedOutage_AdvancesClockAcrossMultipleRetryWindows(t *testing.T) {
+	t0 := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	clock := t0 // mutable: every r.now() in a reconcile returns this; stepped BETWEEN reconciles
+	sch := makeScheme(t)
+	const (
+		ns                = "default"
+		name              = "eph-outage-progression"
+		effectiveInterval = 4 * time.Hour
+	)
+
+	omm := issOMMForTest()
+	omm.EpochStr = t0.Format("2006-01-02T15:04:05.000000") // element epoch = t0 → small forward propagation
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: effectiveInterval},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Name: name, Namespace: ns}
+
+	// Upstream is DOWN for the whole test with a TRANSIENT error → the 1m, 2m, 4m ramp.
+	fetcher := &mockGPFetcher{err: errors.New("connection refused")}
+	r := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(200), Fetcher: fetcher,
+		Now: func() time.Time { return clock },
+	}
+	// Seed a last-good cache already older than the 4h window, so the FIRST reconcile at t0
+	// genuinely attempts a fetch (no need to jump the clock forward 4h first). UID is empty on
+	// both sides (the fake client assigns none), matching obtainOMMs' c.uid == eph.UID gate.
+	r.ommCache.Store(key, cachedFetch{
+		result: ephemeris.GPFetchResult{
+			OMMs: []sgp4.OMM{omm}, SatelliteCount: 1, FetchedAt: t0.Add(-5 * time.Hour),
+		},
+		fetchKey: fetchInputKey(eph.Spec),
+	})
+
+	ctx := context.Background()
+
+	// reconcileAt steps the shared clock to `at`, runs one reconcile, and returns the resulting
+	// cache entry (for backoff assertions) and the reconcile result. A serve-cache reconcile must
+	// NEVER return an error — an error would make the workqueue override RequeueAfter with its own
+	// exponential backoff and starve the propagation heartbeat.
+	reconcileAt := func(at time.Time) (cachedFetch, reconcile.Result) {
+		clock = at
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		if err != nil {
+			t.Fatalf("reconcile @ %s: serve-cache reconcile must not error: %v", at.UTC(), err)
+		}
+		v, ok := r.ommCache.Load(key)
+		if !ok {
+			t.Fatalf("reconcile @ %s: cache entry vanished — the continuity fallback was lost", at.UTC())
+		}
+		return v.(cachedFetch), res
+	}
+
+	// assertContinuity checks the SIB19 heartbeat held on a cycle whose clock is `at`: requeue on
+	// the propagation cadence (NOT the fetch backoff), and a fresh epoch stamped at at+lead.
+	assertContinuity := func(label string, at time.Time, res reconcile.Result) {
+		t.Helper()
+		if res.RequeueAfter <= 0 {
+			t.Fatalf("%s: propagation heartbeat disabled — RequeueAfter=%s; controller-runtime only reschedules "+
+				"for a POSITIVE duration, so a non-positive cadence stops periodic re-propagation and the epoch "+
+				"expires", label, res.RequeueAfter)
+		}
+		if res.RequeueAfter != propagationRefreshInterval {
+			t.Fatalf("%s: requeue must be the propagation cadence %s (the fetch is held separately); "+
+				"got %s — the epoch would die before the next reconcile",
+				label, propagationRefreshInterval, res.RequeueAfter)
+		}
+		obj := &ntnv1alpha1.SatelliteEphemeris{}
+		if err := cli.Get(ctx, key, obj); err != nil {
+			t.Fatalf("%s: get: %v", label, err)
+		}
+		if len(obj.Status.PropagatedStates) == 0 {
+			t.Fatalf("%s: SIB19 continuity lost — no propagated states while serving cache", label)
+		}
+		wantEpoch := at.Add(propagationEpochLead).UnixMilli()
+		if got := obj.Status.PropagatedStates[0].EpochUnixMs; got != wantEpoch {
+			t.Fatalf("%s: epoch = %d, want THIS-cycle clock + lead = %d (a frozen/not-re-propagated "+
+				"cache would keep an older epoch)", label, got, wantEpoch)
+		}
+	}
+
+	// Walk three retry windows. In each we first prove the fetch RE-ATTEMPTS once (and the ramp
+	// grew), then prove the backoff SUPPRESSES a fetch just before the next attempt is due — both
+	// while propagation stays continuous.
+	fetchInstant := t0
+	for window := 1; window <= 3; window++ {
+		wantDelay := min(time.Minute<<(window-1), effectiveInterval) // 1m, 2m, 4m
+
+		// (i) FETCH DUE: step to this window's fetch instant (>= the previous nextFetchAttempt).
+		c, res := reconcileAt(fetchInstant)
+		if n := fetcher.callCount(); n != window {
+			t.Fatalf("window %d: upstream must be contacted exactly once per elapsed window; "+
+				"got %d calls, want %d", window, n, window)
+		}
+		if c.fetchFailures != window {
+			t.Fatalf("window %d: consecutive-failure ramp counter = %d, want %d (a reset every "+
+				"cycle would freeze the ramp at 1m)", window, c.fetchFailures, window)
+		}
+		wantNext := fetchInstant.Add(wantDelay)
+		if !c.nextFetchAttempt.Equal(wantNext) {
+			t.Fatalf("window %d: nextFetchAttempt = %s, want fetch-instant + %s = %s (the ramp must "+
+				"grow 1m→2m→4m off the INJECTED clock, not the wall clock)",
+				window, c.nextFetchAttempt.UTC(), wantDelay, wantNext.UTC())
+		}
+		assertContinuity(fmt.Sprintf("window %d fetch-due", window), fetchInstant, res)
+
+		// (ii) BACKOFF HELD: step to just BEFORE nextFetchAttempt → no new fetch, cache still served.
+		held := wantNext.Add(-time.Second)
+		_, res = reconcileAt(held)
+		if n := fetcher.callCount(); n != window {
+			t.Fatalf("window %d: fetch must be SUPPRESSED inside the backoff window; calls jumped "+
+				"to %d (want still %d)", window, n, window)
+		}
+		assertContinuity(fmt.Sprintf("window %d held", window), held, res)
+
+		// Next window's fetch lands EXACTLY on this nextFetchAttempt. The gate uses Before, so
+		// now == deadline must re-fetch — this pins the boundary and kills a !now.After() mutation
+		// that would keep suppressing at equality (the held sub-cycle above pins now < deadline).
+		fetchInstant = wantNext
+	}
+}

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -442,14 +442,55 @@ func TestPushEphemerisUpdateIfNeeded_PermanentRejectionNoRequeue(t *testing.T) {
 // small so OCUDU's internal propagation from the epoch is short (guards against a
 // regression back to now+refreshInterval, which back-propagated hours).
 func TestPropagationEpochLeadVsSkewMargin(t *testing.T) {
-	if propagationEpochLead <= epochSkewMargin {
-		t.Fatalf("propagationEpochLead (%v) must exceed epochSkewMargin (%v) so a fresh state is not stale-skipped",
-			propagationEpochLead, epochSkewMargin)
+	// The heartbeat only reschedules on a POSITIVE cadence: the reconcile returns
+	// RequeueAfter = min(effectiveInterval, propagationRefreshInterval), and controller-runtime requeues
+	// after a duration only when it is > 0, so a zero/negative cadence disables periodic propagation.
+	if propagationRefreshInterval <= 0 {
+		t.Fatalf("propagationRefreshInterval must be positive; got %v — a non-positive RequeueAfter disables "+
+			"the scheduled propagation heartbeat entirely", propagationRefreshInterval)
+	}
+	// The producer stamps each epoch at now+propagationEpochLead and re-propagates every
+	// propagationRefreshInterval; the consumer rejects a state whose EpochUnixMs <= now+epochSkewMargin.
+	// Both sides serialize through UnixMilli, which truncates sub-millisecond, and the producer's `now` can
+	// sit at ANY sub-millisecond phase — so comparing UnixMilli at a single fixed phase (e.g. the Unix
+	// epoch) is not enough: two instants less than 1ms apart floor into the same millisecond at some phase,
+	// and the consumer's <= then rejects the epoch. The necessary-and-sufficient constant-level condition,
+	// over every phase, is that the nominal headroom (lead - cadence - skew) is at least ONE full
+	// millisecond; then floor(p+lead) is always at least one bucket above floor(p+cadence+skew) for every
+	// phase p (see TestPropagationEpochSerialization_AllClockPhases). This is the constant-level LOWER BOUND
+	// on continuity — runtime processing / queue / status-watch / delivery latency live outside it (tracked
+	// by #234); it is NOT an unconditional "never expires" guarantee. (The outage progression test proves
+	// only that the fetch-retry state machine does not BLOCK the heartbeat; it cannot prove the lead is
+	// large enough, as its expected epoch is derived from this same constant.) This subsumes the old
+	// lead > epochSkewMargin check.
+	if headroom := propagationEpochLead - propagationRefreshInterval - epochSkewMargin; headroom < time.Millisecond {
+		t.Fatalf("propagationEpochLead (%v) must leave at least 1ms of nominal headroom after "+
+			"propagationRefreshInterval (%v) + epochSkewMargin (%v); got %v — at some sub-millisecond clock "+
+			"phase the serialized (UnixMilli) epoch collapses onto the consumer's stale cutoff",
+			propagationEpochLead, propagationRefreshInterval, epochSkewMargin, headroom)
 	}
 	if propagationEpochLead > 30*time.Minute {
 		t.Fatalf("propagationEpochLead (%v) is too large; a near-now epoch keeps OCUDU's internal propagation short",
 			propagationEpochLead)
 	}
+}
+
+// TestPropagationEpochSerialization_AllClockPhases is the standalone precision proof behind the
+// >= 1ms headroom requirement in TestPropagationEpochLeadVsSkewMargin: with only a sub-millisecond gap
+// there IS a clock phase where the serialized (UnixMilli) epoch floors into the same millisecond as the
+// consumer's stale cutoff, so the consumer's <= would reject it. It is not tied to the production
+// constants; it demonstrates why a single fixed-phase UnixMilli comparison is insufficient.
+func TestPropagationEpochSerialization_AllClockPhases(t *testing.T) {
+	const gap = 100 * time.Microsecond // a sub-millisecond headroom
+	lead := propagationEpochLead
+	cutoff := lead - gap
+	for phase := time.Duration(0); phase < time.Millisecond; phase += time.Microsecond {
+		base := time.Unix(0, int64(phase))
+		if base.Add(lead).UnixMilli() <= base.Add(cutoff).UnixMilli() {
+			return // found the phase where a sub-1ms gap collapses under UnixMilli — exactly why >= 1ms is required
+		}
+	}
+	t.Fatal("expected a sub-millisecond clock phase where a 100µs headroom collapses under UnixMilli, found none")
 }
 
 func TestEphemerisPushShouldRequeue(t *testing.T) {

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -76,8 +76,11 @@ type SatelliteEphemerisReconciler struct {
 	Fetcher                 ephemeris.GPFetcher          // CelesTrak fetcher
 	SpaceTrackFetcher       *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
 
-	// Now returns the current time; nil defaults to time.Now(). Injected in tests to make the
-	// propagation epoch — which is sampled at PROPAGATION time, not reconcile-start — deterministic.
+	// Now returns the current time; nil defaults to time.Now(). Injected in tests to make two
+	// clock-dependent behaviours deterministic: the propagation epoch (sampled at PROPAGATION time,
+	// not reconcile-start) and the fetch-retry backoff window (cacheServe's suppression gate and the
+	// nextFetchAttempt it compares against are both driven by r.now(), so a test can step to and across
+	// a deadline to walk successive retry windows).
 	Now func() time.Time
 
 	// ommCache holds the last real GP-fetch result per SatelliteEphemeris so the
@@ -596,8 +599,9 @@ func classifyFetchErrClass(err error) fetchErrClass {
 //     backoff on a retryKey change, and the count must reset with it so the new episode's first
 //     transient failure also starts at the ramp base rather than inheriting the old episode's N.
 //
-// now is a parameter (production passes time.Now(), sampled AFTER the fetch returned so a 30s
-// client timeout does not eat the first 1-minute window) so the ramp is deterministically testable.
+// now is a parameter (production passes r.now(), i.e. time.Now(), sampled AFTER the fetch returned
+// so a 30s client timeout does not eat the first 1-minute window) so the ramp is deterministically
+// testable — an injected clock advancing to and across nextFetchAttempt lets a test walk the retry windows.
 func applyFetchBackoff(c *cachedFetch, fetchErr error, newRetryKey string, effectiveInterval time.Duration, now time.Time) {
 	if newRetryKey != c.retryKey || classifyFetchErrClass(fetchErr) != classifyFetchErrClass(c.lastFetchErr) {
 		c.fetchFailures = 0
@@ -1438,9 +1442,12 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 			// so the epoch expired ~5 minutes in and SIB19 went stale for the rest of it.)
 			// Advance the fetch-retry ramp and arm nextFetchAttempt. applyFetchBackoff restarts
 			// the ramp when the retry episode changed (new error class or new retryKey), and takes
-			// now = time.Now() sampled HERE — after the fetch returned — so a 30s client timeout
-			// does not eat the first 1-minute transient window (#236, extends #221 review finding 2).
-			applyFetchBackoff(&c, fetchErr, retryInputKey(eph.Spec, effectiveInterval), effectiveInterval, time.Now())
+			// now = r.now() sampled HERE — after the fetch returned — so a 30s client timeout does
+			// not eat the first 1-minute transient window (#236, extends #221 review finding 2).
+			// r.now() (time.Now() in production) rather than a bare time.Now() so cacheServe's
+			// gate and this arm share ONE injectable clock: a test can advance to and across nextFetchAttempt
+			// to walk successive retry windows deterministically (#237).
+			applyFetchBackoff(&c, fetchErr, retryInputKey(eph.Spec, effectiveInterval), effectiveInterval, r.now())
 			r.ommCache.Store(req.NamespacedName, c)
 			log.Info("GP fetch failed; serving last cached OMMs for SIB19 continuity",
 				"err", fetchErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String(),


### PR DESCRIPTION
## What

Fills the last EPIC #232 continuity-test gap: a **deterministic** test that an ephemeris outage lasting **longer than one fetch-retry backoff window** keeps SIB19 alive, and narrows an over-claimed doc comment.

## Why

`assertSustainedOutageKeepsPropagating` runs on the real wall clock (a 2 ms sleep between cycles), so it can only ever observe the **first** backoff window — every cycle sees `calls == 1`. Its doc comment nonetheless claimed it as the whole I-18 "serve cache preserves SIB19 continuity" property. What happens as the outage *outlasts* that window — the fetch re-attempting once per window while the `1m → 2m → 4m` ramp grows and propagation stays continuous — was untested.

That test was impossible to write deterministically because of a partial-clock seam #235/#236 deferred: `obtainOMMs` armed `nextFetchAttempt` from a bare `time.Now()`, while `cacheServe`'s suppression gate reads the injectable `r.now()`.

## Changes

- **`satelliteephemeris_controller.go`** — arm the fetch backoff from `r.now()` instead of a bare `time.Now()`. `r.now()` **is** `time.Now()` in production (`r.Now` is a test-only field, grep-verified never set in `cmd/` or non-test code), so behavior is unchanged; the gate and the arm now share one injectable clock.
- **`ephemeris_outage_progression_test.go`** (new) — `TestReconcile_SustainedOutage_AdvancesClockAcrossMultipleRetryWindows`: a mutable clock steps to and across each `nextFetchAttempt` over three windows and asserts the exact ramp growth, once-per-window re-fetch, in-window suppression, and continuous propagation.
- **`ephemeris_continuity_test.go`** — narrow the sibling test's doc comment to its actual within-a-single-window scope; cross-reference the new test.

## Verification

- **Progression test — mutation-proven (4):** reverting the seam (`r.now()` → `time.Now()`), resetting the ramp, disabling the suppression gate, and weakening the gate to `!now.After()` (equality-suppression) each make it FAIL; restored passes. The equality case is pinned by stepping each window's fetch to the **exact** `nextFetchAttempt` (gate uses `Before`, so `now == deadline` must fetch), while the held sub-cycle pins `now < deadline`.

### Re-review findings addressed

The progression test proves the fetch-retry state machine never **blocks** the heartbeat, but it **cannot** prove the epoch stays valid *between* propagations — its expected epoch is derived from the same `propagationEpochLead` constant. That property is locked at the constant level in **`TestPropagationEpochLeadVsSkewMargin`**, which now pins the continuity **lower bound**, hardened across two review rounds:

- **Positive cadence.** `propagationRefreshInterval > 0` — the reconcile requeues on `min(effectiveInterval, propagationRefreshInterval)`, and controller-runtime only reschedules for a **positive** duration, so a zero/negative cadence silently disables the heartbeat. The progression test also now rejects `RequeueAfter <= 0` directly.
- **Serialized (`UnixMilli`) precision, at every clock phase.** `EpochUnixMs` and the consumer cutoff both serialize through `UnixMilli` (truncating sub-millisecond), and the producer's `now` can sit at any sub-millisecond phase. Comparing `UnixMilli` at one fixed phase (the Unix epoch) misses a mutation that collapses only at another phase, so the invariant instead requires **at least 1 ms of nominal headroom** (`lead − cadence − skew ≥ 1 ms`) — the necessary-and-sufficient phase-independent condition. `TestPropagationEpochSerialization_AllClockPhases` demonstrates that a sub-1 ms gap does collide at some phase.
- **Scoped claim.** This is a constant-level *lower bound*, **not** an unconditional "never expires" guarantee — runtime processing / queue / status-watch / delivery latency live outside it and are tracked by **#234**. The doc comment, commit message, and this body say so.

**Mutation-proven (6):** seam revert, ramp reset, gate disable, `!now.After()` equality-suppression, a non-positive `propagationRefreshInterval` (fails both the constant and progression tests), and `lead = cadence + skew + 1ns` (`UnixMilli` collapse) each FAIL a test; restored passes.

- Gate green: `make test` (all packages, controller 88.8%), `golangci-lint` v2.12.2 0 issues, no generated-file drift, `-race ×50` stable.

Closes #237.
Part of #232 (post-merge continuity/HA/runbook hardening). No behavior change in production.