### PR TITLE
feat(ci): HA topology assertions + failover/PDB/cache-sync E2E (#230)

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -110,6 +110,13 @@ jobs:
           grace=$($H template t ./dist/chart | grep -oE 'terminationGracePeriodSeconds: [0-9]+' | head -1 | grep -oE '[0-9]+$')
           { [ -n "$grace" ] && [ "$grace" -ge "$renew" ]; } || { echo "FAIL: chart terminationGracePeriodSeconds='$grace' must be >= RenewDeadline ${renew}s"; exit 1; }
           echo "chart terminationGracePeriodSeconds=$grace (>= RenewDeadline ${renew}s) OK"
+          # Pin the ABSOLUTE HA failover budget. The E2E RTO bounds are self-calibrating (relative to the live
+          # Lease's leaseDurationSeconds), so they would silently scale with a leaderLeaseDuration regression
+          # (15s -> 120s makes an 8x-slower handoff still pass). Assert the source constant stays within the
+          # stated sub-15s active-passive budget (docs/high-availability.md).
+          lease=$(grep -oE 'leaderLeaseDuration = [0-9]+ \* time\.Second' cmd/main.go | grep -oE '[0-9]+' | head -1)
+          { [ -n "$lease" ] && [ "$lease" -le 15 ]; } || { echo "FAIL: leaderLeaseDuration='$lease's exceeds the pinned 15s HA failover budget"; exit 1; }
+          echo "leaderLeaseDuration=${lease}s (<= 15s HA budget) OK"
 
       # #230 item 1: the active-passive HA topology the design relies on was never asserted structurally.
       # A drift that dropped the soft anti-affinity, changed the default replica count, misaligned the PDB
@@ -172,11 +179,14 @@ jobs:
       - name: Verify the deployed manager runs the just-built image
         run: |
           set -euo pipefail
-          imgs=$(kubectl -n ntn-operators-system get deploy -l control-plane=controller-manager \
-                   -o jsonpath='{.items[*].spec.template.spec.containers[*].image}')
-          echo "deployed manager image(s): $imgs"
-          echo "$imgs" | grep -q 'controller:latest' \
-            || { echo "FAIL: deployed manager image is not the built controller:latest (stale-code risk)"; exit 1; }
+          # Select the "manager" container BY NAME and compare EXACTLY — a substring grep over all containers
+          # could be satisfied by a sidecar tagged controller:latest (or fooled by controller:latest-debug)
+          # while the manager itself deployed a stale image.
+          img=$(kubectl -n ntn-operators-system get deploy -l control-plane=controller-manager \
+                  -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name=="manager")].image}')
+          echo "deployed manager container image: $img"
+          [ "$img" = "controller:latest" ] \
+            || { echo "FAIL: manager container image is '$img', not the built controller:latest (stale-code risk)"; exit 1; }
 
       # #230 items 2-5: exercise the active-passive HA behaviours against the just-deployed 2-replica
       # release — graceful failover (leader delete → standby acquires lease → new leader reconciles),
@@ -201,7 +211,14 @@ jobs:
           if grep -Eq 'no tests to run|no test files' /tmp/ha_e2e.out; then
             echo "FALSE GREEN: go test -tags=e2e_ha ran no tests"; exit 1
           fi
-          for tc in TestHAGracefulFailover TestHAUngracefulFailover TestHAPDBEviction TestHACacheSyncRolloutGate; do
+          # DERIVE the TestHA* set from the compiled binary so a NEW HA test or a rename is auto-covered (not
+          # just a hardcoded list), require at least the current four, then assert each actually PASSED. A
+          # build-tag typo makes the list empty -> caught by the floor.
+          mapfile -t HATESTS < <(go test -tags=e2e_ha ./test/e2e/ -list '^TestHA' 2>/dev/null | grep '^TestHA' || true)
+          if [ "${#HATESTS[@]}" -lt 4 ]; then
+            echo "FALSE GREEN: expected >= 4 TestHA* tests, found ${#HATESTS[@]} (build-tag/rename regression?)"; exit 1
+          fi
+          for tc in "${HATESTS[@]}"; do
             grep -Eq "^--- PASS: ${tc} " /tmp/ha_e2e.out || { echo "FALSE GREEN: ${tc} did not run+PASS"; exit 1; }
           done
-          echo "verified: all 4 TestHA* ran and passed"
+          echo "verified: all ${#HATESTS[@]} TestHA* ran and passed"

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -79,6 +79,79 @@ jobs:
           { [ -n "$grace" ] && [ "$grace" -ge "$renew" ]; } || { echo "FAIL: chart terminationGracePeriodSeconds='$grace' must be >= RenewDeadline ${renew}s"; exit 1; }
           echo "chart terminationGracePeriodSeconds=$grace (>= RenewDeadline ${renew}s) OK"
 
+      # #230 item 1: the active-passive HA topology the design relies on was never asserted structurally.
+      # A drift that dropped the soft anti-affinity, changed the default replica count, or misaligned the
+      # PDB selector (so it stops selecting the manager pods → the minAvailable guard silently protects
+      # nothing) would ship green. Assert the rendered topology holds.
+      - name: Verify chart HA topology (replicas / PDB selector alignment / soft anti-affinity)
+        run: |
+          set -euo pipefail
+          ./bin/helm template t ./dist/chart -n ntn-system --set podDisruptionBudget.enable=true > /tmp/ha_topology.yaml
+          python3 - <<'PY'
+          import sys, math, yaml
+          docs = [d for d in yaml.safe_load_all(open('/tmp/ha_topology.yaml')) if d]
+          deps = [d for d in docs if d['kind'] == 'Deployment']
+          pdbs = [d for d in docs if d['kind'] == 'PodDisruptionBudget']
+          errs = []
+          if len(deps) != 1:
+              errs.append(f"expected exactly 1 Deployment, got {len(deps)}")
+          if len(pdbs) != 1:
+              errs.append(f"expected exactly 1 PodDisruptionBudget, got {len(pdbs)}")
+          if not errs:
+              dep, pdb = deps[0], pdbs[0]
+              # (1) active-passive default = 2 replicas (one active reconciler + one warm standby).
+              if dep['spec'].get('replicas') != 2:
+                  errs.append(f"default replicas must be 2 (active-passive), got {dep['spec'].get('replicas')}")
+              # (2) PDB minAvailable=1 over 2 replicas → a drain may take at most one at a time.
+              if pdb['spec'].get('minAvailable') != 1:
+                  errs.append(f"PDB minAvailable must be 1, got {pdb['spec'].get('minAvailable')}")
+              pod_labels = dep['spec']['template']['metadata']['labels']
+              # (3) soft (preferred) pod anti-affinity spreads the standby onto another node; must NOT be
+              #     hard (required), which would wedge scheduling on a single-node cluster; AND its
+              #     labelSelector must actually SELECT the manager pods and spread by hostname — else the
+              #     spread silently guards nothing (the same class the PDB alignment check below catches).
+              paa = dep['spec']['template']['spec'].get('affinity', {}).get('podAntiAffinity', {})
+              pref = paa.get('preferredDuringSchedulingIgnoredDuringExecution', [])
+              if not pref:
+                  errs.append("Deployment must set a SOFT (preferred) podAntiAffinity")
+              if 'requiredDuringSchedulingIgnoredDuringExecution' in paa:
+                  errs.append("podAntiAffinity must NOT be hard (required) — it would wedge single-node scheduling")
+              if pref:
+                  term = pref[0].get('podAffinityTerm', {})
+                  aff_sel = term.get('labelSelector', {}).get('matchLabels', {})
+                  aff_mism = {k: (v, pod_labels.get(k)) for k, v in aff_sel.items() if pod_labels.get(k) != v}
+                  if not aff_sel or aff_mism:
+                      errs.append(f"podAntiAffinity labelSelector does not select the manager pods (sel={aff_sel} mismatch={aff_mism})")
+                  if term.get('topologyKey') != 'kubernetes.io/hostname':
+                      errs.append(f"podAntiAffinity topologyKey must be kubernetes.io/hostname, got {term.get('topologyKey')}")
+              # (4) selector alignment: the PDB must actually SELECT the manager pods, else minAvailable
+              #     guards nothing. Every PDB selector label must match the Deployment's pod-template labels.
+              sel = pdb['spec']['selector']['matchLabels']
+              mism = {k: (v, pod_labels.get(k)) for k, v in sel.items() if pod_labels.get(k) != v}
+              if not sel or mism:
+                  errs.append(f"PDB selector does not match the Deployment pod labels (sel={sel} mismatch={mism})")
+              # (5) the cache-sync /readyz rollout gate (TestHACacheSyncRolloutGate, #230) relies on the
+              #     effective maxUnavailable being 0 for the default 2 replicas: a broken new pod must NOT be
+              #     able to tear down the last healthy one. Kube's default RollingUpdate (25%/25%) floors to 0
+              #     over 2 replicas; assert nothing overrode that into a >0 value and that the strategy is not
+              #     Recreate (which drops every pod at once). Percentages for maxUnavailable round DOWN.
+              strat = dep['spec'].get('strategy') or {}
+              if strat.get('type') == 'Recreate':
+                  errs.append("Deployment strategy must not be Recreate — it tears down the healthy version during a rollout")
+              mu = (strat.get('rollingUpdate') or {}).get('maxUnavailable')
+              if mu is None:
+                  eff_mu = 0  # kube default 25% of 2 replicas → floor(0.5) = 0
+              elif isinstance(mu, str) and mu.endswith('%'):
+                  eff_mu = math.floor(int(mu[:-1]) / 100 * 2)
+              else:
+                  eff_mu = int(mu)
+              if eff_mu != 0:
+                  errs.append(f"effective maxUnavailable over 2 replicas must be 0 (strategy.rollingUpdate.maxUnavailable={mu} -> {eff_mu}); a >0 value lets a broken new pod evict the last healthy replica")
+          if errs:
+              print("FAIL: chart HA topology:\n  - " + "\n  - ".join(errs)); sys.exit(1)
+          print("chart HA topology OK (replicas=2, PDB minAvailable=1 selecting the manager pods, soft anti-affinity)")
+          PY
+
       # F7 (#228): the egress NetworkPolicy was never rendered or validated in CI, so a regression that
       # dropped DNS/UDP or an egress port would ship silently. Assert it renders only when enabled, carries
       # the egress rules the operator depends on, and is accepted by the live API server (server-side
@@ -119,3 +192,12 @@ jobs:
 
       - name: Check Helm release status
         run: make helm-status
+
+      # #230 items 2-5: exercise the active-passive HA behaviours against the just-deployed 2-replica
+      # release — graceful failover (leader delete → standby acquires lease → new leader reconciles),
+      # ungraceful failover (SIGKILL → failover within LeaseDuration), PDB eviction (evicts at most one),
+      # and the cache-sync /readyz rollout gate (a broken replica stays NotReady, healthy version preserved).
+      # These are DESTRUCTIVE (kill/evict pods, briefly break RBAC) so they run last, after the chart
+      # validations above. The suite self-heals to 2 ready replicas between cases.
+      - name: HA failover / PDB / cache-sync E2E (#230)
+        run: HA_NAMESPACE=ntn-operators-system make test-e2e-ha

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -3,19 +3,47 @@ name: Test Chart
 on:
   push:
     branches: [main]
+    # Broad on purpose: this job is the ONLY one that runs the HA suite (make test-e2e-ha, tag e2e_ha), so it
+    # must re-run whenever anything the HA behaviour depends on changes — the chart topology, the manager
+    # Deployment/RBAC, leader-election/readiness (cmd), the controllers + API used by the reconcile-proof, the
+    # provider, controller-runtime (go.mod), the HA test itself, or the topology checker. The general E2E job
+    # covers test/** but only runs -tags=e2e, which does NOT compile ha_test.go.
     paths:
       - 'dist/chart/**'
       - 'bundle/**'
       - 'config/crd/**'
+      - 'config/manager/**'
+      - 'config/rbac/**'
       - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'api/**'
+      - 'test/e2e/ha_test.go'
+      - 'hack/verify_ha_topology*.py'
+      - 'go.mod'
+      - 'go.sum'
       - 'Makefile'
       - '.github/workflows/**'
   pull_request:
+    # Broad on purpose: this job is the ONLY one that runs the HA suite (make test-e2e-ha, tag e2e_ha), so it
+    # must re-run whenever anything the HA behaviour depends on changes — the chart topology, the manager
+    # Deployment/RBAC, leader-election/readiness (cmd), the controllers + API used by the reconcile-proof, the
+    # provider, controller-runtime (go.mod), the HA test itself, or the topology checker. The general E2E job
+    # covers test/** but only runs -tags=e2e, which does NOT compile ha_test.go.
     paths:
       - 'dist/chart/**'
       - 'bundle/**'
       - 'config/crd/**'
+      - 'config/manager/**'
+      - 'config/rbac/**'
       - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'api/**'
+      - 'test/e2e/ha_test.go'
+      - 'hack/verify_ha_topology*.py'
+      - 'go.mod'
+      - 'go.sum'
       - 'Makefile'
       - '.github/workflows/**'
 
@@ -80,77 +108,17 @@ jobs:
           echo "chart terminationGracePeriodSeconds=$grace (>= RenewDeadline ${renew}s) OK"
 
       # #230 item 1: the active-passive HA topology the design relies on was never asserted structurally.
-      # A drift that dropped the soft anti-affinity, changed the default replica count, or misaligned the
-      # PDB selector (so it stops selecting the manager pods → the minAvailable guard silently protects
-      # nothing) would ship green. Assert the rendered topology holds.
-      - name: Verify chart HA topology (replicas / PDB selector alignment / soft anti-affinity)
+      # A drift that dropped the soft anti-affinity, changed the default replica count, misaligned the PDB
+      # selector (so it stops selecting the manager pods → minAvailable silently protects nothing), or picked
+      # a rollout strategy that can tear down the healthy version would ship green. Assert the rendered
+      # topology holds (hack/verify_ha_topology.py), then SELF-TEST the checker against deliberately-broken
+      # renders so a refactor that weakens a guard fails here rather than letting real drift through.
+      - name: Verify chart HA topology + self-test the checker (negative controls)
         run: |
           set -euo pipefail
           ./bin/helm template t ./dist/chart -n ntn-system --set podDisruptionBudget.enable=true > /tmp/ha_topology.yaml
-          python3 - <<'PY'
-          import sys, math, yaml
-          docs = [d for d in yaml.safe_load_all(open('/tmp/ha_topology.yaml')) if d]
-          deps = [d for d in docs if d['kind'] == 'Deployment']
-          pdbs = [d for d in docs if d['kind'] == 'PodDisruptionBudget']
-          errs = []
-          if len(deps) != 1:
-              errs.append(f"expected exactly 1 Deployment, got {len(deps)}")
-          if len(pdbs) != 1:
-              errs.append(f"expected exactly 1 PodDisruptionBudget, got {len(pdbs)}")
-          if not errs:
-              dep, pdb = deps[0], pdbs[0]
-              # (1) active-passive default = 2 replicas (one active reconciler + one warm standby).
-              if dep['spec'].get('replicas') != 2:
-                  errs.append(f"default replicas must be 2 (active-passive), got {dep['spec'].get('replicas')}")
-              # (2) PDB minAvailable=1 over 2 replicas → a drain may take at most one at a time.
-              if pdb['spec'].get('minAvailable') != 1:
-                  errs.append(f"PDB minAvailable must be 1, got {pdb['spec'].get('minAvailable')}")
-              pod_labels = dep['spec']['template']['metadata']['labels']
-              # (3) soft (preferred) pod anti-affinity spreads the standby onto another node; must NOT be
-              #     hard (required), which would wedge scheduling on a single-node cluster; AND its
-              #     labelSelector must actually SELECT the manager pods and spread by hostname — else the
-              #     spread silently guards nothing (the same class the PDB alignment check below catches).
-              paa = dep['spec']['template']['spec'].get('affinity', {}).get('podAntiAffinity', {})
-              pref = paa.get('preferredDuringSchedulingIgnoredDuringExecution', [])
-              if not pref:
-                  errs.append("Deployment must set a SOFT (preferred) podAntiAffinity")
-              if 'requiredDuringSchedulingIgnoredDuringExecution' in paa:
-                  errs.append("podAntiAffinity must NOT be hard (required) — it would wedge single-node scheduling")
-              if pref:
-                  term = pref[0].get('podAffinityTerm', {})
-                  aff_sel = term.get('labelSelector', {}).get('matchLabels', {})
-                  aff_mism = {k: (v, pod_labels.get(k)) for k, v in aff_sel.items() if pod_labels.get(k) != v}
-                  if not aff_sel or aff_mism:
-                      errs.append(f"podAntiAffinity labelSelector does not select the manager pods (sel={aff_sel} mismatch={aff_mism})")
-                  if term.get('topologyKey') != 'kubernetes.io/hostname':
-                      errs.append(f"podAntiAffinity topologyKey must be kubernetes.io/hostname, got {term.get('topologyKey')}")
-              # (4) selector alignment: the PDB must actually SELECT the manager pods, else minAvailable
-              #     guards nothing. Every PDB selector label must match the Deployment's pod-template labels.
-              sel = pdb['spec']['selector']['matchLabels']
-              mism = {k: (v, pod_labels.get(k)) for k, v in sel.items() if pod_labels.get(k) != v}
-              if not sel or mism:
-                  errs.append(f"PDB selector does not match the Deployment pod labels (sel={sel} mismatch={mism})")
-              # (5) the cache-sync /readyz rollout gate (TestHACacheSyncRolloutGate, #230) relies on the
-              #     effective maxUnavailable being 0 for the default 2 replicas: a broken new pod must NOT be
-              #     able to tear down the last healthy one. Kube's default RollingUpdate (25%/25%) floors to 0
-              #     over 2 replicas; assert nothing overrode that into a >0 value and that the strategy is not
-              #     Recreate (which drops every pod at once). Percentages for maxUnavailable round DOWN.
-              strat = dep['spec'].get('strategy') or {}
-              if strat.get('type') == 'Recreate':
-                  errs.append("Deployment strategy must not be Recreate — it tears down the healthy version during a rollout")
-              mu = (strat.get('rollingUpdate') or {}).get('maxUnavailable')
-              if mu is None:
-                  eff_mu = 0  # kube default 25% of 2 replicas → floor(0.5) = 0
-              elif isinstance(mu, str) and mu.endswith('%'):
-                  eff_mu = math.floor(int(mu[:-1]) / 100 * 2)
-              else:
-                  eff_mu = int(mu)
-              if eff_mu != 0:
-                  errs.append(f"effective maxUnavailable over 2 replicas must be 0 (strategy.rollingUpdate.maxUnavailable={mu} -> {eff_mu}); a >0 value lets a broken new pod evict the last healthy replica")
-          if errs:
-              print("FAIL: chart HA topology:\n  - " + "\n  - ".join(errs)); sys.exit(1)
-          print("chart HA topology OK (replicas=2, PDB minAvailable=1 selecting the manager pods, soft anti-affinity)")
-          PY
+          python3 hack/verify_ha_topology.py /tmp/ha_topology.yaml
+          python3 hack/verify_ha_topology_selftest.py /tmp/ha_topology.yaml
 
       # F7 (#228): the egress NetworkPolicy was never rendered or validated in CI, so a regression that
       # dropped DNS/UDP or an egress port would ship silently. Assert it renders only when enabled, carries
@@ -200,4 +168,9 @@ jobs:
       # These are DESTRUCTIVE (kill/evict pods, briefly break RBAC) so they run last, after the chart
       # validations above. The suite self-heals to 2 ready replicas between cases.
       - name: HA failover / PDB / cache-sync E2E (#230)
-        run: HA_NAMESPACE=ntn-operators-system make test-e2e-ha
+        env:
+          HA_NAMESPACE: ntn-operators-system
+          HA_ALLOW_DESTRUCTIVE: "1"    # explicit opt-in — the suite cordons nodes, evicts pods, mutates cluster RBAC
+          HA_EXPECT_KIND: "1"          # refuse to run unless EVERY node is a disposable Kind node
+          HA_REQUIRE_UNGRACEFUL: "1"   # the ungraceful SIGKILL test must RUN — a skip is a FAILURE here, not green
+        run: make test-e2e-ha

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -18,8 +18,10 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'api/**'
-      - 'test/e2e/ha_test.go'
+      - 'test/e2e/**'
       - 'hack/verify_ha_topology*.py'
+      - 'Dockerfile'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
@@ -40,8 +42,10 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'api/**'
-      - 'test/e2e/ha_test.go'
+      - 'test/e2e/**'
       - 'hack/verify_ha_topology*.py'
+      - 'Dockerfile'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
@@ -161,6 +165,19 @@ jobs:
       - name: Check Helm release status
         run: make helm-status
 
+      # Assert the deployed manager runs the JUST-BUILT image, not a stale published tag. helm-deploy sets the
+      # image via --set from IMG=controller:latest; if that override were ever dropped, the chart default
+      # (a real published release) could deploy and the HA suite would validate OLD code. pullPolicy=Never
+      # already fails that closed, but assert image identity so the guarantee does not rest on one flag.
+      - name: Verify the deployed manager runs the just-built image
+        run: |
+          set -euo pipefail
+          imgs=$(kubectl -n ntn-operators-system get deploy -l control-plane=controller-manager \
+                   -o jsonpath='{.items[*].spec.template.spec.containers[*].image}')
+          echo "deployed manager image(s): $imgs"
+          echo "$imgs" | grep -q 'controller:latest' \
+            || { echo "FAIL: deployed manager image is not the built controller:latest (stale-code risk)"; exit 1; }
+
       # #230 items 2-5: exercise the active-passive HA behaviours against the just-deployed 2-replica
       # release — graceful failover (leader delete → standby acquires lease → new leader reconciles),
       # ungraceful failover (SIGKILL → failover within LeaseDuration), PDB eviction (evicts at most one),
@@ -173,4 +190,18 @@ jobs:
           HA_ALLOW_DESTRUCTIVE: "1"    # explicit opt-in — the suite cordons nodes, evicts pods, mutates cluster RBAC
           HA_EXPECT_KIND: "1"          # refuse to run unless EVERY node is a disposable Kind node
           HA_REQUIRE_UNGRACEFUL: "1"   # the ungraceful SIGKILL test must RUN — a skip is a FAILURE here, not green
-        run: make test-e2e-ha
+          HA_REQUIRE_RUN: "1"          # a missing HA_ALLOW_DESTRUCTIVE must FAIL here, not skip every test to green
+        run: |
+          set -euo pipefail
+          make test-e2e-ha 2>&1 | tee /tmp/ha_e2e.out
+          # Guard the ONE false-green the HA_REQUIRE_* env vars cannot: those live INSIDE newHAEnv, so if a
+          # build-tag typo or a TestHA* rename makes `go test -run '^TestHA'` match ZERO tests, it exits 0 and
+          # every guard is bypassed. Assert go test did not no-op AND each expected test actually PASSED (also
+          # catches a SKIP, which prints "--- SKIP" not "--- PASS").
+          if grep -Eq 'no tests to run|no test files' /tmp/ha_e2e.out; then
+            echo "FALSE GREEN: go test -tags=e2e_ha ran no tests"; exit 1
+          fi
+          for tc in TestHAGracefulFailover TestHAUngracefulFailover TestHAPDBEviction TestHACacheSyncRolloutGate; do
+            grep -Eq "^--- PASS: ${tc} " /tmp/ha_e2e.out || { echo "FALSE GREEN: ${tc} did not run+PASS"; exit 1; }
+          done
+          echo "verified: all 4 TestHA* ran and passed"

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ dist/install.yaml
 
 # Codex
 .codex
+
+# Python bytecode (hack/verify_ha_topology*.py)
+__pycache__/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Defaults to a Kind en
 	@if [ -z "$$E2E_USE_EXISTING_CLUSTER" ]; then $(MAKE) cleanup-test-e2e; \
 	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind teardown"; fi
 
+.PHONY: test-e2e-ha
+test-e2e-ha: ## Run the HA E2E suite (#230) against an ALREADY-DEPLOYED chart release (2 replicas, leader election). Set HA_NAMESPACE (default ntn-operators-system). Does NOT create a cluster or deploy — run `make helm-deploy` first.
+	go test -tags=e2e_ha ./test/e2e/ -run '^TestHA' -v -timeout 20m
+
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Defaults to a Kind en
 
 .PHONY: test-e2e-ha
 test-e2e-ha: ## Run the HA E2E suite (#230) against an ALREADY-DEPLOYED chart release (2 replicas, leader election). Set HA_NAMESPACE (default ntn-operators-system). Does NOT create a cluster or deploy — run `make helm-deploy` first.
-	go test -tags=e2e_ha ./test/e2e/ -run '^TestHA' -v -timeout 20m
+	go test -tags=e2e_ha -count=1 ./test/e2e/ -run '^TestHA' -v -timeout 20m
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -11,6 +11,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.manager.replicas }}
+  # Active-passive HA: never tear down a healthy replica before its replacement is Ready. The cache-sync
+  # /readyz rollout gate and the PDB both depend on maxUnavailable=0 (a broken new replica must not evict the
+  # last healthy one); maxSurge=1 lets the rollout still progress. Pinned explicitly rather than relying on the
+  # default RollingUpdate rounding (25%/25% happens to floor to 0/ceil to 1 at 2 replicas). See
+  # docs/high-availability.md and hack/verify_ha_topology.py.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "ntn-operators.name" . }}

--- a/hack/verify_ha_topology.py
+++ b/hack/verify_ha_topology.py
@@ -70,6 +70,17 @@ def _as_int(v, default=0):
     return v if isinstance(v, int) and not isinstance(v, bool) else default
 
 
+def _percent(v):
+    """Parse an integer-percentage string ("50%" -> 50); return None for a non-integer or non-"%" string
+    (e.g. "50.5%", "abc%") so the caller fails closed instead of raising a ValueError traceback."""
+    if not isinstance(v, str) or not v.endswith('%'):
+        return None
+    try:
+        return int(v[:-1])
+    except ValueError:
+        return None
+
+
 def _pdb_guaranteed_available(pdb_spec, replicas=2):
     """The minimum pods the PDB guarantees stay available, whether written as minAvailable or maxUnavailable,
     int or percentage — so `maxUnavailable: 1` (equivalent to `minAvailable: 1` over 2 replicas) is accepted,
@@ -77,17 +88,21 @@ def _pdb_guaranteed_available(pdb_spec, replicas=2):
     unavailable-count rounds up, i.e. the fewest guaranteed available). Returns None if neither is set or a
     value is a non-percentage string (kube itself rejects those; the caller flags them)."""
     mn, mx = pdb_spec.get('minAvailable'), pdb_spec.get('maxUnavailable')
+    if mn is not None and mx is not None:
+        return None  # kube forbids setting BOTH — treat as unresolvable so the caller flags it
     if mn is not None:
         if isinstance(mn, bool):
             return None
         if isinstance(mn, str):
-            return math.ceil(int(mn[:-1]) / 100 * replicas) if mn.endswith('%') else None
+            pct = _percent(mn)
+            return math.ceil(pct / 100 * replicas) if pct is not None else None
         return int(mn)
     if mx is not None:
         if isinstance(mx, bool):
             return None
         if isinstance(mx, str):
-            return replicas - math.ceil(int(mx[:-1]) / 100 * replicas) if mx.endswith('%') else None
+            pct = _percent(mx)
+            return replicas - math.ceil(pct / 100 * replicas) if pct is not None else None
         return replicas - int(mx)
     return None
 
@@ -239,6 +254,8 @@ def check(docs):
     #     label; a nodeAffinity (required or preferred) that references the hostname label or pins the node
     #     name; and a podAffinity (ATTRACTION, hard or soft) on the hostname topology selecting the manager
     #     (which pulls the replicas together — the opposite of anti-affinity).
+    # NOTE: this guard covers the kubernetes.io/hostname pinning dimension only — a pin via a custom single-node
+    # label (a rack/zone label that happens to map to one node) cannot be detected from a render alone.
     podspec = dep['spec']['template']['spec']
     if podspec.get('nodeName'):
         errs.append(f"pod template sets spec.nodeName={podspec.get('nodeName')!r} — pins ALL replicas to one "
@@ -250,18 +267,27 @@ def check(docs):
     na_terms = list((na.get('requiredDuringSchedulingIgnoredDuringExecution') or {}).get('nodeSelectorTerms') or [])
     na_terms += [(p.get('preference') or {}) for p in (na.get('preferredDuringSchedulingIgnoredDuringExecution') or [])]
     for term in na_terms:
-        keys = [e.get('key') for e in (term.get('matchExpressions') or [])]
-        fields = [e.get('key') for e in (term.get('matchFields') or [])]
-        if 'kubernetes.io/hostname' in keys or 'metadata.name' in fields:
-            errs.append("nodeAffinity references the node hostname (kubernetes.io/hostname / metadata.name) — "
-                        "can pin all replicas to one node, defeating the HA spread")
+        # Only a POSITIVE pin co-locates: hostname/metadata.name `In` WITH values. NotIn/Exists/DoesNotExist are
+        # exclusions or presence checks that do NOT force all replicas onto one node (so must not be rejected).
+        pins = any(e.get('key') == 'kubernetes.io/hostname' and e.get('operator') == 'In' and (e.get('values') or [])
+                   for e in (term.get('matchExpressions') or []))
+        pins = pins or any(e.get('key') == 'metadata.name' and e.get('operator') == 'In' and (e.get('values') or [])
+                           for e in (term.get('matchFields') or []))
+        if pins:
+            errs.append("nodeAffinity pins the node (kubernetes.io/hostname In / metadata.name In) — can pin all "
+                        "replicas to one node, defeating the HA spread")
             break
     pa = affinity.get('podAffinity') or {}
     pa_terms = list(pa.get('requiredDuringSchedulingIgnoredDuringExecution') or [])
     pa_terms += [(p.get('podAffinityTerm') or {}) for p in (pa.get('preferredDuringSchedulingIgnoredDuringExecution') or [])]
     for term in pa_terms:
-        if term.get('topologyKey') == 'kubernetes.io/hostname' \
-                and _selector_selects(term.get('labelSelector') or {}, pod_labels):
+        if term.get('topologyKey') != 'kubernetes.io/hostname':
+            continue
+        sel = term.get('labelSelector')
+        # An EMPTY {} selector is labels.Everything() (selects ALL pods) -> co-locates; a NIL/absent selector is
+        # labels.Nothing() (selects none) -> harmless. matchLabelKeys merges the selector to same-ReplicaSet
+        # pods -> co-locates. A non-empty selector co-locates iff it selects the manager.
+        if sel == {} or term.get('matchLabelKeys') or (sel and _selector_selects(sel, pod_labels)):
             errs.append("podAffinity ATTRACTS the manager on kubernetes.io/hostname — pulls both replicas onto "
                         "one node, the opposite of the anti-affinity spread")
             break

--- a/hack/verify_ha_topology.py
+++ b/hack/verify_ha_topology.py
@@ -39,15 +39,57 @@ def _selector_selects(sel, pod_labels):
         key, op, vals = expr.get('key'), expr.get('operator'), expr.get('values') or []
         present = key in pod_labels
         pv = pod_labels.get(key)
-        if op == 'In' and (not present or pv not in vals):
-            return False
-        if op == 'NotIn' and (present and pv in vals):
-            return False
-        if op == 'Exists' and not present:
-            return False
-        if op == 'DoesNotExist' and present:
-            return False
+        # FAIL-CLOSED: only the four kube operators are valid, with kube's own value rules (In/NotIn require a
+        # non-empty values list; Exists/DoesNotExist require an empty one). Anything else is malformed — treat
+        # it as NOT selecting the manager rather than silently falling through to True (which would let a
+        # bogus selector pass the "selects the manager" gate).
+        if op == 'In':
+            if not vals or not present or pv not in vals:
+                return False
+        elif op == 'NotIn':
+            if not vals:
+                return False
+            if present and pv in vals:
+                return False
+        elif op == 'Exists':
+            if vals or not present:
+                return False
+        elif op == 'DoesNotExist':
+            if vals or present:
+                return False
+        else:
+            return False  # unknown operator — malformed, do not treat as a match
     return True
+
+
+def _as_int(v, default=0):
+    """Return v only if it is a REAL int (kube's type for fields like weight); otherwise default. A quoted
+    string like "100" is an invalid render (kube wants an int32) and must fail CLOSED — treated as the default
+    (so the term is judged ineffective) rather than parsed as 100 or crashing the checker. bool is excluded
+    (Python bools are ints)."""
+    return v if isinstance(v, int) and not isinstance(v, bool) else default
+
+
+def _pdb_guaranteed_available(pdb_spec, replicas=2):
+    """The minimum pods the PDB guarantees stay available, whether written as minAvailable or maxUnavailable,
+    int or percentage — so `maxUnavailable: 1` (equivalent to `minAvailable: 1` over 2 replicas) is accepted,
+    not falsely rejected. Percentages use kube's WORST-CASE rounding (minAvailable rounds up; maxUnavailable's
+    unavailable-count rounds up, i.e. the fewest guaranteed available). Returns None if neither is set or a
+    value is a non-percentage string (kube itself rejects those; the caller flags them)."""
+    mn, mx = pdb_spec.get('minAvailable'), pdb_spec.get('maxUnavailable')
+    if mn is not None:
+        if isinstance(mn, bool):
+            return None
+        if isinstance(mn, str):
+            return math.ceil(int(mn[:-1]) / 100 * replicas) if mn.endswith('%') else None
+        return int(mn)
+    if mx is not None:
+        if isinstance(mx, bool):
+            return None
+        if isinstance(mx, str):
+            return replicas - math.ceil(int(mx[:-1]) / 100 * replicas) if mx.endswith('%') else None
+        return replicas - int(mx)
+    return None
 
 
 def _effective_max_unavailable(strategy, replicas=2):
@@ -58,6 +100,45 @@ def _effective_max_unavailable(strategy, replicas=2):
     if isinstance(mu, str) and mu.endswith('%'):
         return math.floor(int(mu[:-1]) / 100 * replicas)
     return int(mu)
+
+
+def _effective_max_surge(strategy, replicas=2):
+    """Kube's effective maxSurge over `replicas` (percentages round UP; absent => default 25%)."""
+    ms = (strategy.get('rollingUpdate') or {}).get('maxSurge')
+    if ms is None:
+        return 1  # kube default 25% of 2 replicas -> ceil(0.5) = 1
+    if isinstance(ms, str) and ms.endswith('%'):
+        return math.ceil(int(ms[:-1]) / 100 * replicas)
+    return int(ms)
+
+
+# The manager's distinguishing label — the SAME identity the E2E's managerSelector uses. A PDB or
+# anti-affinity selector that PINS this (matchLabels control-plane=controller-manager) cannot also select
+# non-manager pods (nothing else in the namespace carries it). One that OMITS it and leans on a shared app
+# label (e.g. app.kubernetes.io/name) is over-broad: it still matches the manager, so a plain "does it select
+# the manager" check passes, yet it would protect/spread the WRONG set. A namespace holding only manager pods
+# cannot expose this at runtime (the count is still right), so it must be caught structurally here.
+MANAGER_LABEL_KEY = 'control-plane'
+MANAGER_LABEL_VAL = 'controller-manager'
+
+
+def _pins_manager_identity(sel):
+    """True iff the selector fixes the manager's distinguishing label via matchLabels (so it cannot be over-broad)."""
+    return (sel.get('matchLabels') or {}).get(MANAGER_LABEL_KEY) == MANAGER_LABEL_VAL
+
+
+# Anti-affinity term fields that widen the scope beyond "same-namespace manager pods". A drift adding any of
+# these makes the spread stop targeting the manager replicas even though the labelSelector still looks right
+# (e.g. namespaces:[other] or namespaceSelector:{} score against a different pod set). _selector_selects models
+# only the labelSelector, so any field that changes the pod SET must be rejected fail-closed here.
+_SCOPE_WIDENING_TERM_FIELDS = ('namespaces', 'namespaceSelector', 'matchLabelKeys', 'mismatchLabelKeys')
+
+
+def _term_same_namespace_scoped(term):
+    """True iff the affinity term stays scoped to the pod's own namespace via labelSelector only — no
+    namespaces / namespaceSelector / matchLabelKeys / mismatchLabelKeys that would change the pod set. Note
+    namespaceSelector:{} means ALL namespaces (not 'this one'), so any present value is rejected."""
+    return all(term.get(f) in (None, []) for f in _SCOPE_WIDENING_TERM_FIELDS)
 
 
 def check(docs):
@@ -74,13 +155,26 @@ def check(docs):
     dep, pdb = deps[0], pdbs[0]
     pod_labels = dep['spec']['template']['metadata'].get('labels') or {}
 
-    # (1) active-passive default = 2 replicas (one active reconciler + one warm standby).
-    if dep['spec'].get('replicas') != 2:
-        errs.append(f"default replicas must be 2 (active-passive), got {dep['spec'].get('replicas')}")
+    # (0) anchor: the pod template must carry the manager's distinguishing identity label. The PDB /
+    #     anti-affinity specificity checks below are anchored to it, so a drift that removed it must fail here.
+    if pod_labels.get(MANAGER_LABEL_KEY) != MANAGER_LABEL_VAL:
+        errs.append(f"pod template must carry the manager identity label {MANAGER_LABEL_KEY}={MANAGER_LABEL_VAL} "
+                    f"(got labels {pod_labels})")
 
-    # (2) PDB minAvailable=1 over 2 replicas -> a drain may take at most one at a time.
-    if pdb['spec'].get('minAvailable') != 1:
-        errs.append(f"PDB minAvailable must be 1, got {pdb['spec'].get('minAvailable')}")
+    # (1) active-passive default = 2 replicas (one active reconciler + one warm standby). repr() so a string
+    #     "2" (invalid; kube wants an int) is visibly distinct from the int 2 in the error.
+    if dep['spec'].get('replicas') != 2:
+        errs.append(f"default replicas must be 2 (active-passive), got {dep['spec'].get('replicas')!r}")
+
+    # (2) the PDB must guarantee EXACTLY 1 available pod over 2 replicas — a drain may take at most one at a
+    #     time. Accept either expression (minAvailable OR maxUnavailable, int OR percentage): `maxUnavailable:
+    #     1` is equivalent to `minAvailable: 1` and must not be falsely rejected. A non-percentage string is
+    #     invalid (kube rejects it) -> guaranteed is None -> flagged here too.
+    guaranteed = _pdb_guaranteed_available(pdb['spec'])
+    if guaranteed != 1:
+        errs.append(f"PDB must guarantee exactly 1 available pod over 2 replicas (minAvailable/maxUnavailable "
+                    f"resolves to {guaranteed!r}); minAvailable={pdb['spec'].get('minAvailable')!r} "
+                    f"maxUnavailable={pdb['spec'].get('maxUnavailable')!r}")
 
     # (3) soft (preferred) pod anti-affinity spreads the standby onto another node; it must NOT be hard
     #     (required), which would wedge scheduling on a single-node cluster. Robust against drift: iterate
@@ -93,21 +187,33 @@ def check(docs):
     pref = paa.get('preferredDuringSchedulingIgnoredDuringExecution') or []
     effective = [
         p for p in pref
-        if (p.get('weight') or 0) > 0
+        if _as_int(p.get('weight')) > 0
         and (p.get('podAffinityTerm') or {}).get('topologyKey') == 'kubernetes.io/hostname'
         and _selector_selects((p.get('podAffinityTerm') or {}).get('labelSelector') or {}, pod_labels)
+        and _pins_manager_identity((p.get('podAffinityTerm') or {}).get('labelSelector') or {})
+        and _term_same_namespace_scoped(p.get('podAffinityTerm') or {})
     ]
     if not effective:
-        errs.append("no EFFECTIVE soft podAntiAffinity term (need weight>0, "
-                    f"topologyKey=kubernetes.io/hostname, and a selector selecting the manager pods); "
-                    f"saw {len(pref)} preferred term(s)")
+        errs.append("no EFFECTIVE, manager-specific, same-namespace soft podAntiAffinity term (need weight>0, "
+                    f"topologyKey=kubernetes.io/hostname, a selector pinning {MANAGER_LABEL_KEY}="
+                    f"{MANAGER_LABEL_VAL} so it spreads ONLY the manager, and NO namespaces/namespaceSelector/"
+                    f"matchLabelKeys/mismatchLabelKeys that would re-scope it); saw {len(pref)} preferred term(s)")
 
-    # (4) selector alignment: the PDB must actually SELECT the manager pods, else minAvailable guards nothing.
-    #     Uses full LabelSelector (matchLabels AND matchExpressions) semantics, so a non-matching
-    #     matchExpressions slipped alongside the matchLabels is caught (it would select no pods).
+    # (4) the PDB must protect EXACTLY the manager workload — its selector must equal the Deployment's OWN
+    #     selector (the canonical "match the owning workload" rule). This is strictly stronger than "does it
+    #     select a manager pod": it rejects an OVER-broad selector (which would let minAvailable be satisfied
+    #     by unrelated pods so both managers could be evicted) AND an under-broad one, neither of which a
+    #     manager-only Kind namespace can expose at runtime (the pod count is right regardless). It also
+    #     subsumes the manager-identity pin, since the Deployment selector carries it. As a sanity, the
+    #     selector must still actually select the pod template (guards a Deployment/PDB rendered inconsistently).
+    dep_sel = dep['spec'].get('selector') or {}
     pdb_sel = pdb['spec'].get('selector') or {}
-    if not _selector_selects(pdb_sel, pod_labels):
-        errs.append(f"PDB selector does not select the manager pods (selector={pdb_sel}, pod labels={pod_labels})")
+    if pdb_sel != dep_sel:
+        errs.append(f"PDB selector must EQUAL the Deployment selector (protect exactly the manager workload); "
+                    f"PDB={pdb_sel} Deployment={dep_sel}")
+    if not _selector_selects(pdb_sel, pod_labels) or not _pins_manager_identity(pdb_sel):
+        errs.append(f"PDB selector does not specifically select the manager pods (selector={pdb_sel}, "
+                    f"pod labels={pod_labels})")
 
     # (5) the cache-sync /readyz rollout gate (TestHACacheSyncRolloutGate) relies on the effective
     #     maxUnavailable being 0 for the default 2 replicas: a broken new pod must NOT tear down the last
@@ -119,6 +225,52 @@ def check(docs):
     if eff_mu != 0:
         errs.append(f"effective maxUnavailable over 2 replicas must be 0 (got {eff_mu}); a >0 value lets a "
                     "broken new pod evict the last healthy replica")
+    # (6) the same rollout gate needs a surge pod to exist: with maxUnavailable=0, a maxSurge of 0 deadlocks
+    #     the rollout (kube can neither add nor remove a pod), so the cache-sync test could never observe a
+    #     gated new pod. Require effective maxSurge >= 1.
+    eff_ms = _effective_max_surge(strat)
+    if eff_ms < 1:
+        errs.append(f"effective maxSurge over 2 replicas must be >= 1 (got {eff_ms}); with maxUnavailable=0 a "
+                    "0 surge deadlocks the rollout — the cache-sync gate test could never see a new pod")
+
+    # (7) co-location guard: the soft anti-affinity above exists to SPREAD the two replicas across hosts, but
+    #     several OTHER pod-spec fields can silently pin BOTH onto one node — defeating HA entirely while the
+    #     anti-affinity still "looks right". Reject: a fixed spec.nodeName; a nodeSelector on the hostname
+    #     label; a nodeAffinity (required or preferred) that references the hostname label or pins the node
+    #     name; and a podAffinity (ATTRACTION, hard or soft) on the hostname topology selecting the manager
+    #     (which pulls the replicas together — the opposite of anti-affinity).
+    podspec = dep['spec']['template']['spec']
+    if podspec.get('nodeName'):
+        errs.append(f"pod template sets spec.nodeName={podspec.get('nodeName')!r} — pins ALL replicas to one "
+                    "node, defeating the HA spread")
+    if 'kubernetes.io/hostname' in (podspec.get('nodeSelector') or {}):
+        errs.append("pod template nodeSelector pins kubernetes.io/hostname — forces all replicas onto one node")
+    affinity = podspec.get('affinity') or {}
+    na = affinity.get('nodeAffinity') or {}
+    na_terms = list((na.get('requiredDuringSchedulingIgnoredDuringExecution') or {}).get('nodeSelectorTerms') or [])
+    na_terms += [(p.get('preference') or {}) for p in (na.get('preferredDuringSchedulingIgnoredDuringExecution') or [])]
+    for term in na_terms:
+        keys = [e.get('key') for e in (term.get('matchExpressions') or [])]
+        fields = [e.get('key') for e in (term.get('matchFields') or [])]
+        if 'kubernetes.io/hostname' in keys or 'metadata.name' in fields:
+            errs.append("nodeAffinity references the node hostname (kubernetes.io/hostname / metadata.name) — "
+                        "can pin all replicas to one node, defeating the HA spread")
+            break
+    pa = affinity.get('podAffinity') or {}
+    pa_terms = list(pa.get('requiredDuringSchedulingIgnoredDuringExecution') or [])
+    pa_terms += [(p.get('podAffinityTerm') or {}) for p in (pa.get('preferredDuringSchedulingIgnoredDuringExecution') or [])]
+    for term in pa_terms:
+        if term.get('topologyKey') == 'kubernetes.io/hostname' \
+                and _selector_selects(term.get('labelSelector') or {}, pod_labels):
+            errs.append("podAffinity ATTRACTS the manager on kubernetes.io/hostname — pulls both replicas onto "
+                        "one node, the opposite of the anti-affinity spread")
+            break
+
+    # (8) a paused Deployment ignores all spec updates, so the cache-sync rollout gate (checks 5/6) can never
+    #     fire — the manager would never actually roll. Reject spec.paused.
+    if dep['spec'].get('paused'):
+        errs.append("Deployment spec.paused is true — it would never roll out, so the rollout-gate invariants "
+                    "cannot hold")
     return errs
 
 

--- a/hack/verify_ha_topology.py
+++ b/hack/verify_ha_topology.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verify a rendered NTN-operators chart holds the active-passive HA topology (#230).
+
+Usage: verify_ha_topology.py <rendered-manifests.yaml>
+
+Asserts, on a `helm template` render, the structural HA invariants the design
+(docs/high-availability.md, #226 / ADR-0005) relies on. A drift that dropped the
+soft anti-affinity, changed the default replica count, misaligned the PDB selector
+(so minAvailable silently protects nothing), or picked a rollout strategy that can
+tear down the healthy version would otherwise ship green.
+
+Exit 0 on pass, 1 on failure (printing every error). Kept as a standalone,
+importable module (not inline in the workflow) so the checker itself can be
+self-tested against deliberately-broken renders in CI — see
+verify_ha_topology_selftest.py.
+"""
+import math
+import sys
+
+import yaml
+
+
+def _selector_selects(sel, pod_labels):
+    """True iff a LabelSelector selects a pod carrying pod_labels, using kube's AND semantics.
+
+    A LabelSelector matches only when EVERY matchLabels entry AND EVERY matchExpressions term holds — so a
+    non-matching matchExpressions added alongside a matching matchLabels makes the selector select NOTHING.
+    (An OR reading would wrongly pass that case.) An empty selector (no matchLabels, no matchExpressions)
+    matches everything in kube, but for our invariants it is NOT an intentional targeting of the manager
+    pods, so we treat it as selecting nothing."""
+    ml = sel.get('matchLabels') or {}
+    exprs = sel.get('matchExpressions') or []
+    if not ml and not exprs:
+        return False
+    for k, v in ml.items():
+        if pod_labels.get(k) != v:
+            return False
+    for expr in exprs:
+        key, op, vals = expr.get('key'), expr.get('operator'), expr.get('values') or []
+        present = key in pod_labels
+        pv = pod_labels.get(key)
+        if op == 'In' and (not present or pv not in vals):
+            return False
+        if op == 'NotIn' and (present and pv in vals):
+            return False
+        if op == 'Exists' and not present:
+            return False
+        if op == 'DoesNotExist' and present:
+            return False
+    return True
+
+
+def _effective_max_unavailable(strategy, replicas=2):
+    """Kube's effective maxUnavailable over `replicas` (percentages round DOWN; absent => default 25%)."""
+    mu = (strategy.get('rollingUpdate') or {}).get('maxUnavailable')
+    if mu is None:
+        return 0  # kube default 25% of 2 replicas -> floor(0.5) = 0
+    if isinstance(mu, str) and mu.endswith('%'):
+        return math.floor(int(mu[:-1]) / 100 * replicas)
+    return int(mu)
+
+
+def check(docs):
+    """Return a list of invariant-violation strings for the rendered docs (empty list = all invariants hold)."""
+    errs = []
+    deps = [d for d in docs if d.get('kind') == 'Deployment']
+    pdbs = [d for d in docs if d.get('kind') == 'PodDisruptionBudget']
+    if len(deps) != 1:
+        errs.append(f"expected exactly 1 Deployment, got {len(deps)}")
+    if len(pdbs) != 1:
+        errs.append(f"expected exactly 1 PodDisruptionBudget, got {len(pdbs)}")
+    if errs:
+        return errs
+    dep, pdb = deps[0], pdbs[0]
+    pod_labels = dep['spec']['template']['metadata'].get('labels') or {}
+
+    # (1) active-passive default = 2 replicas (one active reconciler + one warm standby).
+    if dep['spec'].get('replicas') != 2:
+        errs.append(f"default replicas must be 2 (active-passive), got {dep['spec'].get('replicas')}")
+
+    # (2) PDB minAvailable=1 over 2 replicas -> a drain may take at most one at a time.
+    if pdb['spec'].get('minAvailable') != 1:
+        errs.append(f"PDB minAvailable must be 1, got {pdb['spec'].get('minAvailable')}")
+
+    # (3) soft (preferred) pod anti-affinity spreads the standby onto another node; it must NOT be hard
+    #     (required), which would wedge scheduling on a single-node cluster. Robust against drift: iterate
+    #     EVERY preferred term (not just the first) and require at least one that is actually EFFECTIVE —
+    #     positive weight, hostname topology, and a selector (matchLabels or matchExpressions) that selects
+    #     the manager pods — else the spread silently guards nothing.
+    paa = ((dep['spec']['template']['spec'].get('affinity') or {}).get('podAntiAffinity')) or {}
+    if 'requiredDuringSchedulingIgnoredDuringExecution' in paa:
+        errs.append("podAntiAffinity must NOT be hard (required) — it would wedge single-node scheduling")
+    pref = paa.get('preferredDuringSchedulingIgnoredDuringExecution') or []
+    effective = [
+        p for p in pref
+        if (p.get('weight') or 0) > 0
+        and (p.get('podAffinityTerm') or {}).get('topologyKey') == 'kubernetes.io/hostname'
+        and _selector_selects((p.get('podAffinityTerm') or {}).get('labelSelector') or {}, pod_labels)
+    ]
+    if not effective:
+        errs.append("no EFFECTIVE soft podAntiAffinity term (need weight>0, "
+                    f"topologyKey=kubernetes.io/hostname, and a selector selecting the manager pods); "
+                    f"saw {len(pref)} preferred term(s)")
+
+    # (4) selector alignment: the PDB must actually SELECT the manager pods, else minAvailable guards nothing.
+    #     Uses full LabelSelector (matchLabels AND matchExpressions) semantics, so a non-matching
+    #     matchExpressions slipped alongside the matchLabels is caught (it would select no pods).
+    pdb_sel = pdb['spec'].get('selector') or {}
+    if not _selector_selects(pdb_sel, pod_labels):
+        errs.append(f"PDB selector does not select the manager pods (selector={pdb_sel}, pod labels={pod_labels})")
+
+    # (5) the cache-sync /readyz rollout gate (TestHACacheSyncRolloutGate) relies on the effective
+    #     maxUnavailable being 0 for the default 2 replicas: a broken new pod must NOT tear down the last
+    #     healthy one. Assert nothing overrode the default into a >0 value and the strategy is not Recreate.
+    strat = dep['spec'].get('strategy') or {}
+    if strat.get('type') == 'Recreate':
+        errs.append("Deployment strategy must not be Recreate — it tears down the healthy version during a rollout")
+    eff_mu = _effective_max_unavailable(strat)
+    if eff_mu != 0:
+        errs.append(f"effective maxUnavailable over 2 replicas must be 0 (got {eff_mu}); a >0 value lets a "
+                    "broken new pod evict the last healthy replica")
+    return errs
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: verify_ha_topology.py <rendered-manifests.yaml>", file=sys.stderr)
+        return 2
+    with open(argv[1]) as f:
+        docs = [d for d in yaml.safe_load_all(f) if d]
+    errs = check(docs)
+    if errs:
+        print("FAIL: chart HA topology:\n  - " + "\n  - ".join(errs))
+        return 1
+    print("chart HA topology OK (replicas=2, PDB minAvailable=1 selecting the manager pods, "
+          "effective maxUnavailable=0, effective soft anti-affinity on kubernetes.io/hostname)")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hack/verify_ha_topology_selftest.py
+++ b/hack/verify_ha_topology_selftest.py
@@ -195,6 +195,37 @@ def m_pdb_maxunavail_2(d):
     _pdb(d)['spec']['maxUnavailable'] = 2
 
 
+def m_podaffinity_empty_selector(d):
+    # Empty {} labelSelector = labels.Everything() -> selects ALL pods -> co-locates. _selector_selects returns
+    # False for {}, so the guard must special-case it (else a silent HA-defeating co-location slips through).
+    _dep(d)['spec']['template']['spec'].setdefault('affinity', {})['podAffinity'] = {
+        'preferredDuringSchedulingIgnoredDuringExecution': [{
+            'weight': 100,
+            'podAffinityTerm': {'topologyKey': 'kubernetes.io/hostname', 'labelSelector': {}},
+        }],
+    }
+
+
+def m_podaffinity_matchlabelkeys(d):
+    # matchLabelKeys merges the selector to same-ReplicaSet pods -> co-locates even with a base {} selector.
+    _dep(d)['spec']['template']['spec'].setdefault('affinity', {})['podAffinity'] = {
+        'requiredDuringSchedulingIgnoredDuringExecution': [{
+            'topologyKey': 'kubernetes.io/hostname',
+            'labelSelector': {},
+            'matchLabelKeys': ['pod-template-hash'],
+        }],
+    }
+
+
+def m_pdb_both_set(d):
+    _pdb(d)['spec']['minAvailable'] = 1  # kube forbids BOTH minAvailable AND maxUnavailable
+    _pdb(d)['spec']['maxUnavailable'] = 2
+
+
+def m_pdb_frac_pct(d):
+    _pdb(d)['spec']['minAvailable'] = '50.5%'  # malformed percentage -> must reject cleanly, not traceback
+
+
 # Each mutation must be REJECTED by check(); m_aff_weight0 also proves the weight=0 (no-op) case is caught.
 CASES = [
     m_replicas, m_pdb_min, m_pdb_selector, m_recreate, m_maxunavail_int, m_maxunavail_pct,
@@ -204,6 +235,7 @@ CASES = [
     m_aff_invalid_op, m_aff_in_empty, m_aff_notin_empty,
     m_nodename, m_nodeselector_host, m_nodeaffinity_host, m_podaffinity_colocate,
     m_paused, m_weight_str, m_pdb_maxunavail_0, m_pdb_maxunavail_2,
+    m_podaffinity_empty_selector, m_podaffinity_matchlabelkeys, m_pdb_both_set, m_pdb_frac_pct,
 ]
 
 

--- a/hack/verify_ha_topology_selftest.py
+++ b/hack/verify_ha_topology_selftest.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Negative-control self-test for verify_ha_topology.check (#230).
+
+Usage: verify_ha_topology_selftest.py <known-good-render.yaml>
+
+Given the SAME known-good render the positive check runs on, apply each drift we care about and assert the
+checker REJECTS every one — and still ACCEPTS the unmutated base. A refactor that silently broke a guard (so
+real drift would ship green) fails HERE instead. This is the negative-control layer that was previously only
+run by hand; run it in CI right after the positive check.
+"""
+import copy
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import yaml  # noqa: E402  (after sys.path tweak)
+
+from verify_ha_topology import check  # noqa: E402
+
+
+def _dep(docs):
+    return next(d for d in docs if d.get('kind') == 'Deployment')
+
+
+def _pdb(docs):
+    return next(d for d in docs if d.get('kind') == 'PodDisruptionBudget')
+
+
+def _pref(docs):
+    return _dep(docs)['spec']['template']['spec']['affinity']['podAntiAffinity'][
+        'preferredDuringSchedulingIgnoredDuringExecution']
+
+
+def m_replicas(d):
+    _dep(d)['spec']['replicas'] = 1
+
+
+def m_pdb_min(d):
+    _pdb(d)['spec']['minAvailable'] = 2
+
+
+def m_pdb_selector(d):
+    _pdb(d)['spec']['selector']['matchLabels'] = {'app': 'does-not-exist'}
+
+
+def m_recreate(d):
+    _dep(d)['spec']['strategy'] = {'type': 'Recreate'}
+
+
+def m_maxunavail_int(d):
+    _dep(d)['spec']['strategy'] = {'type': 'RollingUpdate', 'rollingUpdate': {'maxUnavailable': 1}}
+
+
+def m_maxunavail_pct(d):
+    _dep(d)['spec']['strategy'] = {'type': 'RollingUpdate', 'rollingUpdate': {'maxUnavailable': '50%'}}
+
+
+def m_aff_hard(d):
+    _dep(d)['spec']['template']['spec']['affinity']['podAntiAffinity'][
+        'requiredDuringSchedulingIgnoredDuringExecution'] = [{
+            'topologyKey': 'kubernetes.io/hostname',
+            'labelSelector': {'matchLabels': {'control-plane': 'controller-manager'}},
+        }]
+
+
+def m_aff_weight0(d):
+    for p in _pref(d):
+        p['weight'] = 0
+
+
+def m_aff_selector(d):
+    _pref(d)[0]['podAffinityTerm']['labelSelector']['matchLabels'] = {'app': 'does-not-exist'}
+
+
+def m_aff_topology(d):
+    _pref(d)[0]['podAffinityTerm']['topologyKey'] = 'topology.kubernetes.io/zone'
+
+
+def m_pdb_matchexpr(d):
+    # A non-matching matchExpressions ANDed onto a good matchLabels makes the selector select NOTHING —
+    # an OR reading of the selector would wrongly accept this.
+    _pdb(d)['spec']['selector'].setdefault('matchExpressions', []).append(
+        {'key': 'nonexistent', 'operator': 'Exists'})
+
+
+def m_aff_matchexpr(d):
+    _pref(d)[0]['podAffinityTerm']['labelSelector'].setdefault('matchExpressions', []).append(
+        {'key': 'nonexistent', 'operator': 'Exists'})
+
+
+# Each mutation must be REJECTED by check(); m_aff_weight0 also proves the weight=0 (no-op) case is caught.
+CASES = [
+    m_replicas, m_pdb_min, m_pdb_selector, m_recreate, m_maxunavail_int, m_maxunavail_pct,
+    m_aff_hard, m_aff_weight0, m_aff_selector, m_aff_topology, m_pdb_matchexpr, m_aff_matchexpr,
+]
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: verify_ha_topology_selftest.py <known-good-render.yaml>", file=sys.stderr)
+        return 2
+    with open(argv[1]) as f:
+        base = [d for d in yaml.safe_load_all(f) if d]
+
+    fails = []
+    # The unmutated base must PASS — guards against a checker that rejects everything (which would make the
+    # negative controls below trivially "pass").
+    if check(copy.deepcopy(base)):
+        fails.append("BASE render REJECTED — the checker rejects even a good render")
+    for fn in CASES:
+        docs = copy.deepcopy(base)
+        fn(docs)
+        if not check(docs):
+            fails.append(f"{fn.__name__}: a broken render was ACCEPTED (the guard is missing/ineffective)")
+
+    if fails:
+        print("SELF-TEST FAILED:\n  - " + "\n  - ".join(fails))
+        return 1
+    print(f"HA topology checker self-test OK ({len(CASES)} negative controls rejected, base accepted)")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hack/verify_ha_topology_selftest.py
+++ b/hack/verify_ha_topology_selftest.py
@@ -89,10 +89,121 @@ def m_aff_matchexpr(d):
         {'key': 'nonexistent', 'operator': 'Exists'})
 
 
+def m_pdb_broad(d):
+    # Over-broad: still SELECTS the manager (shared app label) but drops the distinguishing control-plane
+    # label, so it could also select non-manager pods. A manager-only namespace cannot expose this at runtime.
+    _pdb(d)['spec']['selector']['matchLabels'] = {'app.kubernetes.io/name': 'ntn-operators'}
+
+
+def m_aff_broad(d):
+    _pref(d)[0]['podAffinityTerm']['labelSelector']['matchLabels'] = {'app.kubernetes.io/name': 'ntn-operators'}
+
+
+def m_maxsurge0(d):
+    # With the default maxUnavailable (0 over 2 replicas), a 0 surge deadlocks the rollout.
+    _dep(d)['spec']['strategy'] = {'type': 'RollingUpdate', 'rollingUpdate': {'maxSurge': 0}}
+
+
+def m_pod_identity(d):
+    # Remove the manager identity label from the pod template — the anchor the specificity checks rely on.
+    _dep(d)['spec']['template']['metadata']['labels'].pop('control-plane', None)
+
+
+def m_pdb_narrower(d):
+    # Narrower than the Deployment selector (adds an extra constraint) — no longer protects exactly the
+    # workload. Over-broad is caught by m_pdb_broad; this proves the PDB==Deployment check catches under-broad.
+    _pdb(d)['spec']['selector']['matchLabels']['pod-template-hash'] = 'deadbeef'
+
+
+def m_aff_namespaces(d):
+    # Re-scopes the spread to a DIFFERENT namespace — it no longer spreads the manager replicas.
+    _pref(d)[0]['podAffinityTerm']['namespaces'] = ['definitely-not-ntn-system']
+
+
+def m_aff_nsselector(d):
+    # namespaceSelector:{} means ALL namespaces, widening the scored pod set beyond the manager's namespace.
+    _pref(d)[0]['podAffinityTerm']['namespaceSelector'] = {}
+
+
+def m_aff_matchlabelkeys(d):
+    # matchLabelKeys changes the effective pod set; the checker does not model it, so it must fail closed.
+    _pref(d)[0]['podAffinityTerm']['matchLabelKeys'] = ['pod-template-hash']
+
+
+def m_aff_invalid_op(d):
+    # An invalid operator alongside a good matchLabels — the fail-open bug would accept this.
+    _pref(d)[0]['podAffinityTerm']['labelSelector'].setdefault('matchExpressions', []).append(
+        {'key': 'control-plane', 'operator': 'Superset', 'values': ['x']})
+
+
+def m_aff_in_empty(d):
+    _pref(d)[0]['podAffinityTerm']['labelSelector'].setdefault('matchExpressions', []).append(
+        {'key': 'control-plane', 'operator': 'In', 'values': []})
+
+
+def m_aff_notin_empty(d):
+    # NotIn with empty values matches EVERYTHING — over-broad; must be rejected, not treated as a match.
+    _pref(d)[0]['podAffinityTerm']['labelSelector'].setdefault('matchExpressions', []).append(
+        {'key': 'anything', 'operator': 'NotIn', 'values': []})
+
+
+# --- co-location (F1): fields that pin BOTH replicas to one node, defeating the anti-affinity spread ---
+def m_nodename(d):
+    _dep(d)['spec']['template']['spec']['nodeName'] = 'node-a'
+
+
+def m_nodeselector_host(d):
+    _dep(d)['spec']['template']['spec']['nodeSelector'] = {'kubernetes.io/hostname': 'node-a'}
+
+
+def m_nodeaffinity_host(d):
+    _dep(d)['spec']['template']['spec'].setdefault('affinity', {})['nodeAffinity'] = {
+        'requiredDuringSchedulingIgnoredDuringExecution': {
+            'nodeSelectorTerms': [{'matchExpressions': [
+                {'key': 'kubernetes.io/hostname', 'operator': 'In', 'values': ['node-a']}]}],
+        },
+    }
+
+
+def m_podaffinity_colocate(d):
+    _dep(d)['spec']['template']['spec'].setdefault('affinity', {})['podAffinity'] = {
+        'requiredDuringSchedulingIgnoredDuringExecution': [{
+            'topologyKey': 'kubernetes.io/hostname',
+            'labelSelector': {'matchLabels': {'control-plane': 'controller-manager'}},
+        }],
+    }
+
+
+def m_paused(d):
+    _dep(d)['spec']['paused'] = True  # a paused Deployment never rolls -> the rollout gate can't fire
+
+
+def m_weight_str(d):
+    for p in _pref(d):
+        p['weight'] = '100'  # a string weight must fail closed (no effective term), not crash the checker
+
+
+def m_pdb_maxunavail_0(d):
+    # maxUnavailable:0 guarantees 2 available -> blocks EVERY voluntary disruption (over-strict, wrong).
+    _pdb(d)['spec'].pop('minAvailable', None)
+    _pdb(d)['spec']['maxUnavailable'] = 0
+
+
+def m_pdb_maxunavail_2(d):
+    # maxUnavailable:2 guarantees 0 available -> the PDB protects nothing.
+    _pdb(d)['spec'].pop('minAvailable', None)
+    _pdb(d)['spec']['maxUnavailable'] = 2
+
+
 # Each mutation must be REJECTED by check(); m_aff_weight0 also proves the weight=0 (no-op) case is caught.
 CASES = [
     m_replicas, m_pdb_min, m_pdb_selector, m_recreate, m_maxunavail_int, m_maxunavail_pct,
     m_aff_hard, m_aff_weight0, m_aff_selector, m_aff_topology, m_pdb_matchexpr, m_aff_matchexpr,
+    m_pdb_broad, m_aff_broad, m_maxsurge0, m_pod_identity,
+    m_pdb_narrower, m_aff_namespaces, m_aff_nsselector, m_aff_matchlabelkeys,
+    m_aff_invalid_op, m_aff_in_empty, m_aff_notin_empty,
+    m_nodename, m_nodeselector_host, m_nodeaffinity_host, m_podaffinity_colocate,
+    m_paused, m_weight_str, m_pdb_maxunavail_0, m_pdb_maxunavail_2,
 ]
 
 

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -538,5 +539,126 @@ func TestEphemerisPushShouldRequeue(t *testing.T) {
 		if !ephemerisPushShouldRequeue(reason) {
 			t.Errorf("%s SHOULD requeue (transient)", reason)
 		}
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_CrashBeforeStatusPersists_RepushIsIdempotent (#230 item 6): if the leader
+// pushes to the gNB (PushRuntimeUpdate succeeds) but crashes BEFORE its status write persists the push
+// marker, the new leader — reading a status without the marker — re-pushes. isEphemerisPushUpToDate keys the
+// dedup on the persisted EphemerisPushed condition Message (the epoch-derived marker), so a marker that never
+// persisted means the re-push happens; the SAFETY is that it carries the SAME epoch — a level re-assert the
+// gNB dedups by epoch, not a harmful duplicate (no delta, not a satSwitch). We simulate the crash by never
+// writing the marker back to cc.Status between two pushEphemerisUpdateIfNeeded calls, then show the dedup
+// closes once the marker finally persists.
+func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatusPersists_RepushIsIdempotent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	futureMs := time.Now().Add(time.Hour).UnixMilli()
+	eph := ephWithPropagatedState(futureMs)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+
+	// Push #1: the leader pushes the runtime ephemeris.
+	pushed1, marker1, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil || !pushed1 {
+		t.Fatalf("push #1: pushed=%v err=%v", pushed1, err)
+	}
+	if mock.RuntimeCalls != 1 {
+		t.Fatalf("push #1 must call the provider once; got %d", mock.RuntimeCalls)
+	}
+	epoch1 := mock.LastRuntime.EpochUnixMs
+
+	// CRASH before status persists: the marker is NOT written to cc.Status, so isEphemerisPushUpToDate stays
+	// false. The new leader reconciles the same (unchanged) state.
+	pushed2, marker2, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil || !pushed2 {
+		t.Fatalf("re-push #2: pushed=%v err=%v", pushed2, err)
+	}
+	if mock.RuntimeCalls != 2 {
+		t.Fatalf("an unpersisted marker must trigger a re-push; got %d provider calls", mock.RuntimeCalls)
+	}
+	epoch2 := mock.LastRuntime.EpochUnixMs
+
+	// Safety: the re-push is an idempotent level re-assert — SAME epoch-derived marker, SAME epoch — so the
+	// gNB dedups it by epoch rather than acting on a harmful duplicate.
+	if marker1 != marker2 {
+		t.Fatalf("re-push marker must be identical (epoch-keyed idempotent); got %q then %q", marker1, marker2)
+	}
+	if epoch1 != futureMs || epoch2 != futureMs {
+		t.Fatalf("both pushes must carry the same propagated epoch %d; got %d then %d", futureMs, epoch1, epoch2)
+	}
+
+	// Once the marker DOES persist (the new leader completes its status write), a further reconcile must NOT
+	// re-push — the epoch-keyed dedup closes.
+	meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionEphemerisPushed, Status: metav1.ConditionTrue,
+		Reason: "Pushed", Message: marker2, ObservedGeneration: cc.Generation,
+	})
+	pushed3, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil {
+		t.Fatalf("push #3: %v", err)
+	}
+	if pushed3 || mock.RuntimeCalls != 2 {
+		t.Fatalf("once the marker persists the dedup must close (no re-push); pushed=%v calls=%d", pushed3, mock.RuntimeCalls)
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_CrashBeforeStatus_PendingSatSwitch_IsIdempotent (#230 item 6, satSwitch
+// path): a pending SatSwitchWithResync — the most state-changing runtime payload, and the only surface
+// carrying k_mac (#52) — rides on every runtime push. If the leader crashes after PushRuntimeUpdate but
+// before persisting the marker, the new leader re-pushes with the SAME pending switch at the SAME epoch. This
+// must be an EXACT idempotent duplicate (identical switch incl. k_mac, same epoch-keyed marker) that OCUDU
+// dedups by epoch — NOT a new/mutated delta. This complements the ephemeris-only crash-dedup test above,
+// which only excused the satSwitch case in a comment.
+func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatus_PendingSatSwitch_IsIdempotent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+	cc := ccWithRemoteControl()
+	kmac := 42
+	cc.Spec.NTN.SatSwitchWithResync = &ntnv1alpha1.SatSwitchWithResync{
+		NTNConfig: ntnv1alpha1.SatSwitchNTNConfig{
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 7000000, PosY: 1000000, PosZ: 2000000},
+			KMac:          &kmac,
+		},
+		EpochUnixMs: 1893456000000,
+	}
+
+	// Push #1: the leader pushes ephemeris + the pending satSwitch.
+	pushed1, marker1, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil || !pushed1 || mock.RuntimeCalls != 1 {
+		t.Fatalf("push #1: pushed=%v err=%v calls=%d", pushed1, err, mock.RuntimeCalls)
+	}
+	if mock.LastRuntime.SatSwitch == nil {
+		t.Fatal("push #1 must carry the pending satSwitch")
+	}
+	sw1 := *mock.LastRuntime.SatSwitch
+
+	// CRASH before status persists → the new leader re-pushes the same unchanged state.
+	pushed2, marker2, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil || !pushed2 || mock.RuntimeCalls != 2 {
+		t.Fatalf("re-push #2: pushed=%v err=%v calls=%d", pushed2, err, mock.RuntimeCalls)
+	}
+	if mock.LastRuntime.SatSwitch == nil {
+		t.Fatal("re-push #2 must re-carry the pending satSwitch")
+	}
+	sw2 := *mock.LastRuntime.SatSwitch
+
+	// The re-push is an EXACT idempotent duplicate: same epoch-keyed marker and the identical satSwitch (same
+	// k_mac, target ephemeris, epoch) — a repeated same-epoch frame OCUDU dedups, not a new delta.
+	if marker1 != marker2 {
+		t.Fatalf("re-push marker must be identical; got %q then %q", marker1, marker2)
+	}
+	if !reflect.DeepEqual(sw1, sw2) {
+		t.Fatalf("re-push satSwitch must be an identical duplicate; got %+v then %+v", sw1, sw2)
 	}
 }

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -546,10 +546,10 @@ func TestEphemerisPushShouldRequeue(t *testing.T) {
 // pushes to the gNB (PushRuntimeUpdate succeeds) but crashes BEFORE its status write persists the push
 // marker, the new leader — reading a status without the marker — re-pushes. isEphemerisPushUpToDate keys the
 // dedup on the persisted EphemerisPushed condition Message (the epoch-derived marker), so a marker that never
-// persisted means the re-push happens; the SAFETY is that it carries the SAME epoch — a level re-assert the
-// gNB dedups by epoch, not a harmful duplicate (no delta, not a satSwitch). We simulate the crash by never
-// writing the marker back to cc.Status between two pushEphemerisUpdateIfNeeded calls, then show the dedup
-// closes once the marker finally persists.
+// persisted means the re-push happens; the SAFETY is that it re-emits a byte-identical, SAME-epoch frame (a
+// level re-assert, no delta) — de-duplicating a repeated same-epoch push is the gNB/OCUDU runtime's job, not
+// something this unit test itself proves. We simulate the crash by never writing the marker back to cc.Status
+// between two pushEphemerisUpdateIfNeeded calls, then show the dedup closes once the marker finally persists.
 func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatusPersists_RepushIsIdempotent(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
@@ -583,13 +583,26 @@ func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatusPersists_RepushIsIdempoten
 	}
 	epoch2 := mock.LastRuntime.EpochUnixMs
 
-	// Safety: the re-push is an idempotent level re-assert — SAME epoch-derived marker, SAME epoch — so the
-	// gNB dedups it by epoch rather than acting on a harmful duplicate.
+	// Safety: the re-push is an idempotent level re-assert — SAME epoch-derived marker, SAME epoch, and (below)
+	// a byte-identical whole frame. Whether the downstream gNB acts on or dedups the repeated same-epoch push is
+	// the runtime's responsibility, not asserted here.
 	if marker1 != marker2 {
 		t.Fatalf("re-push marker must be identical (epoch-keyed idempotent); got %q then %q", marker1, marker2)
 	}
 	if epoch1 != futureMs || epoch2 != futureMs {
 		t.Fatalf("both pushes must carry the same propagated epoch %d; got %d then %d", futureMs, epoch1, epoch2)
+	}
+	// Stronger than marker+epoch: the WHOLE runtime frame (cell, epoch, UL-sync validity, ephemeris payload,
+	// satSwitch) AND the resolved target must be identical across the two pushes. RuntimeHistory/TargetHistory
+	// hold a DEEP COPY of each call, so this compares the actual frames, not an aliased view of the latest one.
+	if len(mock.RuntimeHistory) != 2 || len(mock.TargetHistory) != 2 {
+		t.Fatalf("expected 2 recorded runtime frames + targets; got %d / %d", len(mock.RuntimeHistory), len(mock.TargetHistory))
+	}
+	if !reflect.DeepEqual(mock.RuntimeHistory[0], mock.RuntimeHistory[1]) {
+		t.Fatalf("re-push runtime frame must be byte-identical; got %+v then %+v", mock.RuntimeHistory[0], mock.RuntimeHistory[1])
+	}
+	if !reflect.DeepEqual(mock.TargetHistory[0], mock.TargetHistory[1]) {
+		t.Fatalf("re-push target must be identical; got %+v then %+v", mock.TargetHistory[0], mock.TargetHistory[1])
 	}
 
 	// Once the marker DOES persist (the new leader completes its status write), a further reconcile must NOT
@@ -611,9 +624,10 @@ func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatusPersists_RepushIsIdempoten
 // path): a pending SatSwitchWithResync — the most state-changing runtime payload, and the only surface
 // carrying k_mac (#52) — rides on every runtime push. If the leader crashes after PushRuntimeUpdate but
 // before persisting the marker, the new leader re-pushes with the SAME pending switch at the SAME epoch. This
-// must be an EXACT idempotent duplicate (identical switch incl. k_mac, same epoch-keyed marker) that OCUDU
-// dedups by epoch — NOT a new/mutated delta. This complements the ephemeris-only crash-dedup test above,
-// which only excused the satSwitch case in a comment.
+// must be an EXACT idempotent duplicate (identical switch incl. k_mac, same epoch-keyed marker) — a repeated
+// same-epoch frame, NOT a new/mutated delta (whether OCUDU dedups it by epoch is the runtime's concern, not
+// asserted here). This complements the ephemeris-only crash-dedup test above, which only excused the satSwitch
+// case in a comment.
 func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatus_PendingSatSwitch_IsIdempotent(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
@@ -653,12 +667,20 @@ func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatus_PendingSatSwitch_IsIdempo
 	}
 	sw2 := *mock.LastRuntime.SatSwitch
 
-	// The re-push is an EXACT idempotent duplicate: same epoch-keyed marker and the identical satSwitch (same
-	// k_mac, target ephemeris, epoch) — a repeated same-epoch frame OCUDU dedups, not a new delta.
+	// The re-push is an EXACT idempotent duplicate: same epoch-keyed marker, the identical satSwitch (same
+	// k_mac, target ephemeris, epoch), and a byte-identical whole frame — a repeated same-epoch push, not a new
+	// delta. (Whether OCUDU dedups it by epoch is the runtime's concern, not asserted here.)
 	if marker1 != marker2 {
 		t.Fatalf("re-push marker must be identical; got %q then %q", marker1, marker2)
 	}
 	if !reflect.DeepEqual(sw1, sw2) {
 		t.Fatalf("re-push satSwitch must be an identical duplicate; got %+v then %+v", sw1, sw2)
+	}
+	if len(mock.RuntimeHistory) != 2 {
+		t.Fatalf("expected 2 recorded runtime frames; got %d", len(mock.RuntimeHistory))
+	}
+	if !reflect.DeepEqual(mock.RuntimeHistory[0], mock.RuntimeHistory[1]) {
+		t.Fatalf("re-push runtime frame (incl. satSwitch) must be byte-identical; got %+v then %+v",
+			mock.RuntimeHistory[0], mock.RuntimeHistory[1])
 	}
 }

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -46,6 +46,11 @@ type MockProvider struct {
 	LastRuntime    *RuntimeUpdate
 	LastTarget     *ResolvedRemoteControl
 	StatusValue    *ntnv1alpha1.NTNCellConfigStatus
+	// RuntimeHistory / TargetHistory record a DEEP COPY of every PushRuntimeUpdate call's frame (not just the
+	// last pointer), so a test can compare successive pushes byte-for-byte — e.g. proving a crash re-push
+	// re-emits an identical same-epoch payload rather than a mutated/aliased view of the latest one.
+	RuntimeHistory []RuntimeUpdate
+	TargetHistory  []ResolvedRemoteControl
 }
 
 func (m *MockProvider) ApplyCellConfig(
@@ -84,6 +89,20 @@ func (m *MockProvider) PushRuntimeUpdate(_ context.Context, target ResolvedRemot
 	m.RuntimeCalls++
 	m.LastRuntime = &update
 	m.LastTarget = &target
+	// Deep-copy the frame into the history so a later mutation/aliasing of the caller's pointers cannot
+	// retroactively change what we recorded for THIS call.
+	hist := update
+	if update.SatSwitch != nil {
+		hist.SatSwitch = update.SatSwitch.DeepCopy()
+	}
+	if update.Ephemeris.ECEF != nil {
+		hist.Ephemeris.ECEF = update.Ephemeris.ECEF.DeepCopy()
+	}
+	if update.Ephemeris.Orbital != nil {
+		hist.Ephemeris.Orbital = update.Ephemeris.Orbital.DeepCopy()
+	}
+	m.RuntimeHistory = append(m.RuntimeHistory, hist)
+	m.TargetHistory = append(m.TargetHistory, target)
 	return m.RuntimeErr
 }
 

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -169,7 +169,15 @@ func (e *haEnv) leaseDuration(t *testing.T) time.Duration {
 	if l.Spec.LeaseDurationSeconds == nil {
 		t.Fatalf("lease %s has no leaseDurationSeconds", haLeaseName)
 	}
-	return time.Duration(*l.Spec.LeaseDurationSeconds) * time.Second
+	ld := time.Duration(*l.Spec.LeaseDurationSeconds) * time.Second
+	// Pin the ABSOLUTE HA failover budget. The RTO bounds derived from ld are self-calibrating (relative to
+	// it), so they would silently scale with a leaderLeaseDuration regression — 15s -> 120s makes an 8x-slower
+	// handoff still "pass". Assert the deployed lease stays within the stated sub-15s active-passive budget
+	// (docs/high-availability.md; the chart-invariants CI step pins the source constant too).
+	if ld > 15*time.Second {
+		t.Fatalf("deployed lease duration %s exceeds the pinned 15s HA failover budget", ld)
+	}
+	return ld
 }
 
 // holderPodBase maps a controller-runtime holderIdentity ("<pod>_<uuid>") to its owning pod name.

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -39,15 +39,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
-	// haLeaseName must equal LeaderElectionID in cmd/main.go.
-	haLeaseName = "b1076767.operators.dev"
-	// haLeaseDuration must track leaderLeaseDuration in cmd/main.go — an ungraceful (SIGKILL) failover
-	// waits out at most this before the standby can steal the lease.
-	haLeaseDuration = 15 * time.Second
+	// haLeaseName must equal LeaderElectionID in cmd/main.go. If it drifts, leaseHolder() fails loudly
+	// (Lease not found) rather than passing wrongly. The lease DURATION is NOT hard-coded here — it is read
+	// from the live Lease (leaseDuration()) so the RTO bounds track the actual running config, not a copy.
+	haLeaseName     = "b1076767.operators.dev"
 	managerSelector = "control-plane=controller-manager"
 	haReplicas      = 2 // active-passive: one active reconciler + one warm standby
 	crdAPIGroup     = "ntn.operators.dev"
@@ -70,6 +70,13 @@ type haEnv struct {
 
 func newHAEnv(t *testing.T) *haEnv {
 	t.Helper()
+	// Hard opt-in: this suite is DESTRUCTIVE (cordons every node, deletes/evicts manager pods, rewrites a
+	// cluster-scoped ClusterRole). Refuse to run unless the caller explicitly acknowledges that — so a stray
+	// `make test-e2e-ha` against the wrong kubecontext cannot cordon a production fleet or break a live operator.
+	if os.Getenv("HA_ALLOW_DESTRUCTIVE") != "1" {
+		t.Skip("HA suite is DESTRUCTIVE (cordons every node, evicts manager pods, mutates cluster RBAC); " +
+			"set HA_ALLOW_DESTRUCTIVE=1 and point KUBECONFIG at a disposable Kind cluster to run it")
+	}
 	cfg, err := ctrlcfg.GetConfig()
 	if err != nil {
 		t.Fatalf("load kube config (is KUBECONFIG set to the Kind cluster?): %v", err)
@@ -82,7 +89,35 @@ func newHAEnv(t *testing.T) *haEnv {
 	if err != nil {
 		t.Fatalf("dynamic client: %v", err)
 	}
-	return &haEnv{cs: cs, dyn: dyn, ns: haNamespace(), ctx: context.Background()}
+	e := &haEnv{cs: cs, dyn: dyn, ns: haNamespace(), ctx: context.Background()}
+	e.requireDisposableCluster(t)
+	return e
+}
+
+// requireDisposableCluster refuses to run unless EVERY node is a Kind node (providerID "kind://…"). The PDB
+// test cordons all nodes and the cache-sync test rewrites a cluster-scoped ClusterRole, so a wrong kubecontext
+// could cordon a production fleet or break a live operator's RBAC. Set HA_EXPECT_KIND=0 to bypass ONLY when
+// you are certain the target is disposable (e.g. a non-Kind ephemeral test cluster).
+func (e *haEnv) requireDisposableCluster(t *testing.T) {
+	t.Helper()
+	if os.Getenv("HA_EXPECT_KIND") == "0" {
+		t.Log("HA_EXPECT_KIND=0 — skipping the Kind safety check; caller asserts the cluster is disposable")
+		return
+	}
+	nodes, err := e.cs.CoreV1().Nodes().List(e.ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list nodes for the disposable-cluster safety check: %v", err)
+	}
+	if len(nodes.Items) == 0 {
+		t.Fatal("no nodes found — refusing to run the destructive HA suite")
+	}
+	for i := range nodes.Items {
+		if pid := nodes.Items[i].Spec.ProviderID; !strings.HasPrefix(pid, "kind://") {
+			t.Fatalf("node %s is not a Kind node (providerID=%q) — refusing to cordon/mutate a non-disposable "+
+				"cluster; set HA_EXPECT_KIND=0 only if you are certain the target is disposable",
+				nodes.Items[i].Name, pid)
+		}
+	}
 }
 
 // eventually polls cond until it returns (true, _) or timeout; on timeout it fails with the last message.
@@ -113,6 +148,20 @@ func (e *haEnv) leaseHolder() (string, error) {
 		return "", nil
 	}
 	return *l.Spec.HolderIdentity, nil
+}
+
+// leaseDuration reads the deployed leader-election Lease's configured duration, so RTO bounds track the
+// ACTUAL running config (cmd/main.go's leaderLeaseDuration) instead of a hard-coded copy that could drift.
+func (e *haEnv) leaseDuration(t *testing.T) time.Duration {
+	t.Helper()
+	l, err := e.cs.CoordinationV1().Leases(e.ns).Get(e.ctx, haLeaseName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get lease %s for its duration: %v", haLeaseName, err)
+	}
+	if l.Spec.LeaseDurationSeconds == nil {
+		t.Fatalf("lease %s has no leaseDurationSeconds", haLeaseName)
+	}
+	return time.Duration(*l.Spec.LeaseDurationSeconds) * time.Second
 }
 
 // holderPodBase maps a controller-runtime holderIdentity ("<pod>_<uuid>") to its owning pod name.
@@ -251,6 +300,17 @@ func TestHAGracefulFailover(t *testing.T) {
 	e.assertLeaderReconciles(t, "ha-graceful-probe")
 }
 
+// ungracefulSkipOrFail skips the ungraceful test locally, but FAILS it under HA_REQUIRE_UNGRACEFUL=1 — a CI
+// job that claims to exercise ungraceful (SIGKILL) failover must actually run it, never skip-then-green when
+// docker/crictl/Kind integration regresses.
+func ungracefulSkipOrFail(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if os.Getenv("HA_REQUIRE_UNGRACEFUL") == "1" {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
 // TestHAUngracefulFailover (#230 item 3): an UNGRACEFUL leader loss (the container SIGKILLed on the node, so
 // the process never runs the lease-release defer) must still fail over — the standby waits out LeaseDuration
 // — and the RTO is recorded. A plain pod delete cannot exercise this: the manager image is distroless, so a
@@ -261,35 +321,53 @@ func TestHAGracefulFailover(t *testing.T) {
 func TestHAUngracefulFailover(t *testing.T) {
 	e := newHAEnv(t)
 	e.waitReadyManagerPods(t)
-	holder0 := e.waitLeaseHolder(t)
-	leader0 := holderPodBase(holder0)
-
-	pod, err := e.cs.CoreV1().Pods(e.ns).Get(e.ctx, leader0, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get leader pod: %v", err)
-	}
-	node := pod.Spec.NodeName
-	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].ContainerID == "" {
-		t.Fatalf("leader pod %s has no running container id", leader0)
-	}
-	cid := strings.TrimPrefix(pod.Status.ContainerStatuses[0].ContainerID, "containerd://")
-	t.Logf("initial leader pod=%s node=%s container=%.12s", leader0, node, cid)
+	ld := e.leaseDuration(t) // self-calibrating: RTO bounds derive from the live Lease, not a hard-coded copy
 
 	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skip("docker not available: the ungraceful (node-level SIGKILL) test needs a Kind cluster")
+		ungracefulSkipOrFail(t, "docker not available: the ungraceful (node-level SIGKILL) test needs a Kind cluster")
 	}
-	// Leadership can legitimately move in the gap while we resolved the pod/container id above; if it has,
-	// the container we're about to kill is no longer the leader and the RTO would be meaningless — skip.
-	if h, _ := e.leaseHolder(); h != holder0 {
-		t.Skipf("leadership moved before the kill (%s -> %s); nothing to measure", holder0, h)
+
+	// Resolve the CURRENT leader and SIGKILL its container, RETRYING if leadership moves during resolution — a
+	// stale target would make the RTO meaningless. Leadership is stable in steady state, so attempt 0 almost
+	// always wins; we retry rather than skip so a genuine environment regression cannot hide behind a skip. A
+	// missing docker or a failed crictl is an environment fault, not a race, so it goes through
+	// ungracefulSkipOrFail (fatal under HA_REQUIRE_UNGRACEFUL, skip otherwise).
+	var holder0 string
+	var start time.Time
+	killed := false
+	for attempt := 0; attempt < 3 && !killed; attempt++ {
+		holder0 = e.waitLeaseHolder(t)
+		leader0 := holderPodBase(holder0)
+		pod, err := e.cs.CoreV1().Pods(e.ns).Get(e.ctx, leader0, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("attempt %d: get leader pod %s: %v — re-resolving", attempt, leader0, err)
+			continue
+		}
+		if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].ContainerID == "" {
+			t.Logf("attempt %d: leader pod %s has no running container id — re-resolving", attempt, leader0)
+			continue
+		}
+		node := pod.Spec.NodeName
+		cid := strings.TrimPrefix(pod.Status.ContainerStatuses[0].ContainerID, "containerd://")
+		// Re-confirm this is STILL the leader immediately before the kill; if it moved during resolution, retry.
+		if h, _ := e.leaseHolder(); h != holder0 {
+			t.Logf("attempt %d: leadership moved during resolution (%s -> %s) — re-resolving", attempt, holder0, h)
+			continue
+		}
+		t.Logf("attempt %d: SIGKILL leader pod=%s node=%s container=%.12s", attempt, leader0, node, cid)
+		// crictl stop --timeout 0 SIGKILLs the container immediately — no SIGTERM, so no lease release.
+		kill := exec.Command("docker", "exec", node, "crictl", "stop", "--timeout", "0", cid)
+		if out, err := kill.CombinedOutput(); err != nil {
+			ungracefulSkipOrFail(t, "could not SIGKILL the container via docker/crictl (non-Kind cluster?): %v: %s", err, out)
+		}
+		start = time.Now() // measure the RTO from the fault, NOT including the docker-exec setup
+		killed = true
 	}
-	// crictl stop --timeout 0 SIGKILLs the container immediately — no SIGTERM, so no lease release.
-	kill := exec.Command("docker", "exec", node, "crictl", "stop", "--timeout", "0", cid)
-	if out, err := kill.CombinedOutput(); err != nil {
-		t.Skipf("could not SIGKILL the container via docker/crictl (non-Kind cluster?): %v: %s", err, out)
+	if !killed {
+		ungracefulSkipOrFail(t, "leadership kept moving before the kill across 3 attempts; cannot measure RTO")
 	}
-	start := time.Now() // measure the RTO from the fault, NOT including the docker-exec setup
-	eventually(t, haLeaseDuration+30*time.Second, time.Second, "ungraceful failover", func() (bool, string) {
+
+	eventually(t, ld+30*time.Second, time.Second, "ungraceful failover", func() (bool, string) {
 		h, err := e.leaseHolder()
 		if err != nil {
 			return false, err.Error()
@@ -304,18 +382,18 @@ func TestHAUngracefulFailover(t *testing.T) {
 		return true, ""
 	})
 	rto := time.Since(start)
-	t.Logf("ungraceful (SIGKILL) failover RTO=%s (LeaseDuration=%s)", rto.Round(time.Millisecond), haLeaseDuration)
+	t.Logf("ungraceful (SIGKILL) failover RTO=%s (LeaseDuration=%s)", rto.Round(time.Millisecond), ld)
 
 	// The lease renews every few seconds, so the standby cannot steal it until ~LeaseDuration after the last
-	// renew. A graceful release would be ~1 s; require the RTO to be clearly in the lease-timeout regime,
-	// proving no release happened, while bounding the top for a slow CI.
-	if rto < 8*time.Second {
-		t.Fatalf("ungraceful RTO %s too fast — the lease was released, not the LeaseDuration path", rto)
+	// renew. A graceful release would be ~1 s; require the RTO to be clearly in the lease-timeout regime
+	// (>= half the lease duration), proving no release happened, while bounding the top for a slow CI.
+	if rto < ld/2 {
+		t.Fatalf("ungraceful RTO %s too fast (<LeaseDuration/2=%s) — released, not the lease-timeout path", rto, ld/2)
 	}
 	// Upper bound kept below the eventually window (LeaseDuration+30s) so a legitimately-slow-but-bounded
 	// failover trips THIS clear message rather than the generic eventually timeout.
-	if rto > haLeaseDuration+20*time.Second {
-		t.Fatalf("ungraceful failover RTO %s exceeded LeaseDuration+margin", rto)
+	if rto > ld+20*time.Second {
+		t.Fatalf("ungraceful failover RTO %s exceeded LeaseDuration+margin (%s)", rto, ld+20*time.Second)
 	}
 	e.waitReadyManagerPods(t)
 }
@@ -346,14 +424,27 @@ func TestHAPDBEviction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list nodes: %v", err)
 	}
-	for i := range nodes.Items {
-		e.setCordon(t, nodes.Items[i].Name, true)
-	}
+	// Register the uncordon cleanup BEFORE cordoning, so a mid-loop cordon failure (Fatal) still releases the
+	// nodes already cordoned. A cordon that SILENTLY failed would let the replacement become Ready and the
+	// second eviction be legitimately allowed — which we would then misreport as "PDB unprotected" — so a
+	// SETUP cordon failure is Fatal; the cleanup uncordon is best-effort but reported.
 	t.Cleanup(func() {
+		var stuck []string
 		for i := range nodes.Items {
-			e.setCordon(t, nodes.Items[i].Name, false)
+			if err := e.setCordon(nodes.Items[i].Name, false); err != nil {
+				stuck = append(stuck, nodes.Items[i].Name)
+				t.Logf("cleanup: uncordon %s failed: %v", nodes.Items[i].Name, err)
+			}
+		}
+		if len(stuck) > 0 {
+			t.Errorf("CRITICAL: cleanup left node(s) cordoned %v — the cluster may not schedule new pods", stuck)
 		}
 	})
+	for i := range nodes.Items {
+		if err := e.setCordon(nodes.Items[i].Name, true); err != nil {
+			t.Fatalf("setup: cordon node %s failed: %v", nodes.Items[i].Name, err)
+		}
+	}
 
 	evict := func(pod string) error {
 		return e.cs.PolicyV1().Evictions(e.ns).Evict(e.ctx, &policyv1.Eviction{
@@ -393,13 +484,10 @@ func TestHAPDBEviction(t *testing.T) {
 	t.Logf("second eviction of %s correctly REFUSED by the PDB", ready[1])
 }
 
-func (e *haEnv) setCordon(t *testing.T, node string, unschedulable bool) {
-	t.Helper()
+func (e *haEnv) setCordon(node string, unschedulable bool) error {
 	patch := fmt.Sprintf(`{"spec":{"unschedulable":%v}}`, unschedulable)
 	_, err := e.cs.CoreV1().Nodes().Patch(e.ctx, node, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-	if err != nil {
-		t.Logf("warning: patch node %s unschedulable=%v: %v", node, unschedulable, err)
-	}
+	return err
 }
 
 // TestHACacheSyncRolloutGate (#230 item 4): /readyz gates on informer cache-sync, not leadership (#226). A
@@ -415,22 +503,65 @@ func TestHACacheSyncRolloutGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get ClusterRole %s: %v", crName, err)
 	}
-	deploy := e.deployName(t)
-	// Idempotent: the explicit in-body restore (to assert recovery) and the t.Cleanup failsafe both call this,
-	// but sync.Once collapses them to a single RBAC-restore + rollout — no redundant second rollout, and the
-	// Cleanup still restores if the test fails before the in-body call.
-	var restoreOnce sync.Once
-	restore := func() {
-		restoreOnce.Do(func() {
-			if cur, err := e.cs.RbacV1().ClusterRoles().Get(context.Background(), crName, metav1.GetOptions{}); err == nil {
-				cur.Rules = orig.Rules
-				_, _ = e.cs.RbacV1().ClusterRoles().Update(context.Background(), cur, metav1.UpdateOptions{})
-			}
-			_, _ = e.cs.AppsV1().Deployments(e.ns).Patch(context.Background(), deploy,
-				types.StrategicMergePatchType, []byte(rolloutRestartPatch()), metav1.PatchOptions{})
-		})
+	// Guard against an already-broken baseline (a prior aborted run may have left list/watch stripped): if we
+	// captured a broken ClusterRole as "orig", restoring to it would LOCK IN the breakage. Require the baseline
+	// to currently grant list+watch on the CRD group before we break it.
+	if !clusterRoleGrantsCRDListWatch(orig) {
+		t.Fatalf("ClusterRole %s does not currently grant list+watch on %s — the baseline looks already broken; "+
+			"redeploy the chart (make helm-deploy) before running the HA suite", crName, crdAPIGroup)
 	}
-	t.Cleanup(restore)
+	deploy := e.deployName(t)
+
+	// Reliable, idempotent restore: retry on conflict, and mark "restored" ONLY after BOTH the RBAC update and
+	// the rollout patch succeed — so a transient API error on the in-body restore does not consume the attempt
+	// and leave the ClusterRole permanently broken (the t.Cleanup failsafe then still retries). The in-body
+	// caller fails the test on error; the cleanup reports a CRITICAL if it ultimately cannot restore.
+	var restoreMu sync.Mutex
+	restored := false
+	restore := func() error {
+		restoreMu.Lock()
+		defer restoreMu.Unlock()
+		if restored {
+			return nil
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			cur, err := e.cs.RbacV1().ClusterRoles().Get(context.Background(), crName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			cur.Rules = orig.Rules
+			_, err = e.cs.RbacV1().ClusterRoles().Update(context.Background(), cur, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
+			return fmt.Errorf("restore ClusterRole %s: %w", crName, err)
+		}
+		if _, err := e.cs.AppsV1().Deployments(e.ns).Patch(context.Background(), deploy,
+			types.StrategicMergePatchType, []byte(rolloutRestartPatch()), metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("rollout restart after RBAC restore: %w", err)
+		}
+		restored = true
+		return nil
+	}
+	t.Cleanup(func() {
+		if err := restore(); err != nil {
+			t.Errorf("CRITICAL: cleanup could not restore the manager ClusterRole/rollout — the cluster may be "+
+				"left with broken RBAC: %v", err)
+		}
+	})
+
+	// Record the pre-rollout pod-template-hashes: the healthy (old) generation the gate must NOT tear down, and
+	// the baseline for identifying a NEW-generation (rolled) pod below.
+	oldHashes := map[string]bool{}
+	if pods, err := e.managerPods(); err == nil {
+		for i := range pods {
+			if h := pods[i].Labels["pod-template-hash"]; h != "" {
+				oldHashes[h] = true
+			}
+		}
+	}
+	if len(oldHashes) == 0 {
+		t.Fatal("could not record any pre-rollout pod-template-hash — cannot distinguish new pods from old")
+	}
 
 	// Strip list/watch on the CRD group so a fresh informer cannot sync those caches.
 	broken := orig.DeepCopy()
@@ -449,67 +580,160 @@ func TestHACacheSyncRolloutGate(t *testing.T) {
 		t.Fatalf("rollout restart: %v", err)
 	}
 
-	// Invariant over the window: a NotReady new pod appears (the broken replica the cache-sync /readyz gate
-	// holds back) AND the count of Ready manager pods never drops below 1 (the healthy version is never torn
-	// down under a broken new one). maxUnavailable rounds to 0 for 2 replicas, so old stays Ready while the
-	// surged new pod is stuck NotReady.
+	// Invariant over the window: a NEW-generation pod (a pod-template-hash absent before the rollout) whose
+	// container is RUNNING but which never becomes Ready — i.e. held by the cache-sync /readyz gate, not a
+	// pull/schedule failure — appears, while a Ready pod is preserved throughout. The structural guarantee is
+	// maxUnavailable=0 (asserted by the chart topology check), so kube cannot remove a healthy old pod before a
+	// new one is Ready; this loop is the runtime confirmation. Polled at 1s — the "never below 1 Ready" claim
+	// holds to that sampling resolution.
 	sawGatedNewPod := false
+	sawNewPod := false
 	minReady := 1 << 30
-	deadline := time.Now().Add(90 * time.Second)
+	deadline := time.Now().Add(120 * time.Second)
 	for time.Now().Before(deadline) {
-		ready, notReady, err := e.countReady()
-		if err == nil {
+		if pods, err := e.managerPods(); err == nil {
+			ready, gatedNew, sawNew := scanRolloutGate(pods, oldHashes)
+			if sawNew {
+				sawNewPod = true
+			}
 			if ready < minReady {
 				minReady = ready
 			}
-			if notReady >= 1 && ready >= 1 {
+			if gatedNew && ready >= 1 {
 				sawGatedNewPod = true
 			}
 		}
-		time.Sleep(3 * time.Second)
+		time.Sleep(time.Second)
 	}
 	if !sawGatedNewPod {
-		t.Fatal("expected a NotReady new pod (cache-sync gate holding a broken replica) while a Ready pod is preserved")
+		t.Fatalf("did not observe a RUNNING new-generation pod held NotReady by the cache-sync gate while a "+
+			"Ready pod was preserved (sawNewPod=%v, minReady=%d) — if no new pod appeared the rollout may not "+
+			"have progressed; if it came up Ready the gate failed to hold it", sawNewPod, minReady)
 	}
 	if minReady < 1 {
-		t.Fatalf("healthy version torn down under a broken rollout (min ready %d) — cache-sync gate failed", minReady)
+		t.Fatalf("a healthy pod was torn down under the broken rollout (min ready=%d, 1s resolution) — the "+
+			"cache-sync gate / maxUnavailable=0 guarantee failed", minReady)
 	}
-	t.Logf("cache-sync /readyz gate held: a NotReady new pod was gated while ready pods stayed >= %d", minReady)
+	t.Logf("cache-sync /readyz gate held: a RUNNING but NotReady new-generation pod was gated while ready pods "+
+		"stayed >= %d over the window", minReady)
 
-	// Restore RBAC + roll again, and confirm full recovery (also guaranteed by Cleanup).
-	restore()
+	// Restore RBAC + roll again, and confirm full recovery (the Cleanup is the failsafe).
+	if err := restore(); err != nil {
+		t.Fatalf("restore RBAC + roll: %v", err)
+	}
 	e.waitReadyManagerPods(t)
 	t.Log("recovered: 2 ready manager pods after restoring RBAC")
+}
+
+// scanRolloutGate summarizes one poll of the manager pods during a rollout: ready = count of Ready pods;
+// gatedNew = a NEW-generation pod (pod-template-hash absent from oldHashes) is RUNNING but held NotReady (the
+// cache-sync gate, not a pull/schedule failure); sawNew = any new-generation pod exists at all. Extracted from
+// TestHACacheSyncRolloutGate to keep that test's cyclomatic complexity bounded.
+func scanRolloutGate(pods []corev1.Pod, oldHashes map[string]bool) (ready int, gatedNew, sawNew bool) {
+	for i := range pods {
+		p := &pods[i]
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		isNew := false
+		if h := p.Labels["pod-template-hash"]; h != "" && !oldHashes[h] {
+			isNew, sawNew = true, true
+		}
+		switch {
+		case podReady(p):
+			ready++
+		case isNew && containerRunning(p):
+			gatedNew = true // started (not a pull/schedule failure) yet held NotReady by the gate
+		}
+	}
+	return ready, gatedNew, sawNew
+}
+
+// containerRunning reports whether any of the pod's containers is currently in the Running state — used to
+// distinguish "started but held NotReady by the readiness gate" from a pull/schedule/create failure.
+func containerRunning(p *corev1.Pod) bool {
+	for _, cs := range p.Status.ContainerStatuses {
+		if cs.State.Running != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// clusterRoleGrantsCRDListWatch reports whether the ClusterRole grants list AND watch on the CRD API group.
+func clusterRoleGrantsCRDListWatch(cr *rbacv1.ClusterRole) bool {
+	for i := range cr.Rules {
+		if ruleHasGroup(&cr.Rules[i], crdAPIGroup) && ruleGrantsVerbs(&cr.Rules[i], "list", "watch") {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *haEnv) deployName(t *testing.T) string {
 	t.Helper()
 	dl, err := e.cs.AppsV1().Deployments(e.ns).List(e.ctx, metav1.ListOptions{LabelSelector: managerSelector})
-	if err != nil || len(dl.Items) == 0 {
-		t.Fatalf("find manager Deployment: err=%v n=%d", err, len(dl.Items))
+	if err != nil {
+		t.Fatalf("list manager Deployments: %v", err)
+	}
+	if len(dl.Items) != 1 {
+		t.Fatalf("expected exactly 1 manager Deployment (%s in %s), got %d", managerSelector, e.ns, len(dl.Items))
 	}
 	return dl.Items[0].Name
 }
 
+// managerClusterRoleName resolves the manager's ClusterRole PRECISELY — from a manager pod's ServiceAccount
+// through the ClusterRoleBindings that bind it to their roleRef — rather than scanning every ClusterRole by a
+// name substring, so a multi-release or multi-operator cluster cannot lead us to break the wrong role. Among
+// the ClusterRoles bound to the SA it returns the one that actually grants list+watch on the CRD group (the
+// informer's RBAC), and fails if that is ambiguous.
 func (e *haEnv) managerClusterRoleName(t *testing.T) string {
 	t.Helper()
-	crl, err := e.cs.RbacV1().ClusterRoles().List(e.ctx, metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("list ClusterRoles: %v", err)
+	pods, err := e.managerPods()
+	if err != nil || len(pods) == 0 {
+		t.Fatalf("find a manager pod to resolve its ServiceAccount: err=%v n=%d", err, len(pods))
 	}
-	for i := range crl.Items {
-		cr := &crl.Items[i]
-		if !strings.Contains(cr.Name, "manager-role") {
+	sa := pods[0].Spec.ServiceAccountName
+	if sa == "" {
+		t.Fatalf("manager pod %s has no ServiceAccountName", pods[0].Name)
+	}
+	crbs, err := e.cs.RbacV1().ClusterRoleBindings().List(e.ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list ClusterRoleBindings: %v", err)
+	}
+	// Collect the ClusterRoles bound to the manager SA.
+	var bound []string
+	for i := range crbs.Items {
+		crb := &crbs.Items[i]
+		if crb.RoleRef.Kind != "ClusterRole" {
 			continue
 		}
-		for j := range cr.Rules {
-			if ruleHasGroup(&cr.Rules[j], crdAPIGroup) {
-				return cr.Name
+		for _, s := range crb.Subjects {
+			if s.Kind == "ServiceAccount" && s.Name == sa && s.Namespace == e.ns {
+				bound = append(bound, crb.RoleRef.Name)
+				break
 			}
 		}
 	}
-	t.Fatalf("could not find the manager ClusterRole with %s rules", crdAPIGroup)
-	return ""
+	// Pick the bound role that grants list+watch on the CRD group; that uniquely identifies the informer role.
+	match := ""
+	for _, name := range bound {
+		cr, err := e.cs.RbacV1().ClusterRoles().Get(e.ctx, name, metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+		if clusterRoleGrantsCRDListWatch(cr) {
+			if match != "" && match != name {
+				t.Fatalf("ambiguous: ClusterRoles %s and %s (both bound to SA %s) grant list+watch on %s",
+					match, name, sa, crdAPIGroup)
+			}
+			match = name
+		}
+	}
+	if match == "" {
+		t.Fatalf("no ClusterRole bound to SA %s grants list+watch on %s (bound roles: %v)", sa, crdAPIGroup, bound)
+	}
+	return match
 }
 
 func ruleHasGroup(r *rbacv1.PolicyRule, group string) bool {
@@ -519,6 +743,24 @@ func ruleHasGroup(r *rbacv1.PolicyRule, group string) bool {
 		}
 	}
 	return false
+}
+
+// ruleGrantsVerbs reports whether the rule grants EVERY listed verb (treating "*" as all verbs).
+func ruleGrantsVerbs(r *rbacv1.PolicyRule, verbs ...string) bool {
+	has := func(want string) bool {
+		for _, v := range r.Verbs {
+			if v == want || v == "*" {
+				return true
+			}
+		}
+		return false
+	}
+	for _, want := range verbs {
+		if !has(want) {
+			return false
+		}
+	}
+	return true
 }
 
 func withoutVerbs(vs []string, drop ...string) []string {

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -1,0 +1,544 @@
+//go:build e2e_ha
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// This file is the HA suite (#230) for package e2e. It exercises the active-passive HA behaviours the
+// design in docs/high-availability.md relies on, against a chart-deployed 2-replica release (leader
+// election on) on a Kind cluster. It uses a SEPARATE build tag (e2e_ha) from the kustomize single-replica
+// Ginkgo suite (e2e), so `go test -tags=e2e_ha` compiles only this file. Run via `make test-e2e-ha`.
+//
+// Namespace comes from HA_NAMESPACE (default ntn-operators-system, the helm-deploy default). The lease is
+// the controller-runtime leader-election Lease named after LeaderElectionID in cmd/main.go.
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	// haLeaseName must equal LeaderElectionID in cmd/main.go.
+	haLeaseName = "b1076767.operators.dev"
+	// haLeaseDuration must track leaderLeaseDuration in cmd/main.go — an ungraceful (SIGKILL) failover
+	// waits out at most this before the standby can steal the lease.
+	haLeaseDuration = 15 * time.Second
+	managerSelector = "control-plane=controller-manager"
+	haReplicas      = 2 // active-passive: one active reconciler + one warm standby
+	crdAPIGroup     = "ntn.operators.dev"
+)
+
+func haNamespace() string {
+	if ns := os.Getenv("HA_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return "ntn-operators-system"
+}
+
+// haEnv bundles the clients + namespace for the suite.
+type haEnv struct {
+	cs  *kubernetes.Clientset
+	dyn dynamic.Interface
+	ns  string
+	ctx context.Context
+}
+
+func newHAEnv(t *testing.T) *haEnv {
+	t.Helper()
+	cfg, err := ctrlcfg.GetConfig()
+	if err != nil {
+		t.Fatalf("load kube config (is KUBECONFIG set to the Kind cluster?): %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("clientset: %v", err)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	return &haEnv{cs: cs, dyn: dyn, ns: haNamespace(), ctx: context.Background()}
+}
+
+// eventually polls cond until it returns (true, _) or timeout; on timeout it fails with the last message.
+func eventually(t *testing.T, timeout, interval time.Duration, desc string, cond func() (bool, string)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		ok, msg := cond()
+		if ok {
+			return
+		}
+		last = msg
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for %s; last: %s", timeout, desc, last)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// leaseHolder returns the current leader-election Lease holderIdentity ("" if unset).
+func (e *haEnv) leaseHolder() (string, error) {
+	l, err := e.cs.CoordinationV1().Leases(e.ns).Get(e.ctx, haLeaseName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if l.Spec.HolderIdentity == nil {
+		return "", nil
+	}
+	return *l.Spec.HolderIdentity, nil
+}
+
+// holderPodBase maps a controller-runtime holderIdentity ("<pod>_<uuid>") to its owning pod name.
+func holderPodBase(holder string) string {
+	if i := strings.LastIndex(holder, "_"); i > 0 {
+		return holder[:i]
+	}
+	return holder
+}
+
+// managerPods lists the controller-manager pods.
+func (e *haEnv) managerPods() ([]corev1.Pod, error) {
+	pl, err := e.cs.CoreV1().Pods(e.ns).List(e.ctx, metav1.ListOptions{LabelSelector: managerSelector})
+	if err != nil {
+		return nil, err
+	}
+	return pl.Items, nil
+}
+
+func podReady(p *corev1.Pod) bool {
+	if p.DeletionTimestamp != nil {
+		return false
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func (e *haEnv) countReady() (ready, notReady int, err error) {
+	pods, err := e.managerPods()
+	if err != nil {
+		return 0, 0, err
+	}
+	for i := range pods {
+		if pods[i].DeletionTimestamp != nil {
+			continue
+		}
+		if podReady(&pods[i]) {
+			ready++
+		} else {
+			notReady++
+		}
+	}
+	return ready, notReady, nil
+}
+
+// waitReadyManagerPods blocks until exactly want manager pods are Ready (and none extra lingering NotReady).
+func (e *haEnv) waitReadyManagerPods(t *testing.T) {
+	const want = haReplicas
+	t.Helper()
+	eventually(t, 4*time.Minute, 3*time.Second, fmt.Sprintf("%d ready manager pods", want), func() (bool, string) {
+		ready, notReady, err := e.countReady()
+		if err != nil {
+			return false, err.Error()
+		}
+		return ready == want && notReady == 0, fmt.Sprintf("%d ready / %d notReady", ready, notReady)
+	})
+}
+
+// waitLeaseHolder blocks until the lease has a non-empty holder and returns it.
+func (e *haEnv) waitLeaseHolder(t *testing.T) string {
+	t.Helper()
+	holder := ""
+	eventually(t, time.Minute, 2*time.Second, "an initial lease holder", func() (bool, string) {
+		h, err := e.leaseHolder()
+		if err != nil {
+			return false, err.Error()
+		}
+		holder = h
+		return h != "", "holder empty"
+	})
+	return holder
+}
+
+var gslGVR = schema.GroupVersionResource{Group: crdAPIGroup, Version: "v1alpha1", Resource: "groundstationlifecycles"}
+
+// assertLeaderReconciles proves the CURRENT leader actually reconciles (not just holds the lease): it
+// creates a GroundStationLifecycle and waits for the controller to populate .status.conditions.
+func (e *haEnv) assertLeaderReconciles(t *testing.T, name string) {
+	t.Helper()
+	gsl := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": crdAPIGroup + "/v1alpha1",
+		"kind":       "GroundStationLifecycle",
+		"metadata":   map[string]any{"name": name, "namespace": e.ns},
+		"spec": map[string]any{
+			"hardware":   map[string]any{"vendor": "ennoconn", "model": "edge-5000"},
+			"deployment": map[string]any{"location": map[string]any{"lat": "25.0330", "lon": "121.5654"}},
+		},
+	}}
+	if _, err := e.dyn.Resource(gslGVR).Namespace(e.ns).Create(e.ctx, gsl, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create GroundStationLifecycle: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = e.dyn.Resource(gslGVR).Namespace(e.ns).Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+	eventually(t, 90*time.Second, 3*time.Second, "leader reconciles a GroundStationLifecycle", func() (bool, string) {
+		got, err := e.dyn.Resource(gslGVR).Namespace(e.ns).Get(e.ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+		return len(conds) > 0, fmt.Sprintf("%d status conditions", len(conds))
+	})
+}
+
+// TestHAGracefulFailover (#230 item 2): deleting the leader pod GRACEFULLY (LeaderElectionReleaseOnCancel
+// releases the lease on SIGTERM) must hand the lease to the standby, and the NEW leader must complete a
+// real reconcile — not merely win the lease.
+func TestHAGracefulFailover(t *testing.T) {
+	e := newHAEnv(t)
+	e.waitReadyManagerPods(t)
+	holder0 := e.waitLeaseHolder(t)
+	leader0 := holderPodBase(holder0)
+	t.Logf("initial leader pod=%s holder=%s", leader0, holder0)
+
+	if err := e.cs.CoreV1().Pods(e.ns).Delete(e.ctx, leader0, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete leader pod: %v", err)
+	}
+	start := time.Now()
+	eventually(t, time.Minute, time.Second, "the lease to fail over to a new holder", func() (bool, string) {
+		h, err := e.leaseHolder()
+		if err != nil {
+			return false, err.Error()
+		}
+		if h == "" || holderPodBase(h) == leader0 {
+			return false, "holder still " + h
+		}
+		return true, ""
+	})
+	h1, _ := e.leaseHolder()
+	t.Logf("GRACEFUL failover took %s; new holder=%s", time.Since(start).Round(time.Millisecond), h1)
+	e.waitReadyManagerPods(t)
+	e.assertLeaderReconciles(t, "ha-graceful-probe")
+}
+
+// TestHAUngracefulFailover (#230 item 3): an UNGRACEFUL leader loss (the container SIGKILLed on the node, so
+// the process never runs the lease-release defer) must still fail over — the standby waits out LeaseDuration
+// — and the RTO is recorded. A plain pod delete cannot exercise this: the manager image is distroless, so a
+// pod delete routes through the kubelet's SIGTERM and the manager releases the lease in ~1 s (that is the
+// GRACEFUL path, covered above). To force the no-release path we SIGKILL the container directly via crictl on
+// the Kind node. Requires docker + a Kind node; skipped otherwise. The lower-bound assertion PROVES the
+// lease-timeout path was taken (a graceful release would be ~1 s), not just that failover eventually happened.
+func TestHAUngracefulFailover(t *testing.T) {
+	e := newHAEnv(t)
+	e.waitReadyManagerPods(t)
+	holder0 := e.waitLeaseHolder(t)
+	leader0 := holderPodBase(holder0)
+
+	pod, err := e.cs.CoreV1().Pods(e.ns).Get(e.ctx, leader0, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get leader pod: %v", err)
+	}
+	node := pod.Spec.NodeName
+	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].ContainerID == "" {
+		t.Fatalf("leader pod %s has no running container id", leader0)
+	}
+	cid := strings.TrimPrefix(pod.Status.ContainerStatuses[0].ContainerID, "containerd://")
+	t.Logf("initial leader pod=%s node=%s container=%.12s", leader0, node, cid)
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available: the ungraceful (node-level SIGKILL) test needs a Kind cluster")
+	}
+	// Leadership can legitimately move in the gap while we resolved the pod/container id above; if it has,
+	// the container we're about to kill is no longer the leader and the RTO would be meaningless — skip.
+	if h, _ := e.leaseHolder(); h != holder0 {
+		t.Skipf("leadership moved before the kill (%s -> %s); nothing to measure", holder0, h)
+	}
+	// crictl stop --timeout 0 SIGKILLs the container immediately — no SIGTERM, so no lease release.
+	kill := exec.Command("docker", "exec", node, "crictl", "stop", "--timeout", "0", cid)
+	if out, err := kill.CombinedOutput(); err != nil {
+		t.Skipf("could not SIGKILL the container via docker/crictl (non-Kind cluster?): %v: %s", err, out)
+	}
+	start := time.Now() // measure the RTO from the fault, NOT including the docker-exec setup
+	eventually(t, haLeaseDuration+30*time.Second, time.Second, "ungraceful failover", func() (bool, string) {
+		h, err := e.leaseHolder()
+		if err != nil {
+			return false, err.Error()
+		}
+		// A crictl SIGKILL restarts the container in the SAME pod, which can re-acquire the lease before the
+		// standby — but any re-acquire mints a FRESH holderIdentity (a new uuid), so compare the full identity,
+		// not just the pod name. This detects the lease-timeout recovery whether the standby wins or the
+		// restarted leader does; the RTO is ~LeaseDuration either way.
+		if h == "" || h == holder0 {
+			return false, "holder still " + h
+		}
+		return true, ""
+	})
+	rto := time.Since(start)
+	t.Logf("ungraceful (SIGKILL) failover RTO=%s (LeaseDuration=%s)", rto.Round(time.Millisecond), haLeaseDuration)
+
+	// The lease renews every few seconds, so the standby cannot steal it until ~LeaseDuration after the last
+	// renew. A graceful release would be ~1 s; require the RTO to be clearly in the lease-timeout regime,
+	// proving no release happened, while bounding the top for a slow CI.
+	if rto < 8*time.Second {
+		t.Fatalf("ungraceful RTO %s too fast — the lease was released, not the LeaseDuration path", rto)
+	}
+	// Upper bound kept below the eventually window (LeaseDuration+30s) so a legitimately-slow-but-bounded
+	// failover trips THIS clear message rather than the generic eventually timeout.
+	if rto > haLeaseDuration+20*time.Second {
+		t.Fatalf("ungraceful failover RTO %s exceeded LeaseDuration+margin", rto)
+	}
+	e.waitReadyManagerPods(t)
+}
+
+// TestHAPDBEviction (#230 item 5): the PDB (minAvailable=1 over 2 replicas) must let a voluntary disruption
+// evict at most ONE manager pod at a time. Cordon the node(s) so an evicted pod's replacement cannot become
+// Ready, then evict both: exactly one eviction succeeds and the other is refused by the PDB.
+func TestHAPDBEviction(t *testing.T) {
+	e := newHAEnv(t)
+	e.waitReadyManagerPods(t)
+	pods, err := e.managerPods()
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	var ready []string
+	for i := range pods {
+		if podReady(&pods[i]) {
+			ready = append(ready, pods[i].Name)
+		}
+	}
+	if len(ready) != 2 {
+		t.Fatalf("need exactly 2 ready manager pods, got %d", len(ready))
+	}
+
+	// Cordon every node so an evicted pod's replacement stays Pending (never Ready), making the PDB's
+	// currentHealthy accounting deterministic. Uncordon on cleanup.
+	nodes, err := e.cs.CoreV1().Nodes().List(e.ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list nodes: %v", err)
+	}
+	for i := range nodes.Items {
+		e.setCordon(t, nodes.Items[i].Name, true)
+	}
+	t.Cleanup(func() {
+		for i := range nodes.Items {
+			e.setCordon(t, nodes.Items[i].Name, false)
+		}
+	})
+
+	evict := func(pod string) error {
+		return e.cs.PolicyV1().Evictions(e.ns).Evict(e.ctx, &policyv1.Eviction{
+			ObjectMeta: metav1.ObjectMeta{Name: pod, Namespace: e.ns},
+		})
+	}
+	// First eviction must succeed (2 healthy → 1, still >= minAvailable=1).
+	if err := evict(ready[0]); err != nil {
+		t.Fatalf("first eviction of %s should succeed (2 healthy → 1 >= minAvailable); got: %v", ready[0], err)
+	}
+	t.Logf("evicted %s (first, allowed)", ready[0])
+	// The second eviction must be REFUSED by the PDB (evicting it would drop below minAvailable=1). The
+	// replacement cannot become Ready (cordoned), so currentHealthy stays 1. Retry ONLY on a transient
+	// error (the PDB status may lag the first eviction by a poll); an ALLOWED eviction — or a later NotFound
+	// proving a prior attempt was wrongly allowed — is a genuine PDB regression and must fail FAST with a
+	// clear message, not be masked as a timeout after we've silently destroyed the last replica.
+	refused := false
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		err := evict(ready[1])
+		switch {
+		case err == nil:
+			t.Fatalf("PDB ALLOWED the second eviction of %s — the last replica was left unprotected", ready[1])
+		case apierrors.IsTooManyRequests(err) || strings.Contains(err.Error(), "disruption budget"):
+			refused = true
+		case apierrors.IsNotFound(err):
+			t.Fatalf("second pod %s is gone — a prior eviction was wrongly allowed (PDB unprotected)", ready[1])
+		default:
+			time.Sleep(2 * time.Second) // transient (e.g. PDB currentHealthy not yet recomputed); retry
+			continue
+		}
+		break
+	}
+	if !refused {
+		t.Fatal("timed out waiting for the PDB to refuse the second eviction")
+	}
+	t.Logf("second eviction of %s correctly REFUSED by the PDB", ready[1])
+}
+
+func (e *haEnv) setCordon(t *testing.T, node string, unschedulable bool) {
+	t.Helper()
+	patch := fmt.Sprintf(`{"spec":{"unschedulable":%v}}`, unschedulable)
+	_, err := e.cs.CoreV1().Nodes().Patch(e.ctx, node, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	if err != nil {
+		t.Logf("warning: patch node %s unschedulable=%v: %v", node, unschedulable, err)
+	}
+}
+
+// TestHACacheSyncRolloutGate (#230 item 4): /readyz gates on informer cache-sync, not leadership (#226). A
+// replica whose cache cannot sync must NOT become Ready, so a rollout of such a replica must NOT tear down
+// the healthy old version. We break the manager ClusterRole's list/watch on the CRD group, force a rollout,
+// and assert that a new NotReady pod appears while ≥1 Ready pod is preserved throughout; then restore.
+func TestHACacheSyncRolloutGate(t *testing.T) {
+	e := newHAEnv(t)
+	e.waitReadyManagerPods(t)
+
+	crName := e.managerClusterRoleName(t)
+	orig, err := e.cs.RbacV1().ClusterRoles().Get(e.ctx, crName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ClusterRole %s: %v", crName, err)
+	}
+	deploy := e.deployName(t)
+	// Idempotent: the explicit in-body restore (to assert recovery) and the t.Cleanup failsafe both call this,
+	// but sync.Once collapses them to a single RBAC-restore + rollout — no redundant second rollout, and the
+	// Cleanup still restores if the test fails before the in-body call.
+	var restoreOnce sync.Once
+	restore := func() {
+		restoreOnce.Do(func() {
+			if cur, err := e.cs.RbacV1().ClusterRoles().Get(context.Background(), crName, metav1.GetOptions{}); err == nil {
+				cur.Rules = orig.Rules
+				_, _ = e.cs.RbacV1().ClusterRoles().Update(context.Background(), cur, metav1.UpdateOptions{})
+			}
+			_, _ = e.cs.AppsV1().Deployments(e.ns).Patch(context.Background(), deploy,
+				types.StrategicMergePatchType, []byte(rolloutRestartPatch()), metav1.PatchOptions{})
+		})
+	}
+	t.Cleanup(restore)
+
+	// Strip list/watch on the CRD group so a fresh informer cannot sync those caches.
+	broken := orig.DeepCopy()
+	for i := range broken.Rules {
+		r := &broken.Rules[i]
+		if ruleHasGroup(r, crdAPIGroup) {
+			r.Verbs = withoutVerbs(r.Verbs, "list", "watch")
+		}
+	}
+	if _, err := e.cs.RbacV1().ClusterRoles().Update(e.ctx, broken, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("break ClusterRole: %v", err)
+	}
+	// Force a rollout so new-generation pods start with the broken RBAC.
+	if _, err := e.cs.AppsV1().Deployments(e.ns).Patch(e.ctx, deploy,
+		types.StrategicMergePatchType, []byte(rolloutRestartPatch()), metav1.PatchOptions{}); err != nil {
+		t.Fatalf("rollout restart: %v", err)
+	}
+
+	// Invariant over the window: a NotReady new pod appears (the broken replica the cache-sync /readyz gate
+	// holds back) AND the count of Ready manager pods never drops below 1 (the healthy version is never torn
+	// down under a broken new one). maxUnavailable rounds to 0 for 2 replicas, so old stays Ready while the
+	// surged new pod is stuck NotReady.
+	sawGatedNewPod := false
+	minReady := 1 << 30
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		ready, notReady, err := e.countReady()
+		if err == nil {
+			if ready < minReady {
+				minReady = ready
+			}
+			if notReady >= 1 && ready >= 1 {
+				sawGatedNewPod = true
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if !sawGatedNewPod {
+		t.Fatal("expected a NotReady new pod (cache-sync gate holding a broken replica) while a Ready pod is preserved")
+	}
+	if minReady < 1 {
+		t.Fatalf("healthy version torn down under a broken rollout (min ready %d) — cache-sync gate failed", minReady)
+	}
+	t.Logf("cache-sync /readyz gate held: a NotReady new pod was gated while ready pods stayed >= %d", minReady)
+
+	// Restore RBAC + roll again, and confirm full recovery (also guaranteed by Cleanup).
+	restore()
+	e.waitReadyManagerPods(t)
+	t.Log("recovered: 2 ready manager pods after restoring RBAC")
+}
+
+func (e *haEnv) deployName(t *testing.T) string {
+	t.Helper()
+	dl, err := e.cs.AppsV1().Deployments(e.ns).List(e.ctx, metav1.ListOptions{LabelSelector: managerSelector})
+	if err != nil || len(dl.Items) == 0 {
+		t.Fatalf("find manager Deployment: err=%v n=%d", err, len(dl.Items))
+	}
+	return dl.Items[0].Name
+}
+
+func (e *haEnv) managerClusterRoleName(t *testing.T) string {
+	t.Helper()
+	crl, err := e.cs.RbacV1().ClusterRoles().List(e.ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list ClusterRoles: %v", err)
+	}
+	for i := range crl.Items {
+		cr := &crl.Items[i]
+		if !strings.Contains(cr.Name, "manager-role") {
+			continue
+		}
+		for j := range cr.Rules {
+			if ruleHasGroup(&cr.Rules[j], crdAPIGroup) {
+				return cr.Name
+			}
+		}
+	}
+	t.Fatalf("could not find the manager ClusterRole with %s rules", crdAPIGroup)
+	return ""
+}
+
+func ruleHasGroup(r *rbacv1.PolicyRule, group string) bool {
+	for _, g := range r.APIGroups {
+		if g == group || g == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func withoutVerbs(vs []string, drop ...string) []string {
+	out := make([]string, 0, len(vs))
+	for _, v := range vs {
+		keep := v != "*"
+		for _, d := range drop {
+			if v == d {
+				keep = false
+			}
+		}
+		if keep {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func rolloutRestartPatch() string {
+	// A unique annotation forces a new ReplicaSet rollout without changing behaviour.
+	return fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"ntn.operators.dev/ha-e2e-restart":%q}}}}}`,
+		time.Now().Format(time.RFC3339Nano))
+}

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -74,8 +74,16 @@ func newHAEnv(t *testing.T) *haEnv {
 	// cluster-scoped ClusterRole). Refuse to run unless the caller explicitly acknowledges that — so a stray
 	// `make test-e2e-ha` against the wrong kubecontext cannot cordon a production fleet or break a live operator.
 	if os.Getenv("HA_ALLOW_DESTRUCTIVE") != "1" {
-		t.Skip("HA suite is DESTRUCTIVE (cordons every node, evicts manager pods, mutates cluster RBAC); " +
-			"set HA_ALLOW_DESTRUCTIVE=1 and point KUBECONFIG at a disposable Kind cluster to run it")
+		msg := "HA suite is DESTRUCTIVE (cordons every node, evicts manager pods, mutates cluster RBAC); " +
+			"set HA_ALLOW_DESTRUCTIVE=1 and point KUBECONFIG at a disposable Kind cluster to run it"
+		// In CI (GitHub sets CI=true) or when the caller pins HA_REQUIRE_RUN=1, a missing opt-in is a CONFIG
+		// error, NOT a reason to skip-then-green: if the workflow ever dropped HA_ALLOW_DESTRUCTIVE, silently
+		// skipping every HA test would report success while running nothing. Fail loudly there; skip only for
+		// an interactive local run.
+		if os.Getenv("CI") == "true" || os.Getenv("HA_REQUIRE_RUN") == "1" {
+			t.Fatal(msg + " (refusing to skip under CI/HA_REQUIRE_RUN — that would be a false green)")
+		}
+		t.Skip(msg)
 	}
 	cfg, err := ctrlcfg.GetConfig()
 	if err != nil {
@@ -170,6 +178,18 @@ func holderPodBase(holder string) string {
 		return holder[:i]
 	}
 	return holder
+}
+
+// managerContainerID returns the containerd id of the pod's "manager" container (the chart's container name),
+// stripped of the "containerd://" scheme — selected BY NAME, not container index 0, so it stays correct if a
+// sidecar is ever added.
+func managerContainerID(pod *corev1.Pod) (string, bool) {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "manager" && cs.ContainerID != "" {
+			return strings.TrimPrefix(cs.ContainerID, "containerd://"), true
+		}
+	}
+	return "", false
 }
 
 // managerPods lists the controller-manager pods.
@@ -276,7 +296,14 @@ func (e *haEnv) assertLeaderReconciles(t *testing.T, name string) {
 func TestHAGracefulFailover(t *testing.T) {
 	e := newHAEnv(t)
 	e.waitReadyManagerPods(t)
+	ld := e.leaseDuration(t)
 	holder0 := e.waitLeaseHolder(t)
+	// Re-confirm holder0 is STILL the leader right before the delete — leadership could have moved while the
+	// prior test's churn settled; deleting a standby would make the measurement meaningless and (with no lower
+	// bound) trivially pass. If it moved, re-resolve so we always delete the ACTUAL current leader.
+	if h, err := e.leaseHolder(); err == nil && h != holder0 {
+		holder0 = e.waitLeaseHolder(t)
+	}
 	leader0 := holderPodBase(holder0)
 	t.Logf("initial leader pod=%s holder=%s", leader0, holder0)
 
@@ -284,18 +311,33 @@ func TestHAGracefulFailover(t *testing.T) {
 		t.Fatalf("delete leader pod: %v", err)
 	}
 	start := time.Now()
-	eventually(t, time.Minute, time.Second, "the lease to fail over to a new holder", func() (bool, string) {
+	eventually(t, time.Minute, 200*time.Millisecond, "the lease to fail over to a new holder", func() (bool, string) {
 		h, err := e.leaseHolder()
 		if err != nil {
 			return false, err.Error()
 		}
-		if h == "" || holderPodBase(h) == leader0 {
+		// Full-identity comparison (not pod-base): the deleted leader is gone, so ANY new holder — the standby
+		// or the deleted pod's fresh-named replacement — has a different identity. Stricter than pod-base and
+		// closes the "we deleted a standby and instantly saw the already-moved holder" false pass.
+		if h == "" || h == holder0 {
 			return false, "holder still " + h
 		}
 		return true, ""
 	})
+	rto := time.Since(start)
 	h1, _ := e.leaseHolder()
-	t.Logf("GRACEFUL failover took %s; new holder=%s", time.Since(start).Round(time.Millisecond), h1)
+	t.Logf("GRACEFUL failover took %s; new holder=%s", rto.Round(time.Millisecond), h1)
+	// Upper bound PROVES the lease was ACTIVELY released on SIGTERM (LeaderElectionReleaseOnCancel), not merely
+	// that it failed over eventually: an active release hands off within a few RetryPeriod ticks, whereas a
+	// regressed release falls back to the LeaseDuration timeout (~15 s). Bound at 2/3 of the lease duration:
+	// the standby acquires only on its next client-go acquire tick, which jitters up to RetryPeriod*(1+1.2),
+	// so with SIGTERM delivery + graceful shutdown the worst legitimate active release approaches ~9 s on a
+	// loaded runner — ld/2 (7.5 s) would false-fail; 2*ld/3 (10 s) absorbs the jitter yet stays clearly below
+	// the ~13 s lease-timeout floor (the ungraceful RTO). Without any bound a broken release would still pass.
+	if rto >= 2*ld/3 {
+		t.Fatalf("graceful failover took %s (>= 2*LeaseDuration/3=%s) — the lease was NOT actively released on "+
+			"SIGTERM; it fell back to the timeout path (LeaderElectionReleaseOnCancel regressed?)", rto, 2*ld/3)
+	}
 	e.waitReadyManagerPods(t)
 	e.assertLeaderReconciles(t, "ha-graceful-probe")
 }
@@ -343,14 +385,16 @@ func TestHAUngracefulFailover(t *testing.T) {
 			t.Logf("attempt %d: get leader pod %s: %v — re-resolving", attempt, leader0, err)
 			continue
 		}
-		if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].ContainerID == "" {
-			t.Logf("attempt %d: leader pod %s has no running container id — re-resolving", attempt, leader0)
+		cid, ok := managerContainerID(pod)
+		if !ok {
+			t.Logf("attempt %d: leader pod %s has no running 'manager' container id — re-resolving", attempt, leader0)
 			continue
 		}
 		node := pod.Spec.NodeName
-		cid := strings.TrimPrefix(pod.Status.ContainerStatuses[0].ContainerID, "containerd://")
-		// Re-confirm this is STILL the leader immediately before the kill; if it moved during resolution, retry.
-		if h, _ := e.leaseHolder(); h != holder0 {
+		// Re-confirm this is STILL the leader immediately before the kill; only a SUCCESSFUL read showing a
+		// different holder counts as "moved" (a transient API error must not masquerade as a move and burn a
+		// retry — that would turn flakiness into a HA_REQUIRE_UNGRACEFUL Fatal).
+		if h, err := e.leaseHolder(); err == nil && h != holder0 {
 			t.Logf("attempt %d: leadership moved during resolution (%s -> %s) — re-resolving", attempt, holder0, h)
 			continue
 		}
@@ -419,32 +463,60 @@ func TestHAPDBEviction(t *testing.T) {
 	}
 
 	// Cordon every node so an evicted pod's replacement stays Pending (never Ready), making the PDB's
-	// currentHealthy accounting deterministic. Uncordon on cleanup.
+	// currentHealthy accounting deterministic.
 	nodes, err := e.cs.CoreV1().Nodes().List(e.ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("list nodes: %v", err)
 	}
-	// Register the uncordon cleanup BEFORE cordoning, so a mid-loop cordon failure (Fatal) still releases the
-	// nodes already cordoned. A cordon that SILENTLY failed would let the replacement become Ready and the
+	// Record each node's ORIGINAL schedulability so cleanup restores exactly that, rather than unconditionally
+	// uncordoning — never wrongly un-cordoning a node an operator had deliberately cordoned (matters for a
+	// non-Kind disposable cluster under HA_EXPECT_KIND=0; a fresh Kind node is schedulable anyway).
+	origUnsched := make(map[string]bool, len(nodes.Items))
+	for i := range nodes.Items {
+		origUnsched[nodes.Items[i].Name] = nodes.Items[i].Spec.Unschedulable
+	}
+	// Register the restore cleanup BEFORE cordoning, so a mid-loop cordon failure (Fatal) still restores the
+	// nodes already changed. A cordon that SILENTLY failed would let the replacement become Ready and the
 	// second eviction be legitimately allowed — which we would then misreport as "PDB unprotected" — so a
-	// SETUP cordon failure is Fatal; the cleanup uncordon is best-effort but reported.
+	// SETUP cordon failure is Fatal; the cleanup restore is best-effort but reported.
 	t.Cleanup(func() {
 		var stuck []string
 		for i := range nodes.Items {
-			if err := e.setCordon(nodes.Items[i].Name, false); err != nil {
-				stuck = append(stuck, nodes.Items[i].Name)
-				t.Logf("cleanup: uncordon %s failed: %v", nodes.Items[i].Name, err)
+			n := nodes.Items[i].Name
+			// Retry: a single failed uncordon would leave the node unschedulable and hang the NEXT test's
+			// waitReadyManagerPods for its full 4-minute budget (on a single-node Kind, wedging the suite).
+			var err error
+			for range 5 {
+				if err = e.setCordon(n, origUnsched[n]); err == nil {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+			if err != nil {
+				stuck = append(stuck, n)
+				t.Logf("cleanup: restore node %s unschedulable=%v failed after retries: %v", n, origUnsched[n], err)
 			}
 		}
 		if len(stuck) > 0 {
-			t.Errorf("CRITICAL: cleanup left node(s) cordoned %v — the cluster may not schedule new pods", stuck)
+			t.Errorf("CRITICAL: cleanup could not restore node schedulability for %v", stuck)
 		}
 	})
 	for i := range nodes.Items {
+		if origUnsched[nodes.Items[i].Name] {
+			continue // already cordoned by its operator; leave it (and cleanup leaves it) untouched
+		}
 		if err := e.setCordon(nodes.Items[i].Name, true); err != nil {
 			t.Fatalf("setup: cordon node %s failed: %v", nodes.Items[i].Name, err)
 		}
 	}
+
+	// Wait for the PDB status to CATCH UP before evicting: the disruption controller recomputes
+	// disruptionsAllowed asynchronously and lags pod-Ready (this test runs right after the SIGKILL test churns
+	// a pod), so an eviction in that lag window would 429 and false-fail "first eviction should succeed". This
+	// also cross-checks the selector at runtime: expectedPods must equal exactly the manager replica count (a
+	// stray pod sharing the manager label would inflate it — the runtime complement to the checker's
+	// structural over-broad guard).
+	e.waitManagerPDBReady(t)
 
 	evict := func(pod string) error {
 		return e.cs.PolicyV1().Evictions(e.ns).Evict(e.ctx, &policyv1.Eviction{
@@ -468,7 +540,9 @@ func TestHAPDBEviction(t *testing.T) {
 		switch {
 		case err == nil:
 			t.Fatalf("PDB ALLOWED the second eviction of %s — the last replica was left unprotected", ready[1])
-		case apierrors.IsTooManyRequests(err) || strings.Contains(err.Error(), "disruption budget"):
+		case apierrors.IsTooManyRequests(err) && strings.Contains(err.Error(), "disruption budget"):
+			// Require the disruption-budget MESSAGE, not a bare 429 — an unrelated 429 (e.g. API-priority
+			// throttling) must not be misread as a PDB refusal.
 			refused = true
 		case apierrors.IsNotFound(err):
 			t.Fatalf("second pod %s is gone — a prior eviction was wrongly allowed (PDB unprotected)", ready[1])
@@ -488,6 +562,32 @@ func (e *haEnv) setCordon(node string, unschedulable bool) error {
 	patch := fmt.Sprintf(`{"spec":{"unschedulable":%v}}`, unschedulable)
 	_, err := e.cs.CoreV1().Nodes().Patch(e.ctx, node, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
 	return err
+}
+
+// waitManagerPDBReady waits for the single manager PodDisruptionBudget's status to CATCH UP with 2 healthy
+// replicas — disruptionsAllowed >= 1 (the disruption controller computes this asynchronously and lags
+// pod-Ready, so evicting too early would 429) — and cross-checks expectedPods == haReplicas: the selector must
+// resolve to EXACTLY the manager replicas, so a runtime stray sharing the manager label (which the structural
+// checker cannot see) fails here.
+func (e *haEnv) waitManagerPDBReady(t *testing.T) {
+	t.Helper()
+	eventually(t, 60*time.Second, time.Second, "manager PDB to allow one disruption", func() (bool, string) {
+		l, err := e.cs.PolicyV1().PodDisruptionBudgets(e.ns).List(e.ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(l.Items) != 1 {
+			t.Fatalf("expected exactly 1 PodDisruptionBudget in %s, got %d", e.ns, len(l.Items))
+		}
+		s := l.Items[0].Status
+		if s.ExpectedPods > int32(haReplicas) {
+			t.Fatalf("PDB selects %d pods, more than the %d manager replicas — over-broad selector (matches strays)",
+				s.ExpectedPods, haReplicas)
+		}
+		ok := s.ExpectedPods == int32(haReplicas) && s.CurrentHealthy == int32(haReplicas) && s.DisruptionsAllowed >= 1
+		return ok, fmt.Sprintf("expectedPods=%d currentHealthy=%d disruptionsAllowed=%d",
+			s.ExpectedPods, s.CurrentHealthy, s.DisruptionsAllowed)
+	})
 }
 
 // TestHACacheSyncRolloutGate (#230 item 4): /readyz gates on informer cache-sync, not leadership (#226). A
@@ -564,6 +664,16 @@ func TestHACacheSyncRolloutGate(t *testing.T) {
 	}
 
 	// Strip list/watch on the CRD group so a fresh informer cannot sync those caches.
+	//
+	// WHY this holds a STANDBY NotReady (load-bearing, keep this in sync with the controller): the surge/rolled
+	// pod is a non-leader standby, and controllers are leader-election runnables, so their CRD informers are
+	// normally NOT created on a standby. The reason a standby's cache-sync /readyz gate is observable at all is
+	// that NTNCellConfigReconciler.SetupWithManager calls mgr.GetFieldIndexer().IndexField(...), which EAGERLY
+	// creates the NTNCellConfig informer on EVERY replica at setup — and controller-runtime waits on it
+	// (runnables.Caches -> WaitForCacheSync) before the non-leader cacheReadyRunnable flips /readyz ready.
+	// Breaking list/watch on ntn.operators.dev stalls that lone informer -> /readyz 500 -> standby NotReady.
+	// If that eager field indexer is ever removed, a standby would sync its (empty) CRD cache and go Ready under
+	// broken RBAC, flipping this test to a confusing false-FAIL with no /readyz change — revisit this then.
 	broken := orig.DeepCopy()
 	for i := range broken.Rules {
 		r := &broken.Rules[i]
@@ -580,42 +690,65 @@ func TestHACacheSyncRolloutGate(t *testing.T) {
 		t.Fatalf("rollout restart: %v", err)
 	}
 
-	// Invariant over the window: a NEW-generation pod (a pod-template-hash absent before the rollout) whose
-	// container is RUNNING but which never becomes Ready — i.e. held by the cache-sync /readyz gate, not a
-	// pull/schedule failure — appears, while a Ready pod is preserved throughout. The structural guarantee is
-	// maxUnavailable=0 (asserted by the chart topology check), so kube cannot remove a healthy old pod before a
-	// new one is Ready; this loop is the runtime confirmation. Polled at 1s — the "never below 1 Ready" claim
-	// holds to that sampling resolution.
-	sawGatedNewPod := false
-	sawNewPod := false
+	// Proving the gate needs MORE than a single "Running+NotReady" poll: every healthy pod is briefly
+	// Running-but-NotReady during startup (the chart readiness probe has a 5 s initialDelay), so one such poll
+	// could be a transient startup blip, not sustained gating. Instead: (1) wait for the surge pod, failing if
+	// any new-generation pod is already Ready; (2) confirm via /readyz?verbose that the /readyz (cache-sync)
+	// gate is what's failing, not a crash or unrelated probe; (3) hold for a sustained window (>> the ~15 s a
+	// healthy pod needs to go Ready) asserting the SAME pod stays NotReady, NO new-generation pod EVER goes
+	// Ready, and a Ready old-generation pod is preserved (maxUnavailable=0); (4) re-assert NotReady at the end.
+	gatedName, gatedUID := e.waitForGatedNewPod(t, oldHashes)
+	e.assertReadyzGateFailing(t, gatedName)
+
+	const sustain = 45 * time.Second
 	minReady := 1 << 30
-	deadline := time.Now().Add(120 * time.Second)
-	for time.Now().Before(deadline) {
-		if pods, err := e.managerPods(); err == nil {
-			ready, gatedNew, sawNew := scanRolloutGate(pods, oldHashes)
-			if sawNew {
-				sawNewPod = true
-			}
-			if ready < minReady {
-				minReady = ready
-			}
-			if gatedNew && ready >= 1 {
-				sawGatedNewPod = true
-			}
-		}
+	polls, heldPolls, errPolls := 0, 0, 0
+	hold := time.Now().Add(sustain)
+	for time.Now().Before(hold) {
 		time.Sleep(time.Second)
+		pods, err := e.managerPods()
+		if err != nil {
+			errPolls++ // count separately so a run of API errors reports as flakiness, not "gate not holding"
+			continue
+		}
+		polls++
+		ready, gatedHeld, newReady := scanSustained(pods, oldHashes, gatedUID)
+		if newReady != "" {
+			t.Fatalf("new-generation pod %s became Ready under broken cache RBAC — the cache-sync gate did NOT "+
+				"hold (a healthy pod goes Ready; this is exactly the transient-startup false pass a single-poll "+
+				"check would have missed)", newReady)
+		}
+		if ready < minReady {
+			minReady = ready
+		}
+		if gatedHeld {
+			heldPolls++
+		}
 	}
-	if !sawGatedNewPod {
-		t.Fatalf("did not observe a RUNNING new-generation pod held NotReady by the cache-sync gate while a "+
-			"Ready pod was preserved (sawNewPod=%v, minReady=%d) — if no new pod appeared the rollout may not "+
-			"have progressed; if it came up Ready the gate failed to hold it", sawNewPod, minReady)
+	if polls == 0 {
+		t.Fatalf("could not observe the gate — every one of %d polls hit an API error", errPolls)
 	}
-	if minReady < 1 {
-		t.Fatalf("a healthy pod was torn down under the broken rollout (min ready=%d, 1s resolution) — the "+
-			"cache-sync gate / maxUnavailable=0 guarantee failed", minReady)
+	if heldPolls < polls {
+		t.Fatalf("gated pod %s was not continuously present+NotReady across the %s window (%d/%d good polls, %d "+
+			"API errors) — not sustained gating", gatedName, sustain, heldPolls, polls, errPolls)
 	}
-	t.Logf("cache-sync /readyz gate held: a RUNNING but NotReady new-generation pod was gated while ready pods "+
-		"stayed >= %d over the window", minReady)
+	// maxUnavailable=0 must keep BOTH old replicas Ready while the new one is gated — a regression to
+	// maxUnavailable=1 (one old pod torn down) leaves min ready=1, which "< haReplicas" catches but "< 1" would
+	// silently pass. The old pods' cachesSynced latch + readiness failureThreshold=3 keep this stable.
+	if minReady < haReplicas {
+		t.Fatalf("fewer than %d healthy pods during the broken rollout (min ready=%d) — the maxUnavailable=0 "+
+			"guarantee failed (a healthy old replica was torn down)", haReplicas, minReady)
+	}
+	// (4) final re-assert: the gated pod is STILL NotReady, not a blip that recovered.
+	final, err := e.cs.CoreV1().Pods(e.ns).Get(e.ctx, gatedName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get gated pod %s at end: %v", gatedName, err)
+	}
+	if podReady(final) {
+		t.Fatalf("gated pod %s became Ready by the end of the window — the gate did not hold", gatedName)
+	}
+	t.Logf("cache-sync /readyz gate held: %s stayed NotReady (confirmed via the /readyz gate) across %s, no "+
+		"new-generation pod ever went Ready, min ready=%d", gatedName, sustain, minReady)
 
 	// Restore RBAC + roll again, and confirm full recovery (the Cleanup is the failsafe).
 	if err := restore(); err != nil {
@@ -625,11 +758,12 @@ func TestHACacheSyncRolloutGate(t *testing.T) {
 	t.Log("recovered: 2 ready manager pods after restoring RBAC")
 }
 
-// scanRolloutGate summarizes one poll of the manager pods during a rollout: ready = count of Ready pods;
-// gatedNew = a NEW-generation pod (pod-template-hash absent from oldHashes) is RUNNING but held NotReady (the
-// cache-sync gate, not a pull/schedule failure); sawNew = any new-generation pod exists at all. Extracted from
-// TestHACacheSyncRolloutGate to keep that test's cyclomatic complexity bounded.
-func scanRolloutGate(pods []corev1.Pod, oldHashes map[string]bool) (ready int, gatedNew, sawNew bool) {
+// scanSustained summarizes one poll of the sustained cache-sync window: ready = count of Ready pods;
+// gatedHeld = the tracked gated pod (by UID) is present and NotReady; newReady = the name of a NEW-generation
+// pod that has (wrongly) become Ready, or "" if none. Extracted to keep the test's cyclomatic complexity down.
+func scanSustained(
+	pods []corev1.Pod, oldHashes map[string]bool, gatedUID types.UID,
+) (ready int, gatedHeld bool, newReady string) {
 	for i := range pods {
 		p := &pods[i]
 		if p.DeletionTimestamp != nil {
@@ -637,16 +771,87 @@ func scanRolloutGate(pods []corev1.Pod, oldHashes map[string]bool) (ready int, g
 		}
 		isNew := false
 		if h := p.Labels["pod-template-hash"]; h != "" && !oldHashes[h] {
-			isNew, sawNew = true, true
+			isNew = true
 		}
-		switch {
-		case podReady(p):
+		if podReady(p) {
 			ready++
-		case isNew && containerRunning(p):
-			gatedNew = true // started (not a pull/schedule failure) yet held NotReady by the gate
+			if isNew {
+				newReady = p.Name
+			}
+			continue
+		}
+		if p.UID == gatedUID {
+			gatedHeld = true
 		}
 	}
-	return ready, gatedNew, sawNew
+	return ready, gatedHeld, newReady
+}
+
+// waitForGatedNewPod waits for a NEW-generation manager pod (a pod-template-hash absent before the rollout) to
+// appear Running-but-NotReady — the surge pod the cache-sync gate should hold — and returns its name + UID. It
+// FAILS immediately if a new-generation pod is already Ready: a healthy pod goes Ready, so a Ready new pod
+// means the gate is not holding.
+func (e *haEnv) waitForGatedNewPod(t *testing.T, oldHashes map[string]bool) (string, types.UID) {
+	t.Helper()
+	var name string
+	var uid types.UID
+	eventually(t, 60*time.Second, time.Second, "a new-generation pod held NotReady by the rollout", func() (bool, string) {
+		pods, err := e.managerPods()
+		if err != nil {
+			return false, err.Error()
+		}
+		for i := range pods {
+			p := &pods[i]
+			if p.DeletionTimestamp != nil {
+				continue
+			}
+			h := p.Labels["pod-template-hash"]
+			if h == "" || oldHashes[h] {
+				continue
+			}
+			if podReady(p) {
+				t.Fatalf("new-generation pod %s is Ready under broken cache RBAC — the cache-sync gate is not holding", p.Name)
+			}
+			if containerRunning(p) {
+				name, uid = p.Name, p.UID
+				return true, ""
+			}
+		}
+		return false, "no running new-generation pod yet"
+	})
+	return name, uid
+}
+
+// assertReadyzGateFailing confirms the pod is NotReady BECAUSE the /readyz cache-sync gate is failing — not a
+// crash or an unrelated probe — by reading /readyz?verbose through the API-server pod proxy. The manager's ONLY
+// readyz check is the cache-sync gate (cmd/main.go registers "readyz" = cacheSyncReadyCheck), so a failing
+// "readyz" check is the cache-sync gate holding the pod NotReady.
+func (e *haEnv) assertReadyzGateFailing(t *testing.T, pod string) {
+	t.Helper()
+	eventually(t, 30*time.Second, 2*time.Second, "/readyz cache-sync gate to report failing", func() (bool, string) {
+		// /readyz returns HTTP 500 while not ready, so DoRaw sets err for the non-2xx; the verbose body is
+		// still returned in raw. Only a truly empty body is a transport problem worth retrying.
+		raw, err := e.cs.CoreV1().RESTClient().Get().
+			Namespace(e.ns).Resource("pods").SubResource("proxy").
+			Name(pod+":8081").Suffix("readyz").Param("verbose", "").
+			DoRaw(e.ctx)
+		if len(raw) == 0 {
+			if err != nil {
+				return false, err.Error()
+			}
+			return false, "empty /readyz body"
+		}
+		// The verbose body lists each check on its own line: "[+]<name> ok" when passing, "[-]<name> failed:
+		// reason withheld" when failing (controller-runtime's summary line is always "healthz check failed",
+		// even for the readyz endpoint, so we match the per-check "[-]readyz" line — the specific, authoritative
+		// signal that our cache-sync gate is the one holding the pod NotReady).
+		body := string(raw)
+		if strings.Contains(body, "[-]readyz") {
+			return true, ""
+		}
+		return false, "readyz did not report the cache-sync gate failing: " + body
+	})
+	t.Logf("confirmed %s is held NotReady by the /readyz cache-sync gate", pod)
 }
 
 // containerRunning reports whether any of the pod's containers is currently in the Running state — used to


### PR DESCRIPTION
## What

Closes #230 — CI coverage for the active-passive HA design (`docs/high-availability.md`, ADR-0005 / #226). The topology and failover behaviours the design relies on were never asserted in CI, so a drift (dropped anti-affinity, changed replica count, misaligned PDB selector, a rollout strategy that tears down the healthy version, a `/readyz` gate that stops gating on cache-sync) would ship green.

Two layers:

### 1. Structural chart assertions (fast, no cluster) — `test-chart.yml`
A `helm template` + `python3` check on the rendered manifests asserts, with negative controls proving each guard actually fails on drift:
- exactly 1 Deployment + 1 PDB; **replicas == 2** (active-passive); **PDB `minAvailable` == 1**
- **soft** (preferred) pod anti-affinity — present, NOT hard (would wedge single-node scheduling); its `labelSelector` actually selects the manager pods; `topologyKey == kubernetes.io/hostname`
- **PDB selector ⊆ pod labels** (else `minAvailable` guards nothing) — with `not sel` / `not aff_sel` guards against a vacuous pass
- **effective `maxUnavailable` over 2 replicas == 0** and strategy != `Recreate` — the invariant the cache-sync rollout gate below depends on (a `>0` value would let a broken new pod evict the last healthy replica). Percentages round down as kube does.

### 2. Behavioural E2E against a chart-deployed 2-replica release — `test/e2e/ha_test.go` (`//go:build e2e_ha`)
A separate build tag from the kustomize single-replica Ginkgo `e2e` suite, run via `make test-e2e-ha`:
- **`TestHAGracefulFailover`** — delete the leader pod (lease released) → standby acquires the lease fast → the new leader actually reconciles a CR.
- **`TestHAUngracefulFailover`** — node-level SIGKILL (`crictl stop --timeout 0`, no SIGTERM/no lease release) → failover via the LeaseDuration-timeout path; RTO asserted in `[8s, LeaseDuration+20s]` (the ≥8s lower bound proves it took the timeout path, not a graceful release). Skips cleanly off-Kind.
- **`TestHAPDBEviction`** — cordon, evict one replica (allowed), assert the second eviction is **refused** by the PDB (fail-fast if wrongly allowed).
- **`TestHACacheSyncRolloutGate`** — break the manager ClusterRole's list/watch on the CRD group, force a rollout, and assert a NotReady new pod is gated by the cache-sync `/readyz` check while ≥1 Ready pod is preserved throughout (the healthy version is never torn down under a broken replica).

The E2E is destructive (kills/evicts pods, briefly breaks RBAC), self-heals to 2 ready replicas between cases, and runs last in `test-chart.yml` after the chart validations.

Also adds two crash-idempotency tests for the runtime ephemeris-push dedup path (`runtime_push_test.go`): a crash before the status marker persists must re-push the **same** epoch/marker (and the same pending `SatSwitchWithResync`), and once the marker is persisted a third call must not re-push.

## Validation
Built + run on a real local Kind cluster (2-replica chart release):
- graceful failover ~1s; ungraceful RTO ~16s (LeaseDuration=15s); PDB second eviction refused; cache-sync gate held (NotReady new pod gated, ready never < 1).
- Chart topology check: positive control passes; negative controls (replicas≠2, misaligned PDB/anti-affinity selector, hard anti-affinity, wrong topologyKey, `Recreate`, `maxUnavailable` 1 / 50%) all correctly FAIL; `25%`→0 / `0` / no-strategy pass.
- Controller suite green; module lint 0 issues; `e2e_ha` file gofmt/vet/lint clean.

## Adversarial review
Two independent adversarial reviewers; all actionable findings applied — the restart-reacquire ungraceful flake (compare the full holderIdentity, not the pod base, since any re-acquire mints a fresh uuid); leadership-moved-before-kill guard; RTO measured from the fault not the docker-exec setup; PDB fail-fast on a wrongly-allowed eviction; the `maxUnavailable`/`Recreate` strategy coupling made explicit in CI; idempotent RBAC restore.
