### PR TITLE
test: cover runtime push freshness lifecycle in envtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Runtime-push currency/freshness lifecycle now has manager-backed envtest coverage.**
+  The regression drives the real apiserver status subresource and informer cache
+  through same-epoch deduplication, a propagation-input generation bump that fails
+  closed while status is stale, and exactly one re-push after status catches up
+  without a hot requeue (#252).
 - **The chart's PodDisruptionBudget renders only when `replicas > 1`.** A `minAvailable: 1` PDB over
   a single replica blocks every eviction-API disruption (node drain, descheduler, autoscaler) — the
   one pod can never be evicted (it does not gate Deployment rolling updates, which delete pods

--- a/internal/controller/ntncellconfig_runtime_push_envtest_test.go
+++ b/internal/controller/ntncellconfig_runtime_push_envtest_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlrt "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+type runtimePushRecorder struct {
+	provider.MockProvider
+	pushes chan provider.RuntimeUpdate
+}
+
+func newRuntimePushRecorder() *runtimePushRecorder {
+	return &runtimePushRecorder{pushes: make(chan provider.RuntimeUpdate, 8)}
+}
+
+func (p *runtimePushRecorder) PushRuntimeUpdate(
+	_ context.Context, _ provider.ResolvedRemoteControl, update provider.RuntimeUpdate,
+) error {
+	p.pushes <- update
+	return nil
+}
+
+var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
+	const (
+		namespace = "default"
+		cellName  = "runtime-push-envtest-cell"
+		ephName   = "runtime-push-envtest-ephemeris"
+	)
+	cellKey := types.NamespacedName{Namespace: namespace, Name: cellName}
+	ephKey := types.NamespacedName{Namespace: namespace, Name: ephName}
+
+	It("deduplicates a settled epoch and pushes once after input currency catches up", func() {
+		prov := newRuntimePushRecorder()
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  scheme.Scheme,
+			Metrics: metricsserver.Options{BindAddress: "0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler := &NTNCellConfigReconciler{
+			Client:                  mgr.GetClient(),
+			APIReader:               mgr.GetAPIReader(),
+			Scheme:                  mgr.GetScheme(),
+			Providers:               map[string]provider.NTNProvider{"ocudu": prov},
+			MaxConcurrentReconciles: 1,
+		}
+		Expect(mgr.GetFieldIndexer().IndexField(context.Background(), &ntnv1alpha1.NTNCellConfig{},
+			ephemerisRefIndexKey, indexNTNCellConfigByEphemerisRef)).To(Succeed())
+		Expect(ctrl.NewControllerManagedBy(mgr).
+			For(&ntnv1alpha1.NTNCellConfig{}, builder.WithPredicates(reconcileTriggerPredicate())).
+			Watches(&ntnv1alpha1.SatelliteEphemeris{},
+				handler.EnqueueRequestsFromMapFunc(reconciler.ephemerisToNTNCellConfig)).
+			Named("ntncellconfig-runtime-push-envtest").
+			WithOptions(ctrlrt.Options{MaxConcurrentReconciles: reconciler.MaxConcurrentReconciles}).
+			Complete(reconciler)).To(Succeed())
+
+		managerCtx, stopManager := context.WithCancel(context.Background())
+		managerDone := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			managerDone <- mgr.Start(managerCtx)
+		}()
+		Expect(mgr.GetCache().WaitForCacheSync(managerCtx)).To(BeTrue())
+
+		DeferCleanup(func() {
+			stopManager()
+			Eventually(managerDone, "10s").Should(Receive(BeNil()))
+
+			cell := &ntnv1alpha1.NTNCellConfig{}
+			if err := k8sClient.Get(context.Background(), cellKey, cell); err == nil {
+				controllerutil.RemoveFinalizer(cell, "ntn.operators.dev/configmap-cleanup")
+				Expect(k8sClient.Update(context.Background(), cell)).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), cell)).To(Succeed())
+			}
+			eph := &ntnv1alpha1.SatelliteEphemeris{}
+			if err := k8sClient.Get(context.Background(), ephKey, eph); err == nil {
+				Expect(k8sClient.Delete(context.Background(), eph)).To(Succeed())
+			}
+		})
+
+		eph := &ntnv1alpha1.SatelliteEphemeris{
+			ObjectMeta: metav1.ObjectMeta{Name: ephName, Namespace: namespace},
+			Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+				Source: ntnv1alpha1.EphemerisSource{
+					Type:            "CelesTrak",
+					URL:             "https://celestrak.org/runtime-push-envtest-v1",
+					RefreshInterval: metav1.Duration{Duration: 4 * time.Hour},
+				},
+				Satellites: &ntnv1alpha1.SatelliteSelector{NoradIDs: []int{25544}},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), eph)).To(Succeed())
+
+		initialEpoch := time.Now().Add(time.Hour).UnixMilli()
+		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
+		eph.Status = ntnv1alpha1.SatelliteEphemerisStatus{
+			LastUpdated:               &metav1.Time{Time: time.Now()},
+			PropagatedStatesInputHash: propagationInputHash(eph.Spec),
+			PropagatedStates: []ntnv1alpha1.PropagatedState{{
+				Satellite:         "ISS",
+				NoradID:           25544,
+				EpochUnixMs:       initialEpoch,
+				SourceEpochUnixMs: time.Now().Add(-time.Hour).UnixMilli(),
+				ECEF: ntnv1alpha1.EphemerisECEF{
+					PosX: 5_000_000,
+					PosY: 4_000_000,
+					PosZ: 3_000_000,
+				},
+			}},
+		}
+		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
+
+		cell := ccWithRemoteControl()
+		cell.Name = cellName
+		cell.Namespace = namespace
+		cell.Spec.EphemerisRef = ephName
+		Expect(k8sClient.Create(context.Background(), cell)).To(Succeed())
+
+		var firstPush provider.RuntimeUpdate
+		Eventually(prov.pushes, "15s").Should(Receive(&firstPush))
+		Expect(firstPush.EpochUnixMs).To(Equal(initialEpoch))
+
+		var settledMarker string
+		Eventually(func(g Gomega) {
+			current := &ntnv1alpha1.NTNCellConfig{}
+			g.Expect(k8sClient.Get(context.Background(), cellKey, current)).To(Succeed())
+			condition := meta.FindStatusCondition(current.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			g.Expect(condition).NotTo(BeNil())
+			g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(condition.Reason).To(Equal("Pushed"))
+			settledMarker = condition.Message
+		}, "10s", "100ms").Should(Succeed())
+
+		// A status-only event with the same generation and propagated epoch must cross
+		// the informer watch but deduplicate at the persisted runtime marker.
+		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
+		eph.Status.LastUpdated = &metav1.Time{Time: time.Now().Add(time.Second)}
+		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
+		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
+
+		currentCell := &ntnv1alpha1.NTNCellConfig{}
+		Expect(k8sClient.Get(context.Background(), cellKey, currentCell)).To(Succeed())
+		condition := meta.FindStatusCondition(currentCell.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+		Expect(condition).NotTo(BeNil())
+		Expect(condition.Message).To(Equal(settledMarker))
+
+		// The apiserver owns generation: changing a propagation input bumps it while
+		// the status subresource still describes the old input set. The cached
+		// controller must fail closed and settle without pushing stale data.
+		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
+		oldGeneration := eph.Generation
+		eph.Spec.Source.URL = "https://celestrak.org/runtime-push-envtest-v2"
+		Expect(k8sClient.Update(context.Background(), eph)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			currentEph := &ntnv1alpha1.SatelliteEphemeris{}
+			g.Expect(k8sClient.Get(context.Background(), ephKey, currentEph)).To(Succeed())
+			g.Expect(currentEph.Generation).To(Equal(oldGeneration + 1))
+
+			current := &ntnv1alpha1.NTNCellConfig{}
+			g.Expect(k8sClient.Get(context.Background(), cellKey, current)).To(Succeed())
+			stale := meta.FindStatusCondition(current.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			g.Expect(stale).NotTo(BeNil())
+			g.Expect(stale.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(stale.Reason).To(Equal(ephemerisReasonInputsStale))
+		}, "10s", "100ms").Should(Succeed())
+		Consistently(prov.pushes, "1s", "100ms").ShouldNot(Receive())
+
+		// Once the producer status catches up to the new inputs and epoch, the status
+		// watch fans out exactly one fresh runtime push. The controller's own status
+		// write must not create a hot requeue or a third push.
+		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
+		nextEpoch := initialEpoch + (3 * time.Minute).Milliseconds()
+		eph.Status.PropagatedStatesInputHash = propagationInputHash(eph.Spec)
+		eph.Status.PropagatedStates[0].EpochUnixMs = nextEpoch
+		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
+
+		var secondPush provider.RuntimeUpdate
+		Eventually(prov.pushes, "10s").Should(Receive(&secondPush))
+		Expect(secondPush.EpochUnixMs).To(Equal(nextEpoch))
+
+		Eventually(func(g Gomega) {
+			current := &ntnv1alpha1.NTNCellConfig{}
+			g.Expect(k8sClient.Get(context.Background(), cellKey, current)).To(Succeed())
+			fresh := meta.FindStatusCondition(current.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			g.Expect(fresh).NotTo(BeNil())
+			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(fresh.Reason).To(Equal("Pushed"))
+			g.Expect(fresh.Message).To(Equal(runtimeEphemerisPushMarker(eph, &eph.Status.PropagatedStates[0])))
+		}, "10s", "100ms").Should(Succeed())
+		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
+	})
+})


### PR DESCRIPTION
## Summary

- add a manager-backed envtest for the runtime ephemeris currency/freshness lifecycle
- drive the real envtest apiserver status subresource, informer cache, field index, and SatelliteEphemeris watch fan-out
- verify same-epoch status events deduplicate, an input-generation bump fails closed while status is stale, and status catch-up produces exactly one fresh push without a hot requeue
- document the new integration coverage in the Unreleased changelog

Closes #252.

## Validation

- `make test`
- `make lint`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.36 -p path)" go test ./internal/controller -run TestControllers -ginkgo.focus="runtime-push lifecycle" -count=1`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.36 -p path)" go test -race ./internal/controller -run TestControllers -ginkgo.focus="runtime-push lifecycle" -count=1`

## Disclosure

I used OpenAI Codex to help prepare this change. The contribution was checked against the repository contribution guidance and validated with the commands above.
