### PR TITLE
docs(runbook): fix gNB-reachability debug (leader, shell, security context) (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ helm install ntn-operators dist/chart \
 > ```
 >
 > Skipping this leaves a new operator running against last release's CRDs. Writes
-> carrying fields the old schema doesn't know are then either **rejected** (strict
-> server-side field validation — the default for `kubectl` 1.25+)
-> or **silently pruned** (lenient validation / older clients), so v0.6+ features
-> that depend on new spec fields (e.g. the runtime NTN push) either fail to apply
-> or go quietly inert.
+> carrying fields the old schema doesn't know then hit one of three server-side
+> field-validation modes: **rejected** (`--validate=strict`, the default for `kubectl`
+> 1.25+), accepted but **pruned with a warning** (`--validate=warn`), or **silently
+> pruned** (`--validate=ignore`, or clients explicitly configured to ignore unknown fields). In the two accepted cases the write
+> succeeds yet the unknown field is dropped, so v0.6+ features that depend on new spec
+> fields (e.g. the runtime NTN push) either fail to apply or go quietly inert.
 > To let Helm own the CRD lifecycle instead, install with `--set crd.enable=true`
 > (the default) and omit `make install` — then `helm upgrade` updates both
 > together.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -112,19 +112,74 @@ sum by (namespace, config, reason) (increase(ntn_operators_ephemeris_push_errors
 | `EphemerisStale` | the propagated state is stale/expired | see **NTNEphemerisEpochStale** |
 
 ```bash
-kubectl describe ntncellconfig <config> -n "$NS"
+# Run in a subshell with strict mode so a failed kubectl (RBAC, a missing/renamed object, an API outage)
+# STOPS the procedure instead of probing an empty target — bash -n cannot catch that, and the exit
+# status of a plain sequence would otherwise be the last command's. The subshell keeps set -e out of
+# your interactive session.
+(
+set -euo pipefail
+: "${NS:?set NS to the NTNCellConfig namespace}"
+: "${CONFIG:?set CONFIG to the NTNCellConfig name}"
+OPERATOR_NS="${OPERATOR_NS:-ntn-operators-system}"   # override if you installed elsewhere
+
+kubectl describe ntncellconfig "$CONFIG" -n "$NS"
 #   Condition EphemerisPushed (Status/Reason/Message) + Event "EphemerisPushFailed"
-# For ProviderPushFailed, test gNB reachability AS THE OPERATOR SEES IT: attach an
-# ephemeral debug container to the operator Pod. It shares the Pod's network namespace,
-# so it is governed by the operator's NetworkPolicy — a real test of the operator's egress.
-# (Do NOT `kubectl run` a pod carrying the operator's labels to mimic it: the operator
-#  ReplicaSet would adopt that pod by selector and delete it as an excess replica.)
-ENDPOINT=$(kubectl get ntncellconfig <config> -n "$NS" -o jsonpath='{.spec.provider.remoteControl.endpoint}')
+
+# For ProviderPushFailed, test gNB reachability AS THE ACTIVE OPERATOR SEES IT. The push runs on the
+# elected LEADER, so probe that pod — its node's CNI/routing/egress is what matters, not an arbitrary
+# replica's. The leader is in the leader-election Lease (holderIdentity is "<pod>_<uuid>").
+LEADER=$(kubectl get lease b1076767.operators.dev -n "$OPERATOR_NS" -o jsonpath='{.spec.holderIdentity}')
+# During a graceful handoff (LeaderElectionReleaseOnCancel) the Lease briefly has NO holder; fail fast
+# rather than probing an empty pod name — wait for the ~2s handoff and retry.
+: "${LEADER:?leader Lease currently has no holder — wait for the ~2s handoff and retry}"
+POD=${LEADER%%_*}
+kubectl get pod "$POD" -n "$OPERATOR_NS" -o wide   # confirm the pod/node you are about to probe
+
+ENDPOINT=$(kubectl get ntncellconfig "$CONFIG" -n "$NS" -o jsonpath='{.spec.provider.remoteControl.endpoint}')
+: "${ENDPOINT:?spec.provider.remoteControl.endpoint is empty for $CONFIG}"
 HOST=${ENDPOINT%:*}; HOST=${HOST#[}; HOST=${HOST%]}   # strip [ ] so [IPv6]:port works with nc
 PORT=${ENDPOINT##*:}
-POD=$(kubectl get pod -n ntn-operators-system -l control-plane=controller-manager \
-  -o jsonpath='{.items[0].metadata.name}')
-kubectl debug -n ntn-operators-system -it "$POD" --image=nicolaka/netshoot -- nc -vz "$HOST" "$PORT"
+
+# Re-read the leader just before probing: if it changed (a handoff between the two reads) we would be
+# probing a pod that is no longer the active operator, so abort and retry. Assign first, THEN compare:
+# `[ "$(kubectl ...)" = "$LEADER" ]` takes its exit status from `[`, not from kubectl, so a kubectl that
+# failed AFTER emitting the holder would slip past set -e; a plain assignment carries kubectl's non-zero
+# exit for set -e to act on.
+CURRENT_LEADER=$(kubectl get lease b1076767.operators.dev -n "$OPERATOR_NS" -o jsonpath='{.spec.holderIdentity}')
+[[ "$CURRENT_LEADER" == "$LEADER" ]] \
+  || { echo "leader changed while preparing the probe; retry the procedure" >&2; exit 1; }
+
+# Emit cleanup for THIS pod now, names baked in (%q-escaped), from INSIDE the subshell: $POD/$OPERATOR_NS
+# exist only here — a subshell is a copy of the parent, so its vars never propagate out; a cleanup line
+# placed after `)` would run in the parent with them UNSET, or worse with a stale $POD from the parent's
+# history → deleting an unrelated pod. Printed BEFORE the probe because a failing `nc` is a normal
+# diagnostic result that, under set -e, would skip anything after it. The ephemeral container stays listed
+# (Terminated) until the pod is recreated — harmless, normally left as-is; to clear it, on the default
+# 2-replica Helm install confirm BOTH replicas are Ready then delete the pod (deleting the leader triggers
+# a ~2s lease handoff — a handoff timing, NOT an end-to-end SLA); on a single-replica / raw-kustomize
+# install deleting the pod is a brief operator outage, so prefer leaving the terminated entry.
+printf '\n# Optional cleanup for THIS debug pod (uncomment a line to run):\n'
+printf '#   kubectl get pod -n %q -l control-plane=controller-manager -o wide   # both Ready first\n' "$OPERATOR_NS"
+printf '#   kubectl delete pod -n %q %q\n' "$OPERATOR_NS" "$POD"
+
+# Attach an ephemeral debug container to the leader pod: it shares the pod's network namespace, so it
+# is governed by the operator's NetworkPolicy — a real test of the operator's egress. (Do NOT
+# `kubectl run` a pod with the operator's labels: the ReplicaSet would adopt and delete it.) The image
+# is digest-pinned — never :latest, since it shares the operator pod's namespace.
+#
+# Use --profile=restricted for a deterministic, hardened debug container (drop ALL capabilities,
+# runAsNonRoot, RuntimeDefault seccomp). Without an explicit profile the kubectl default differs by
+# client version (legacy through v1.35; general from v1.36, which adds an unneeded SYS_PTRACE), so the
+# effective security context would otherwise depend on the operator's kubectl. The ephemeral container
+# INHERITS the pod's securityContext: on the default Helm install the pod sets runAsUser 65532, so it
+# runs as uid 65532 and `nc -vz` works under restricted (verified on Kind, node v1.32.2, kubectl v1.35.4).
+# On the raw kustomize install (config/manager: runAsNonRoot with NO numeric user) netshoot fails with
+# CreateContainerConfigError — its image declares no numeric non-root user (nicolaka/netshoot#163);
+# there, use a debug image that declares a numeric non-root USER (or --custom a runAsUser).
+kubectl debug -n "$OPERATOR_NS" -it "$POD" --profile=restricted \
+  --image=nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70 \
+  -- nc -vz "$HOST" "$PORT"
+)
 ```
 
 **Mitigate.**

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -876,10 +876,13 @@ func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
 // yields a new epoch and a new state — so a same-epoch reconcile dedups without
 // hashing the payload. Refreshing epoch/ephemeris/TA is SI-change-free per TS
 // 38.331. The re-push cadence is bounded by the SatelliteEphemeris re-propagation
-// interval (a few minutes) and is NOT guaranteed shorter than ntn-UlSyncValidityDur:
-// that field's enum spans 5..900 s (an earlier "NR max 240 s" note was wrong), so at
-// the low end the UE-side UL-sync validity can lapse between re-pushes — pairing the
-// two is a deployment-sizing concern this cadence does not enforce.
+// interval (a few minutes) and can be longer than a configured ntn-UlSyncValidityDur
+// value: that field's enum includes values as low as 5 s (an earlier "NR max 240 s"
+// note was wrong). Whether that timing mismatch actually causes a UE-side UL-sync
+// validity lapse, and whether the operator should clamp the cadence, validate/warn on
+// the pairing, or treat it as a deployment-sizing responsibility, remains open in #228.
+// This marker only deduplicates by propagated epoch and does not decide that semantic
+// or policy.
 func runtimeEphemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris, state *ntnv1alpha1.PropagatedState) string {
 	return fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
 		eph.Name, eph.Generation, state.NoradID, state.EpochUnixMs)


### PR DESCRIPTION
## What

Runbook + README hardening for the `ProviderPushFailed` gNB-reachability check, reworked across multiple review rounds and **verified on a real Kind cluster**.

## Kind evidence — `--profile=restricted` on the Helm path

`kubectl debug --profile=restricted --image=nicolaka/netshoot:v0.16` against a Pod with the chart's Pod securityContext (`runAsNonRoot` + `runAsUser: 65532`):

- applied ephemeral-container securityContext: `{allowPrivilegeEscalation:false, capabilities:{drop:[ALL]}, runAsNonRoot:true, seccompProfile:{RuntimeDefault}}`
- `id` → **`uid=65532 gid=65532`** (inherited from the Pod)
- `nc -vz 10.96.0.1 443` → **succeeded**
- kubectl **v1.35.4**, node **v1.32.2**

On the raw **kustomize** path (`runAsNonRoot`, no numeric user) netshoot fails with `CreateContainerConfigError` (#163) — its image declares no numeric non-root user; the runbook says to use a debug image that declares one.

## Re-review fixes (round 2)

- **Use `--profile=restricted`** on the command (was profile-less). Satisfies #239's acceptance criterion, and makes the security context **deterministic** — without a profile the kubectl default varies by version (`legacy` through v1.35, `general` from v1.36, which adds an unneeded `SYS_PTRACE`).
- **G4 comment made neutral.** The `runtimeEphemerisPushMarker` comment previously pre-judged the re-push-cadence vs `ntn-UlSyncValidityDur` pairing as a "deployment-sizing concern". It now records that clamp / warn / deployment-sizing is an **open question tracked in #228** and that the marker does not decide that policy. (This is why the PR now touches a `.go` file.)
- **Empty-`holderIdentity` guard.** During a graceful handoff the Lease briefly has no holder; the script now fails fast on an empty `$LEADER` rather than probing an empty pod name.

## Round-1 fixes (kept)

`<config>` bash-redirection → fail-fast `$CONFIG`/`$NS`; `.items[0]` → leader-from-Lease; cleanup wording (both-Ready check, `~2s` = lease-handoff not SLA); README `--validate=warn` mode + narrowed "older clients"; digest-pinned netshoot `v0.16@sha256:b09d9b21…`.

## Re-review fixes (round 3)

- **True fail-fast.** The block only guarded unset *variables*; a failed `kubectl` (RBAC, missing/renamed object, API outage) would fall through to `nc -vz "" ""`. It is now wrapped in a **subshell with `set -euo pipefail`** (kept out of the user's interactive shell), guards an **empty endpoint**, defaults `OPERATOR_NS` without overriding a user value, and **re-reads the Lease before probing** to abort on a leadership handoff (TOCTOU). Mock-`kubectl` tested: a failing `get ntncellconfig` → exit 7, debug **not** reached; happy path → reaches `debug` with parsed host/port; changed leader → aborts, debug not reached.
- **G4 comment fully neutral.** It previously still asserted the UE-side validity *"can lapse"* — a technical premise #228 leaves open pending TS 38.331. It now states only the timing-value mismatch and defers *whether it causes a lapse* (and the policy) to #228.
- **Version boundary corrected** (a nit from an earlier draft): the kubectl default is `legacy` through v1.35 and `general` from v1.36 (local kubectl v1.35.4 still defaults `legacy`); doc, commit, and this body all state it that way.
- **Cleanup for single-replica.** The "confirm both replicas Ready" advice now notes it applies to the 2-replica Helm HA install; on raw kustomize (1 replica) deleting the pod is a brief outage, so prefer leaving the terminated entry.

## Re-review fixes (round 4)

Two shell-correctness fixes so the procedure fails safe end to end — both **reproduced with a mock `kubectl`** (and the first mutation-proven against the old form):

- **TOCTOU re-read no longer swallows `kubectl`'s exit status.** `[ "$(kubectl get lease …)" = "$LEADER" ]` takes its exit status from `[`, not from the inner `kubectl` — so a `kubectl` that fails *after* emitting the holder string slips past `set -e` and the probe runs anyway. Now it **assigns first, then compares**: `CURRENT_LEADER=$(kubectl …)` (a bare assignment carries the substitution's non-zero, which `set -e` acts on) then `[[ "$CURRENT_LEADER" == "$LEADER" ]]`. Mock proof: a 2nd lease read printing the *same* holder but exiting 7 now **aborts at exit 7, debug not reached**; the old form reached debug.
- **Cleanup commands no longer depend on parent-shell variables.** They were printed **after** the `)` — but a subshell is a copy of the parent, so `$POD`/`$OPERATOR_NS` set inside it never propagate out; the example would run in the parent with them **unset**, or worse with a **stale `$POD` from the parent's history → deleting an unrelated pod**. They are now emitted from **inside** the subshell with the resolved names baked in (`printf %q`), **before** the probe (a failing `nc` is a normal outcome that, under `set -e`, would skip anything after it).

## Verification

Kind evidence above; the rewritten `kubectl debug` block passes `bash -n`; the round-4 shell fixes were exercised by extracting the real subshell from the runbook and running it under a mock `kubectl` (fail-fast, TOCTOU exit-status, and `%q` cleanup all confirmed; TOCTOU fix mutation-proven); the G4 `.go` change builds + `go vet` clean; `gofmt` clean; Markdown fences balanced.

Closes #239.
Part of #232.
