### PR TITLE
test(ntncellconfig): cover the epoch-only runtime-push freshness re-push (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through same-epoch deduplication, a propagation-input generation bump that fails
   closed while status is stale, and exactly one re-push after status catches up
   without a hot requeue (#252).
-- **The chart's PodDisruptionBudget renders only when `replicas > 1`.** A `minAvailable: 1` PDB over
+- **The runtime-push epoch-only freshness re-push now has manager-backed envtest coverage.**
+  An added step to that spec holds the ephemeris spec, generation, and propagation input hash
+  fixed while advancing only the propagated epoch, then requires exactly one re-push carrying the
+  new epoch and a persisted marker asserted **independently** of `runtimeEphemerisPushMarker` — so a
+  regression that drops `epoch` from the dedup key is caught rather than masked. Closes the
+  mutation gap the #252 coverage left open (#255). A `minAvailable: 1` PDB over
   a single replica blocks every eviction-API disruption (node drain, descheduler, autoscaler) — the
   one pod can never be evicted (it does not gate Deployment rolling updates, which delete pods
   directly). The chart defaults to 2 replicas, but a `replicas: 1` override previously still emitted

--- a/internal/controller/ntncellconfig_runtime_push_envtest_test.go
+++ b/internal/controller/ntncellconfig_runtime_push_envtest_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,7 +64,7 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 	cellKey := types.NamespacedName{Namespace: namespace, Name: cellName}
 	ephKey := types.NamespacedName{Namespace: namespace, Name: ephName}
 
-	It("deduplicates a settled epoch and pushes once after input currency catches up", func() {
+	It("deduplicates a settled epoch, re-pushes on an epoch-only freshness advance, and pushes once after input currency catches up", func() {
 		prov := newRuntimePushRecorder()
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:  scheme.Scheme,
@@ -178,6 +179,47 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 		Expect(condition).NotTo(BeNil())
 		Expect(condition.Message).To(Equal(settledMarker))
 
+		// Freshness (#255): advance ONLY the propagated epoch. The spec, generation, and the propagation input
+		// hash all stay fixed, so nothing but the fresh epoch can drive a re-push — this isolates the
+		// between-GP-fetch freshness path (#I-12) that keeps the gNB's SIB19 alive, which the dedup step above
+		// and the catch-up step below both over-determine (they hold the epoch fixed, or advance it together
+		// with a generation bump). Without this step the "drop epoch from the marker key" mutation stays green.
+		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
+		frozenGeneration := eph.Generation
+		frozenSpec := eph.Spec.DeepCopy()
+		frozenInputHash := eph.Status.PropagatedStatesInputHash
+		freshEpoch := initialEpoch + (2 * time.Minute).Milliseconds()
+		eph.Status.PropagatedStates[0].EpochUnixMs = freshEpoch
+		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
+
+		// Exactly one re-push, carrying the fresh epoch.
+		var freshPush provider.RuntimeUpdate
+		Eventually(prov.pushes, "10s").Should(Receive(&freshPush))
+		Expect(freshPush.EpochUnixMs).To(Equal(freshEpoch))
+
+		// Assert the persisted marker with a string built HERE, independent of runtimeEphemerisPushMarker — so
+		// a regression that drops epoch from that function's key is caught by THIS expectation rather than
+		// masked by it (the pre-existing catch-up assertion below computed its expectation with the function
+		// under test, so it could not). Also confirm the spec/generation/input-hash never moved.
+		freshMarker := fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
+			ephName, frozenGeneration, 25544, freshEpoch)
+		Eventually(func(g Gomega) {
+			currentEph := &ntnv1alpha1.SatelliteEphemeris{}
+			g.Expect(k8sClient.Get(context.Background(), ephKey, currentEph)).To(Succeed())
+			g.Expect(currentEph.Generation).To(Equal(frozenGeneration))
+			g.Expect(currentEph.Spec).To(Equal(*frozenSpec))
+			g.Expect(currentEph.Status.PropagatedStatesInputHash).To(Equal(frozenInputHash))
+
+			current := &ntnv1alpha1.NTNCellConfig{}
+			g.Expect(k8sClient.Get(context.Background(), cellKey, current)).To(Succeed())
+			fresh := meta.FindStatusCondition(current.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
+			g.Expect(fresh).NotTo(BeNil())
+			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(fresh.Reason).To(Equal("Pushed"))
+			g.Expect(fresh.Message).To(Equal(freshMarker))
+		}, "10s", "100ms").Should(Succeed())
+		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
+
 		// The apiserver owns generation: changing a propagation input bumps it while
 		// the status subresource still describes the old input set. The cached
 		// controller must fail closed and settle without pushing stale data.
@@ -202,9 +244,10 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 
 		// Once the producer status catches up to the new inputs and epoch, the status
 		// watch fans out exactly one fresh runtime push. The controller's own status
-		// write must not create a hot requeue or a third push.
+		// write must not create a hot requeue or a fourth push (first, epoch-only, catch-up).
 		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
-		nextEpoch := initialEpoch + (3 * time.Minute).Milliseconds()
+		catchUpGeneration := eph.Generation
+		nextEpoch := freshEpoch + (3 * time.Minute).Milliseconds()
 		eph.Status.PropagatedStatesInputHash = propagationInputHash(eph.Spec)
 		eph.Status.PropagatedStates[0].EpochUnixMs = nextEpoch
 		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
@@ -220,7 +263,8 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 			g.Expect(fresh).NotTo(BeNil())
 			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(fresh.Reason).To(Equal("Pushed"))
-			g.Expect(fresh.Message).To(Equal(runtimeEphemerisPushMarker(eph, &eph.Status.PropagatedStates[0])))
+			g.Expect(fresh.Message).To(Equal(fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
+				ephName, catchUpGeneration, 25544, nextEpoch)))
 		}, "10s", "100ms").Should(Succeed())
 		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
 	})

--- a/internal/controller/ntncellconfig_runtime_push_envtest_test.go
+++ b/internal/controller/ntncellconfig_runtime_push_envtest_test.go
@@ -188,6 +188,11 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 		frozenGeneration := eph.Generation
 		frozenSpec := eph.Spec.DeepCopy()
 		frozenInputHash := eph.Status.PropagatedStatesInputHash
+		// Also pin the CELL's generation: "only the epoch moved" relies on the cell's own spec (hence
+		// generation) staying untouched, so assert that explicitly below rather than leaving it implicit.
+		frozenCell := &ntnv1alpha1.NTNCellConfig{}
+		Expect(k8sClient.Get(context.Background(), cellKey, frozenCell)).To(Succeed())
+		frozenCellGeneration := frozenCell.Generation
 		freshEpoch := initialEpoch + (2 * time.Minute).Milliseconds()
 		eph.Status.PropagatedStates[0].EpochUnixMs = freshEpoch
 		Expect(k8sClient.Status().Update(context.Background(), eph)).To(Succeed())
@@ -212,6 +217,7 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 
 			current := &ntnv1alpha1.NTNCellConfig{}
 			g.Expect(k8sClient.Get(context.Background(), cellKey, current)).To(Succeed())
+			g.Expect(current.Generation).To(Equal(frozenCellGeneration))
 			fresh := meta.FindStatusCondition(current.Status.Conditions, ntnv1alpha1.ConditionEphemerisPushed)
 			g.Expect(fresh).NotTo(BeNil())
 			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))


### PR DESCRIPTION
## What

Closes #255 — adds the mutation-proven envtest coverage for the epoch-only runtime-push freshness re-push that #254's spec left uncovered.

#254's currency/freshness spec over-determines every re-push (the dedup step holds generation+epoch fixed; the catch-up step advances generation and epoch together), so a mutation that drops `epoch` from `runtimeEphemerisPushMarker` stays green — the epoch-driven freshness re-push (#I-12, which keeps the gNB's SIB19 alive between GP fetches) is never isolated.

This adds one step that isolates the epoch advance: from a settled `EphemerisPushed=True`/`Reason=Pushed` state, hold the ephemeris spec, generation, and propagation input hash fixed and advance ONLY `status.propagatedStates[0].EpochUnixMs`, then require exactly one re-push carrying the new epoch and a persisted marker asserted **independently** of `runtimeEphemerisPushMarker`. It also fixes the pre-existing catch-up assertion — which computed its expectation with the function under test, and so could not catch a regression inside it — to build the expected marker independently.

## Validation

- Focused envtest passes (`-ginkgo.focus="NTNCellConfig runtime-push lifecycle"`, 15.3s); full controller suite green (16.4s); gofmt + vet clean.
- **Mutation sanity**: dropping `epoch` from the `runtimeEphemerisPushMarker` key fails the focused test at the epoch-only push assertion — proving the coverage catches the exact regression #255 targets.
