### PR TITLE
feat(ephemeris): durable last-good OMM cache for restart/failover outage continuity

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -167,7 +167,9 @@ jobs:
           echo "NetworkPolicy egress assertion OK (server-normalized, 'to'-less .spec.egress: 53 TCP+UDP, 443/9090/8001 TCP)"
 
       - name: Deploy manager via Helm
-        run: make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set manager.image.pullPolicy=Never"
+        # ha-ci-values.yaml adds the celestrak-mock host to --ephemeris-allowed-private-hosts so
+        # TestHAOutageContinuityAcrossFailover can warm the ephemeris cache from the in-cluster mock.
+        run: make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set manager.image.pullPolicy=Never --values test/e2e/fixtures/ha-ci-values.yaml"
 
       - name: Check Helm release status
         run: make helm-status

--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Defaults to a Kind en
 	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind teardown"; fi
 
 .PHONY: test-e2e-ha
-test-e2e-ha: ## Run the HA E2E suite (#230) against an ALREADY-DEPLOYED chart release (2 replicas, leader election). Set HA_NAMESPACE (default ntn-operators-system). Does NOT create a cluster or deploy — run `make helm-deploy` first.
-	go test -tags=e2e_ha -count=1 ./test/e2e/ -run '^TestHA' -v -timeout 20m
+test-e2e-ha: ## Run the HA E2E suite (#230 + durable-cache outage continuity) against an ALREADY-DEPLOYED chart release (2 replicas, leader election). Set HA_NAMESPACE (default ntn-operators-system). Does NOT create a cluster or deploy — run `make helm-deploy` first. Timeout is 30m: TestHAOutageContinuityAcrossFailover must observe continuity BEYOND propagationEpochLead (5m) across a real leader failover.
+	go test -tags=e2e_ha -count=1 ./test/e2e/ -run '^TestHA' -v -timeout 30m
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/docs/adr/0007-durable-omm-cache.md
+++ b/docs/adr/0007-durable-omm-cache.md
@@ -1,0 +1,68 @@
+# ADR 0007 — Durable last-good OMM cache for restart / leader-failover outage continuity
+
+- Status: **Accepted** (implemented on `feat/omm-persist-restart-continuity`)
+- Date: 2026-07-30
+- Deciders: @thc1006
+- Builds on: ADR 0006 (decouple propagation from pass prediction — the propagation heartbeat this cache feeds), ADR 0005 (cluster-scope orchestration — the SatelliteEphemeris → NTNCellConfig runtime push that consumes the propagated states)
+
+## Context
+
+`SatelliteEphemerisReconciler` fetches GP/OMM element sets from CelesTrak/Space-Track, parses them to `sgp4.OMM`, and re-propagates to fresh ECEF on the ~3-minute propagation heartbeat so `status.propagatedStates` (and the downstream `ntn_config_update` runtime push) always carry an epoch in the near future. To stay polite to the upstream it fetches at most every `minRefreshInterval` (2 h) and, on a fetch failure, **serves the last-good OMMs from an in-memory cache** (`ommCache sync.Map`) so a source outage does not stall SIB19 — this is the I-18 continuity behaviour.
+
+The gap: **that cache is in-memory only.** A process restart or a leader-election failover starts the new active reconciler with an empty cache. `status.propagatedStates` holds the ECEF *output* of a past propagation but **not** the orbital *elements* (the SGP4 input), so status alone cannot re-propagate to a new epoch. Concretely: during a sustained upstream outage, if the current leader dies, the standby (which never reconciled, so has an empty cache) takes over with nothing to propagate. Once the last-pushed epoch expires (~`propagationEpochLead`, 5 min), SIB19 goes stale for the rest of the outage even though the operator is healthy — a single-process-memory dependency in an otherwise HA design.
+
+## Decision Drivers
+
+- **D1. HA correctness.** Active-passive HA (ADR/#230) promises continuity across a leader loss. An in-memory-only cache silently breaks that promise precisely when it matters (leader loss *during* an outage).
+- **D2. Do not weaken the freshness contract.** Restart continuity must not become a way to resurrect arbitrarily stale data; the existing window / backoff / `maxEpochAge` gates must still apply.
+- **D3. Minimal blast radius.** The live fetch/propagate path must not regress; persistence is an enhancement, best-effort, and off the hot path.
+- **D4. No new RBAC surface or cluster-wide caching.** Match the codebase's existing "uncached one-off read" discipline (the Space-Track Secret is read via `APIReader` to avoid a cluster-wide Secret informer).
+
+## Options considered
+
+- **A — Status subresource (store elements in `status`).** Rejected: bloats status with raw OMM fields for every tracked NORAD, couples a large data blob to the frequently-written status object, and status is the wrong home for controller-private recovery state.
+- **B — Per-CR owner-ref'd ConfigMap (CHOSEN).** One `<name>-omm-cache` ConfigMap per SatelliteEphemeris holding the tracked OMMs as JSON, owner-ref'd for garbage collection.
+- **C — Secret instead of ConfigMap.** Rejected as the default (see visibility rationale); kept as a documented follow-up if an operator classifies element sets as sensitive.
+- **D — Dedicated CRD for the cache.** Rejected: a CRD is desired-state API; this is internal recovery state, not user-facing spec.
+- **E — External store (etcd lease / object store).** Rejected: new infra dependency for a problem the API server already solves.
+
+## Decision
+
+Adopt **Option B**. On every successful fetch the reconciler writes the tracked, capped OMM set to a per-CR ConfigMap; on a cold reconcile (empty in-memory cache) it hydrates the cache from that ConfigMap before deciding fetch-vs-serve.
+
+### Design
+
+- **Minimal payload.** Persist only `FilterOMMs(result.OMMs, spec.satellites.noradIDs)` capped at `maxPropagatedStates` (128) — the same set `propagateStates` would use, never the full upstream response. `sgp4.OMM`'s CelesTrak JSON tags let it round-trip losslessly through `sgp4.ParseOMMs` (its `EPOCH` is a string, so no time-precision loss).
+- **Identity + integrity metadata** (annotations): source identity (`fetchInputKey` = source type+URL), original fetch time (RFC3339Nano), payload sha256 digest, and owner UID. Restore refuses unless the digest is intact **and** the fetchKey and UID match the live object — so a hand-edit, a source change, or a delete-recreate never restores wrong or orphaned data.
+- **Freshness preserved.** The restored entry keeps its ORIGINAL fetch time, so the normal window / backoff / `maxEpochAge` gates apply exactly as for a warm cache. Restore removes the cold-start cliff and nothing more; it cannot resurrect data the freshness gates would reject.
+- **GC via owner reference.** The ConfigMap is `SetControllerReference`'d to its SatelliteEphemeris, so k8s garbage-collects it on CR deletion. The controller therefore needs `configmaps` `get;create;update` — **no delete** verb.
+- **No resourceVersion churn.** Persist no-ops when the payload digest is unchanged, so the ~2 h fetch cadence does not rewrite the ConfigMap every cycle (consistent with the #204-G3 no-op-write discipline).
+- **Uncached reads.** Both the persist Get-before-write and the restore Get go through `APIReader` (falling back to the cached client only when unwired, e.g. tests), so no cluster-wide ConfigMap informer is started and `configmaps list;watch` is not required. On a cold leader this also reads the ConfigMap the previous leader wrote even before the informer cache would have synced.
+- **Size bound.** Payloads over `maxOMMCacheBytes` (900 KiB, under the 1 MiB ConfigMap limit) skip persistence (logged); the live warm cache is unaffected. Unreachable at the 128-state cap today, kept as a defensive guard.
+
+### Visibility: ConfigMap, not Secret
+
+Orbital element sets for tracked satellites are **public** data (they come from public CelesTrak/Space-Track catalogs), so a ConfigMap exposes nothing sensitive — and `NTNCellConfig` already persists derived ephemeris to a ConfigMap, so this adds no new exposure class. Space-Track *credentials* remain in their Secret and are never written here (only the resulting elements are). If a specific deployment classifies its element sets as sensitive (e.g. a private/supplemental catalog), migrating the cache to a Secret is a mechanical follow-up: same keys, same validation, `Secret` in place of `ConfigMap`.
+
+## Consequences
+
+**Positive**
+- Restart / leader-failover continuity through a sustained upstream outage: a cold process re-propagates from the last-good elements instead of falling off the "nothing to propagate" cliff.
+- No new infra, no new cluster-wide caching, minimal RBAC (`configmaps get;create;update`).
+- Best-effort and off the hot path: a persist/restore failure degrades to today's behaviour, never fails a reconcile.
+
+**Negative / limitations**
+- One extra ConfigMap per SatelliteEphemeris (small; GC'd with the CR).
+- **Name truncation edge:** CR names are bounded to the 253-char k8s limit by truncation. Two CR names longer than 243 chars sharing a 243-char prefix in the same namespace would map to the same cache ConfigMap; the restore UID gate prevents wrong-data restore, so the only effect is that the losing CR forgoes restart-continuity. Acceptable given k8s names are ≤253 and such collisions are pathological.
+- Persistence lags the in-memory cache by one successful fetch (the cache is written after a fetch, not on every propagation) — restart continuity is bounded by `maxEpochAge` from the last *fetch*, which is the intended freshness bound anyway.
+
+## Testing
+
+- **Unit** (`satelliteephemeris_ommcache_persist_test.go`): persist/restore round-trip incl. nanosecond fetch-time and digest integrity; restore refuses digest-corrupt / missing-label / empty / UID-mismatch / fetchKey-mismatch inputs; no-op on identical digest; owner-ref for GC; oversize skip; name truncation; payload filter+cap; and a cold-start integration test that reconciles a fresh reconciler (empty cache) against a simulated outage and asserts the epoch keeps advancing — it fails if the restore hook is removed.
+- **E2E acceptance** (`TestHAOutageContinuityAcrossFailover`, tag `e2e_ha`): warm from the in-cluster mock, scale the mock to zero (total outage), verify the epoch advances, kill the current leader, and verify the cold new leader keeps advancing the epoch beyond `propagationEpochLead` and stays in the future (runtime-push ready). This is the acceptance gate for "outage continuity solved".
+
+## References
+
+- `internal/controller/satelliteephemeris_ommcache_persist.go` (implementation)
+- `internal/controller/satelliteephemeris_controller.go` — `acquireOMMs` (restore hook), `obtainOMMs` (persist hook + fetch-failure fallback)
+- ADR 0006 (propagation heartbeat), #230 (active-passive HA)

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -834,6 +834,11 @@ func (r *SatelliteEphemerisReconciler) acquireOMMs(
 ) (ommFetchOutcome, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
+	// Cold-start / failover continuity: hydrate last-good OMMs from the persisted ConfigMap
+	// before deciding fetch-vs-serve, so a restart mid-outage still re-propagates. No-ops when
+	// warm or when nothing valid is persisted.
+	r.restoreOMMCache(ctx, req, eph, fetchInputKey(eph.Spec))
+
 	switch c, why := r.cacheServe(req.NamespacedName, eph, now, effectiveInterval); why {
 	case cacheServeWindow:
 		log.V(1).Info("re-propagating from cached OMMs; GP source not contacted",
@@ -1642,6 +1647,10 @@ func (r *SatelliteEphemerisReconciler) obtainOMMs(
 
 	// A successful fetch clears the backoff.
 	r.ommCache.Store(req.NamespacedName, cachedFetch{result: result, fetchKey: fetchKey, uid: eph.UID})
+	// Persist the tracked last-good OMMs durably so a later cold process (restart / leader
+	// failover) can re-propagate through a sustained upstream outage. Best-effort; never fails
+	// the reconcile.
+	r.persistOMMCache(ctx, eph, result, fetchKey)
 	return ommFetchOutcome{result: result}, nil, nil
 }
 

--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// Durable last-good OMM cache: persists tracked OMMs to a controller-owned ConfigMap so a cold
+// process (restart / leader failover) can re-propagate through a sustained upstream outage,
+// instead of having nothing to propagate once the last pushed epoch expires. Store rationale
+// (ConfigMap vs Secret) and alternatives: docs/adr/0007-durable-omm-cache.md.
+
+const (
+	ommCacheDataKey    = "omms.json"
+	ommCacheLabelKey   = "ntn.operators.dev/omm-cache"
+	ommCacheLabelValue = "true"
+	// Recorded so a restore never trusts data from a different source, object, or a corrupt payload.
+	ommCacheAnnFetchKey  = "ntn.operators.dev/omm-fetch-key"  // source identity (fetchInputKey)
+	ommCacheAnnFetchedAt = "ntn.operators.dev/omm-fetched-at" // original fetch time (RFC3339Nano)
+	ommCacheAnnDigest    = "ntn.operators.dev/omm-digest"     // sha256 of the payload
+	ommCacheAnnUID       = "ntn.operators.dev/omm-owner-uid"  // delete-recreate guard
+	ommCacheAnnCount     = "ntn.operators.dev/omm-count"
+
+	ommCacheConfigMapSuffix = "-omm-cache"
+	maxOMMCacheBytes        = 900 * 1024 // under the 1 MiB ConfigMap limit; larger sets skip persist
+	maxConfigMapNameLen     = 253
+)
+
+// The per-CR cache ConfigMap is owner-ref'd to its SatelliteEphemeris, so k8s garbage-collects it
+// on CR deletion — the controller never deletes it itself, hence no delete verb.
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update
+
+// readerOrClient returns the uncached APIReader when wired, else the cached client (some tests
+// leave APIReader nil).
+func (r *SatelliteEphemerisReconciler) readerOrClient() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// ommCacheConfigMapName derives the per-CR cache ConfigMap name, bounded to the k8s name limit.
+// Names over the limit are truncated; the restore path UID-gates, so a (pathological) truncation
+// collision between two >243-char names never restores wrong data — see ADR-0007.
+func ommCacheConfigMapName(ephName string) string {
+	if len(ephName)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
+		ephName = ephName[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
+	}
+	return ephName + ommCacheConfigMapSuffix
+}
+
+// ommCachePayload is the tracked, capped set propagateStates would use (never the full GP
+// response). sgp4.OMM's CelesTrak JSON tags let it round-trip through sgp4.ParseOMMs on restore.
+func ommCachePayload(result ephemeris.GPFetchResult, eph *ntnv1alpha1.SatelliteEphemeris) []sgp4.OMM {
+	var norad []int
+	if eph.Spec.Satellites != nil {
+		norad = eph.Spec.Satellites.NoradIDs
+	}
+	omms := ephemeris.FilterOMMs(result.OMMs, norad)
+	if len(omms) > maxPropagatedStates {
+		omms = omms[:maxPropagatedStates]
+	}
+	return omms
+}
+
+func ommDigest(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// persistOMMCache best-effort writes the last-good tracked OMMs to the owner-ref'd ConfigMap.
+// Failures are logged and swallowed (persistence is a restart enhancement, not the live path);
+// identical payloads no-op so the ~2 h fetch cadence does not churn resourceVersion (#204-G3).
+func (r *SatelliteEphemerisReconciler) persistOMMCache(
+	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, result ephemeris.GPFetchResult, fetchKey string,
+) {
+	log := logf.FromContext(ctx)
+	omms := ommCachePayload(result, eph)
+	if len(omms) == 0 {
+		return
+	}
+	data, err := json.Marshal(omms)
+	if err != nil {
+		log.V(1).Info("omm-cache: marshal failed; skipping persist", "err", err.Error())
+		return
+	}
+	if len(data) > maxOMMCacheBytes {
+		log.Info("omm-cache: payload over bound; skipping restart-continuity persist (warm cache unaffected)",
+			"bytes", len(data), "satellites", len(omms))
+		return
+	}
+	digest := ommDigest(data)
+	key := client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+
+	// Read uncached (APIReader) so configmaps get suffices and we do not start an informer that
+	// caches every ConfigMap in the cluster; writes still go through the cached client. Mirrors
+	// the Secret read. Falls back to the cached client only when APIReader is unwired (some tests).
+	reader := r.readerOrClient()
+	cm := &corev1.ConfigMap{}
+	getErr := reader.Get(ctx, key, cm)
+	switch {
+	case apierrors.IsNotFound(getErr):
+		cm = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
+		stampOMMCache(cm, eph, fetchKey, digest, len(omms), string(data), result.FetchedAt)
+		if err := controllerutil.SetControllerReference(eph, cm, r.Scheme); err != nil {
+			log.V(1).Info("omm-cache: owner ref failed; skipping persist", "err", err.Error())
+			return
+		}
+		if err := r.Create(ctx, cm); err != nil && !apierrors.IsAlreadyExists(err) {
+			log.V(1).Info("omm-cache: create failed; skipping persist", "err", err.Error())
+		}
+	case getErr != nil:
+		log.V(1).Info("omm-cache: get failed; skipping persist", "err", getErr.Error())
+	default:
+		if cm.Annotations[ommCacheAnnDigest] == digest && cm.Data[ommCacheDataKey] != "" {
+			return // unchanged
+		}
+		stampOMMCache(cm, eph, fetchKey, digest, len(omms), string(data), result.FetchedAt)
+		_ = controllerutil.SetControllerReference(eph, cm, r.Scheme) // adopt for GC if pre-existing
+		if err := r.Update(ctx, cm); err != nil {
+			log.V(1).Info("omm-cache: update failed; skipping persist", "err", err.Error())
+		}
+	}
+}
+
+func stampOMMCache(cm *corev1.ConfigMap, eph *ntnv1alpha1.SatelliteEphemeris, fetchKey, digest string, count int, data string, fetchedAt time.Time) {
+	if cm.Labels == nil {
+		cm.Labels = map[string]string{}
+	}
+	cm.Labels[ommCacheLabelKey] = ommCacheLabelValue
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+	cm.Annotations[ommCacheAnnFetchKey] = fetchKey
+	cm.Annotations[ommCacheAnnFetchedAt] = fetchedAt.UTC().Format(time.RFC3339Nano)
+	cm.Annotations[ommCacheAnnDigest] = digest
+	cm.Annotations[ommCacheAnnUID] = string(eph.UID)
+	cm.Annotations[ommCacheAnnCount] = strconv.Itoa(count)
+	cm.Data = map[string]string{ommCacheDataKey: data}
+}
+
+// restoreOMMCache hydrates the in-memory cache from the persisted ConfigMap when it is cold for
+// this key, returning true on hydration. It refuses unless the digest is intact and the source
+// identity (fetchKey) and owner UID match the live object, so a source edit or delete-recreate
+// never restores wrong/orphaned data. The entry keeps its ORIGINAL FetchedAt, so the normal
+// window/backoff/freshness gates still apply — restore removes the cold-start cliff, nothing more.
+func (r *SatelliteEphemerisReconciler) restoreOMMCache(
+	ctx context.Context, req ctrl.Request, eph *ntnv1alpha1.SatelliteEphemeris, fetchKey string,
+) bool {
+	log := logf.FromContext(ctx)
+	if _, ok := r.cachedOMMResult(req.NamespacedName); ok {
+		return false // already warm
+	}
+	cm := &corev1.ConfigMap{}
+	if err := r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+		return false
+	}
+	data := cm.Data[ommCacheDataKey]
+	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue || data == "" {
+		return false
+	}
+	if cm.Annotations[ommCacheAnnDigest] != ommDigest([]byte(data)) {
+		log.Info("omm-cache: digest mismatch; ignoring (corrupt or hand-edited)")
+		return false
+	}
+	if cm.Annotations[ommCacheAnnUID] != string(eph.UID) || cm.Annotations[ommCacheAnnFetchKey] != fetchKey {
+		return false // orphaned by delete-recreate, or a different source — do not restore
+	}
+	omms, err := sgp4.ParseOMMs([]byte(data))
+	if err != nil || len(omms) == 0 {
+		log.V(1).Info("omm-cache: payload unparseable; ignoring", "err", err)
+		return false
+	}
+	// Unknown fetch time → zero, i.e. very old, so the next reconcile fetches and only serves
+	// this on failure; restored data is never treated as freshly fetched.
+	fetchedAt, _ := time.Parse(time.RFC3339Nano, cm.Annotations[ommCacheAnnFetchedAt])
+	r.ommCache.Store(req.NamespacedName, cachedFetch{
+		result:   ephemeris.GPFetchResult{OMMs: omms, SatelliteCount: len(omms), FetchedAt: fetchedAt},
+		fetchKey: fetchKey,
+		uid:      eph.UID,
+	})
+	log.Info("omm-cache: hydrated last-good OMMs after cold start", "satellites", len(omms))
+	return true
+}

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// ommCacheScheme is makeScheme + corev1 (the cache lives in a ConfigMap).
+func ommCacheScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := makeScheme(t)
+	if err := corev1.AddToScheme(sch); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	return sch
+}
+
+func newOMMCacheEph(name string, uid types.UID) *ntnv1alpha1.SatelliteEphemeris {
+	return &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: uid, Generation: 1},
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{
+				Type: "CelesTrak", URL: "https://celestrak.org/test",
+				RefreshInterval: metav1.Duration{Duration: 2 * time.Hour},
+			},
+		},
+	}
+}
+
+func ommResultAt(fetchedAt time.Time) ephemeris.GPFetchResult {
+	omm := issOMMForTest()
+	omm.EpochStr = fetchedAt.Format("2006-01-02T15:04:05.000000")
+	return ephemeris.GPFetchResult{OMMs: []sgp4.OMM{omm}, SatelliteCount: 1, FetchedAt: fetchedAt}
+}
+
+// TestOMMCache_PersistRestoreRoundTrip proves a persisted ConfigMap hydrates the in-memory cache
+// with byte-identical OMMs and the original fetch metadata — the whole point of the durable cache.
+func TestOMMCache_PersistRestoreRoundTrip(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-rt", "uid-rt")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+
+	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 123456000, time.UTC)
+	result := ommResultAt(fetchedAt)
+	fetchKey := fetchInputKey(eph.Spec)
+	r.persistOMMCache(ctx, eph, result, fetchKey)
+
+	// The ConfigMap must exist and carry the identity/integrity metadata.
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+		t.Fatalf("persist did not create the cache ConfigMap: %v", err)
+	}
+	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue {
+		t.Fatalf("cache ConfigMap missing marker label")
+	}
+	if cm.Annotations[ommCacheAnnFetchKey] != fetchKey {
+		t.Fatalf("fetchKey annotation = %q, want %q", cm.Annotations[ommCacheAnnFetchKey], fetchKey)
+	}
+	if cm.Annotations[ommCacheAnnUID] != string(eph.UID) {
+		t.Fatalf("uid annotation = %q, want %q", cm.Annotations[ommCacheAnnUID], eph.UID)
+	}
+	if cm.Annotations[ommCacheAnnDigest] != ommDigest([]byte(cm.Data[ommCacheDataKey])) {
+		t.Fatalf("digest annotation does not match stored payload")
+	}
+
+	// Restore into a COLD cache must hydrate it, returning true.
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatalf("restore returned false on a valid cold cache")
+	}
+	got, ok := r.cachedOMMResult(key)
+	if !ok {
+		t.Fatalf("restore did not populate the in-memory cache")
+	}
+	if got.fetchKey != fetchKey || got.uid != eph.UID {
+		t.Fatalf("restored identity = (%q,%q), want (%q,%q)", got.fetchKey, got.uid, fetchKey, eph.UID)
+	}
+	if got.result.SatelliteCount != 1 || len(got.result.OMMs) != 1 {
+		t.Fatalf("restored OMM count = %d, want 1", len(got.result.OMMs))
+	}
+	if got.result.OMMs[0].NoradCatID != result.OMMs[0].NoradCatID || got.result.OMMs[0].EpochStr != result.OMMs[0].EpochStr {
+		t.Fatalf("restored OMM does not round-trip: got norad=%d epoch=%q",
+			got.result.OMMs[0].NoradCatID, got.result.OMMs[0].EpochStr)
+	}
+	// FetchedAt must survive so the normal window/freshness gates still apply post-restore.
+	if !got.result.FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("restored FetchedAt = %s, want %s (restore must not reset the fetch time)", got.result.FetchedAt.UTC(), fetchedAt)
+	}
+	// nextFetchAttempt/lastFetchErr must be zero so the next reconcile is free to fetch.
+	if !got.nextFetchAttempt.IsZero() || got.lastFetchErr != nil || got.fetchFailures != 0 {
+		t.Fatalf("restore must not carry backoff state: nextFetch=%s err=%v failures=%d",
+			got.nextFetchAttempt, got.lastFetchErr, got.fetchFailures)
+	}
+}
+
+// TestOMMCache_RestoreRejectsInvalid proves restore refuses corrupt or wrong-owner/source data,
+// so a tampered or orphaned ConfigMap never poisons the cache.
+func TestOMMCache_RestoreRejectsInvalid(t *testing.T) {
+	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	base := newOMMCacheEph("eph-rej", "uid-rej")
+	fetchKey := fetchInputKey(base.Spec)
+
+	// mutate applies a tampering to the persisted ConfigMap; restoreArgs overrides the eph/fetchKey.
+	cases := []struct {
+		name     string
+		mutate   func(cm *corev1.ConfigMap)
+		eph      *ntnv1alpha1.SatelliteEphemeris
+		fetchKey string
+	}{
+		{name: "digest-corrupt", mutate: func(cm *corev1.ConfigMap) {
+			cm.Data[ommCacheDataKey] += " " // payload no longer matches the digest annotation
+		}, eph: base, fetchKey: fetchKey},
+		{name: "missing-label", mutate: func(cm *corev1.ConfigMap) {
+			delete(cm.Labels, ommCacheLabelKey)
+		}, eph: base, fetchKey: fetchKey},
+		{name: "empty-data", mutate: func(cm *corev1.ConfigMap) {
+			cm.Data[ommCacheDataKey] = ""
+		}, eph: base, fetchKey: fetchKey},
+		{name: "uid-mismatch", mutate: func(cm *corev1.ConfigMap) {}, eph: newOMMCacheEph("eph-rej", "uid-OTHER"), fetchKey: fetchKey},
+		{name: "fetchkey-mismatch", mutate: func(cm *corev1.ConfigMap) {}, eph: base, fetchKey: "some/other/source"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sch := ommCacheScheme(t)
+			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(base).Build()
+			r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+			ctx := context.Background()
+			key := types.NamespacedName{Namespace: base.Namespace, Name: base.Name}
+
+			r.persistOMMCache(ctx, base, ommResultAt(fetchedAt), fetchKey)
+			cm := &corev1.ConfigMap{}
+			cmKey := types.NamespacedName{Namespace: base.Namespace, Name: ommCacheConfigMapName(base.Name)}
+			if err := cli.Get(ctx, cmKey, cm); err != nil {
+				t.Fatalf("get cache cm: %v", err)
+			}
+			tc.mutate(cm)
+			if err := cli.Update(ctx, cm); err != nil {
+				t.Fatalf("update cache cm: %v", err)
+			}
+
+			if r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, tc.eph, tc.fetchKey) {
+				t.Fatalf("restore accepted an invalid cache (%s)", tc.name)
+			}
+			if _, ok := r.cachedOMMResult(key); ok {
+				t.Fatalf("restore populated the cache from invalid data (%s)", tc.name)
+			}
+		})
+	}
+}
+
+// TestOMMCache_RestoreNoopWhenWarm proves a warm in-memory cache is never overwritten by a stale
+// persisted copy (restore is a cold-start bootstrap only).
+func TestOMMCache_RestoreNoopWhenWarm(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-warm", "uid-warm")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	fetchKey := fetchInputKey(eph.Spec)
+
+	// Persist an OLD copy, then warm the cache with a NEWER in-memory entry.
+	r.persistOMMCache(ctx, eph, ommResultAt(time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)), fetchKey)
+	warm := cachedFetch{result: ommResultAt(time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)), fetchKey: fetchKey, uid: eph.UID}
+	r.ommCache.Store(key, warm)
+
+	if r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatalf("restore ran against a warm cache")
+	}
+	got, _ := r.cachedOMMResult(key)
+	if !got.result.FetchedAt.Equal(warm.result.FetchedAt) {
+		t.Fatalf("restore clobbered the warm cache: FetchedAt=%s want %s", got.result.FetchedAt.UTC(), warm.result.FetchedAt.UTC())
+	}
+}
+
+// TestOMMCache_PersistNoopOnIdenticalDigest proves an unchanged payload does not rewrite the
+// ConfigMap — the ~2h fetch cadence must not churn resourceVersion (#204-G3).
+func TestOMMCache_PersistNoopOnIdenticalDigest(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-noop", "uid-noop")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	fetchKey := fetchInputKey(eph.Spec)
+
+	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	r.persistOMMCache(ctx, eph, ommResultAt(fetchedAt), fetchKey)
+	rv1 := getResourceVersion(t, cli, cmKey)
+
+	r.persistOMMCache(ctx, eph, ommResultAt(fetchedAt), fetchKey) // identical payload
+	if rv2 := getResourceVersion(t, cli, cmKey); rv2 != rv1 {
+		t.Fatalf("identical persist rewrote the ConfigMap: rv %s -> %s", rv1, rv2)
+	}
+
+	// A changed payload MUST rewrite it.
+	changed := ommResultAt(fetchedAt)
+	changed.OMMs[0].NoradCatID = 99999
+	r.persistOMMCache(ctx, eph, changed, fetchKey)
+	if rv3 := getResourceVersion(t, cli, cmKey); rv3 == rv1 {
+		t.Fatalf("changed persist did not rewrite the ConfigMap (rv still %s)", rv1)
+	}
+}
+
+// TestOMMCache_PersistSetsOwnerRefForGC proves the ConfigMap is owner-ref'd to its CR so k8s
+// garbage-collects it on CR deletion (the controller has no delete verb).
+func TestOMMCache_PersistSetsOwnerRefForGC(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-gc", "uid-gc")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+
+	r.persistOMMCache(ctx, eph, ommResultAt(time.Now().UTC()), fetchInputKey(eph.Spec))
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+		t.Fatalf("get cm: %v", err)
+	}
+	if len(cm.OwnerReferences) != 1 {
+		t.Fatalf("want exactly 1 owner ref, got %d", len(cm.OwnerReferences))
+	}
+	ref := cm.OwnerReferences[0]
+	if ref.UID != eph.UID || ref.Name != eph.Name || ref.Kind != "SatelliteEphemeris" {
+		t.Fatalf("owner ref = %+v, want controller SatelliteEphemeris/%s/%s", ref, eph.Name, eph.UID)
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("owner ref must be a controller ref for GC")
+	}
+}
+
+// TestOMMCache_PersistSkipsOversizePayload proves an over-bound payload is skipped (no ConfigMap,
+// no panic) so a pathological set never breaches the 1 MiB ConfigMap limit.
+func TestOMMCache_PersistSkipsOversizePayload(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-big", "uid-big")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+
+	result := ommResultAt(time.Now().UTC())
+	result.OMMs[0].ObjectName = strings.Repeat("A", maxOMMCacheBytes+1) // force marshal past the bound
+	r.persistOMMCache(ctx, eph, result, fetchInputKey(eph.Spec))
+
+	cm := &corev1.ConfigMap{}
+	err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("oversize payload must not create a ConfigMap; got err=%v", err)
+	}
+}
+
+// TestOMMCache_ConfigMapNameTruncation proves the derived name always fits the k8s name limit.
+func TestOMMCache_ConfigMapNameTruncation(t *testing.T) {
+	short := ommCacheConfigMapName("eph-a")
+	if short != "eph-a"+ommCacheConfigMapSuffix {
+		t.Fatalf("short name = %q", short)
+	}
+	long := ommCacheConfigMapName(strings.Repeat("x", 300))
+	if len(long) > maxConfigMapNameLen {
+		t.Fatalf("truncated name len = %d, exceeds %d", len(long), maxConfigMapNameLen)
+	}
+}
+
+// TestOMMCache_PayloadFilteredAndCapped proves the persisted set honors the NORAD filter and the
+// maxPropagatedStates cap (never the full upstream response).
+func TestOMMCache_PayloadFilteredAndCapped(t *testing.T) {
+	eph := newOMMCacheEph("eph-pl", "uid-pl")
+	eph.Spec.Satellites = &ntnv1alpha1.SatelliteSelector{NoradIDs: []int{25544}}
+
+	omms := make([]sgp4.OMM, 0, 3)
+	for i := range 3 {
+		o := issOMMForTest()
+		o.NoradCatID = 25544 + i // only 25544 is selected
+		omms = append(omms, o)
+	}
+	got := ommCachePayload(ephemeris.GPFetchResult{OMMs: omms}, eph)
+	if len(got) != 1 || got[0].NoradCatID != 25544 {
+		t.Fatalf("payload not filtered to NORAD 25544: %+v", got)
+	}
+
+	// Cap: an unfiltered oversize set is bounded to maxPropagatedStates.
+	ephAll := newOMMCacheEph("eph-cap", "uid-cap")
+	over := make([]sgp4.OMM, maxPropagatedStates+5)
+	for i := range over {
+		over[i] = issOMMForTest()
+		over[i].NoradCatID = 40000 + i
+	}
+	if capped := ommCachePayload(ephemeris.GPFetchResult{OMMs: over}, ephAll); len(capped) != maxPropagatedStates {
+		t.Fatalf("payload cap = %d, want %d", len(capped), maxPropagatedStates)
+	}
+}
+
+// TestReconcile_ColdStartRestoresAndPropagatesDuringOutage is the unit-level proof of the mandated
+// acceptance scenario: a warm fetch persists the cache; a fresh process (empty in-memory cache)
+// facing a total upstream outage restores from the ConfigMap and keeps advancing the epoch — both
+// while the refresh window is fresh (direct serve) AND after it expires (fetch fails → fallback).
+func TestReconcile_ColdStartRestoresAndPropagatesDuringOutage(t *testing.T) {
+	sch := ommCacheScheme(t)
+	t0 := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	clock := t0
+	eph := newOMMCacheEph("eph-cold", "uid-cold")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).WithStatusSubresource(eph).Build()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	ctx := context.Background()
+
+	// ---- Phase A: warm process, upstream UP → fetch, persist, propagate.
+	warmFetcher := &mockGPFetcher{result: ommResultAt(t0)}
+	rWarm := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(200), Fetcher: warmFetcher,
+		Now: func() time.Time { return clock },
+	}
+	if _, err := rWarm.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("warm reconcile: %v", err)
+	}
+	if warmFetcher.callCount() == 0 {
+		t.Fatalf("warm phase never contacted upstream")
+	}
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+		t.Fatalf("warm phase did not persist the cache ConfigMap: %v", err)
+	}
+
+	// ---- Phase B: SIMULATED RESTART — fresh reconciler (empty ommCache), SAME client, upstream DOWN.
+	downFetcher := &mockGPFetcher{err: context.DeadlineExceeded}
+	rCold := &SatelliteEphemerisReconciler{
+		Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(200), Fetcher: downFetcher,
+		Now: func() time.Time { return clock },
+	}
+
+	// B1: within the refresh window (t0+10m) — restore hydrates, cacheServe serves directly.
+	clock = t0.Add(10 * time.Minute)
+	if _, err := rCold.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("cold reconcile (in-window): %v", err)
+	}
+	assertEpochAdvanced(t, ctx, cli, key, clock)
+	if _, ok := rCold.cachedOMMResult(key); !ok {
+		t.Fatalf("cold restore did not hydrate the in-memory cache")
+	}
+
+	// B2: PAST the 2h window (t0+3h) — cacheServe expires, the fetch is attempted and FAILS, and the
+	// obtainOMMs fallback (fetchKey+uid match, set by restore) keeps re-propagating.
+	clock = t0.Add(3 * time.Hour)
+	if _, err := rCold.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("cold reconcile (window expired): %v", err)
+	}
+	if downFetcher.callCount() == 0 {
+		t.Fatalf("window expired but no upstream fetch was attempted")
+	}
+	assertEpochAdvanced(t, ctx, cli, key, clock)
+}
+
+// assertEpochAdvanced checks propagatedStates exist and are stamped at the CURRENT reconcile clock
+// + lead (proving a fresh re-propagation, not a frozen carry-over).
+func assertEpochAdvanced(t *testing.T, ctx context.Context, cli client.Client, key types.NamespacedName, at time.Time) {
+	t.Helper()
+	obj := &ntnv1alpha1.SatelliteEphemeris{}
+	if err := cli.Get(ctx, key, obj); err != nil {
+		t.Fatalf("get eph: %v", err)
+	}
+	if len(obj.Status.PropagatedStates) == 0 {
+		t.Fatalf("no propagated states — continuity lost at %s", at.UTC())
+	}
+	want := at.Add(propagationEpochLead).UnixMilli()
+	if got := obj.Status.PropagatedStates[0].EpochUnixMs; got != want {
+		t.Fatalf("epoch = %d, want current-clock+lead = %d (frozen cache would keep an older epoch)", got, want)
+	}
+}
+
+func getResourceVersion(t *testing.T, cli client.Client, key types.NamespacedName) string {
+	t.Helper()
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), key, cm); err != nil {
+		t.Fatalf("get cm %s: %v", key, err)
+	}
+	return cm.ResourceVersion
+}

--- a/test/e2e/fixtures/ha-ci-values.yaml
+++ b/test/e2e/fixtures/ha-ci-values.yaml
@@ -1,0 +1,10 @@
+# Helm values for the HA E2E CI deploy (test-chart.yml). Adds the in-cluster
+# celestrak-mock host to --ephemeris-allowed-private-hosts so
+# TestHAOutageContinuityAcrossFailover can warm the SatelliteEphemeris cache from
+# it — the SSRF-safe GP fetch client blocks private-IP hosts by default. Setting
+# manager.args replaces the chart default, so --leader-elect is repeated here
+# (HA needs leader election). The other TestHA* tests are unaffected.
+manager:
+  args:
+    - --leader-elect
+    - --ephemeris-allowed-private-hosts=celestrak-mock.default.svc.cluster.local

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -996,4 +998,294 @@ func rolloutRestartPatch() string {
 	// A unique annotation forces a new ReplicaSet rollout without changing behaviour.
 	return fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"ntn.operators.dev/ha-e2e-restart":%q}}}}}`,
 		time.Now().Format(time.RFC3339Nano))
+}
+
+// ---------------------------------------------------------------------------
+// Durable OMM cache: outage-continuity across leader failover (acceptance test)
+// ---------------------------------------------------------------------------
+
+var satephGVR = schema.GroupVersionResource{Group: crdAPIGroup, Version: "v1alpha1", Resource: "satelliteephemeris"}
+
+const (
+	outageNS      = "default" // the mock Service DNS + --ephemeris-allowed-private-hosts are pinned to default
+	mockName      = "celestrak-mock"
+	mockFixtureCM = "celestrak-mock-fixture"
+	satephName    = "oneweb-constellation"
+
+	// Mirrors internal/controller propagationEpochLead / propagationRefreshInterval (the e2e package
+	// cannot import an internal package). Only used for generous polling budgets, so mild drift is safe.
+	haEpochLead        = 5 * time.Minute
+	haPropagationCycle = 3 * time.Minute
+)
+
+// mockGPJSON is one fresh OMM (EPOCH=now, so within maxEpochAge for the whole run) served as /gp.json.
+func mockGPJSON() string {
+	epoch := time.Now().UTC().Format("2006-01-02T15:04:05.000000")
+	return fmt.Sprintf(`[{"OBJECT_NAME":"ISS (ZARYA)","OBJECT_ID":"1998-067A","EPOCH":%q,`+
+		`"MEAN_MOTION":15.49554387,"ECCENTRICITY":0.000588,"INCLINATION":51.6381,`+
+		`"RA_OF_ASC_NODE":276.7884,"ARG_OF_PERICENTER":282.5765,"MEAN_ANOMALY":192.7824,`+
+		`"EPHEMERIS_TYPE":0,"CLASSIFICATION_TYPE":"U","NORAD_CAT_ID":25544,`+
+		`"ELEMENT_SET_NO":999,"REV_AT_EPOCH":47189,"BSTAR":0.00025892,`+
+		`"MEAN_MOTION_DOT":0.00019394,"MEAN_MOTION_DDOT":0}]`, epoch)
+}
+
+// deployCelestrakMock creates the fixture ConfigMap + nginx Deployment + Service and waits for ready.
+func (e *haEnv) deployCelestrakMock(t *testing.T) {
+	t.Helper()
+	labels := map[string]string{"app.kubernetes.io/name": mockName, "app.kubernetes.io/component": "e2e-fixture"}
+	sel := map[string]string{"app.kubernetes.io/name": mockName}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: mockFixtureCM, Namespace: outageNS, Labels: labels},
+		Data:       map[string]string{"gp.json": mockGPJSON()},
+	}
+	if _, err := e.cs.CoreV1().ConfigMaps(outageNS).Create(e.ctx, cm, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create mock fixture configmap: %v", err)
+	}
+
+	replicas := int32(1)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: mockName, Namespace: outageNS, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: sel},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.27-alpine",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name: "fixture", MountPath: "/usr/share/nginx/html/gp.json", SubPath: "gp.json", ReadOnly: true,
+						}},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/gp.json", Port: intstr.FromString("http")}},
+							PeriodSeconds: 2, FailureThreshold: 15,
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "fixture",
+						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: mockFixtureCM},
+							Items:                []corev1.KeyToPath{{Key: "gp.json", Path: "gp.json"}},
+						}},
+					}},
+				},
+			},
+		},
+	}
+	if _, err := e.cs.AppsV1().Deployments(outageNS).Create(e.ctx, dep, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create mock deployment: %v", err)
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: mockName, Namespace: outageNS, Labels: labels},
+		Spec: corev1.ServiceSpec{
+			Selector: sel,
+			Ports:    []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromString("http")}},
+		},
+	}
+	if _, err := e.cs.CoreV1().Services(outageNS).Create(e.ctx, svc, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create mock service: %v", err)
+	}
+
+	eventually(t, 2*time.Minute, 3*time.Second, "celestrak-mock to become available", func() (bool, string) {
+		d, err := e.cs.AppsV1().Deployments(outageNS).Get(e.ctx, mockName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return d.Status.AvailableReplicas >= 1, fmt.Sprintf("available=%d", d.Status.AvailableReplicas)
+	})
+}
+
+// scaleMock sets the mock replica count (0 = simulate a total upstream outage).
+func (e *haEnv) scaleMock(t *testing.T, replicas int32) {
+	t.Helper()
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		d, err := e.cs.AppsV1().Deployments(outageNS).Get(e.ctx, mockName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		d.Spec.Replicas = &replicas
+		_, err = e.cs.AppsV1().Deployments(outageNS).Update(e.ctx, d, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		t.Fatalf("scale mock to %d: %v", replicas, err)
+	}
+}
+
+// createOutageSatEph creates a SatelliteEphemeris pointing at the in-cluster mock (no passPrediction —
+// only the propagatedStates heartbeat matters here).
+func (e *haEnv) createOutageSatEph(t *testing.T) {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": crdAPIGroup + "/v1alpha1",
+		"kind":       "SatelliteEphemeris",
+		"metadata":   map[string]any{"name": satephName, "namespace": outageNS},
+		"spec": map[string]any{
+			"source": map[string]any{
+				"type":            "CelesTrak",
+				"url":             "http://celestrak-mock.default.svc.cluster.local/gp.json",
+				"refreshInterval": "4h",
+			},
+		},
+	}}
+	if _, err := e.dyn.Resource(satephGVR).Namespace(outageNS).Create(e.ctx, obj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create SatelliteEphemeris: %v", err)
+	}
+}
+
+// satephEpoch returns status.propagatedStates[0].epochUnixMs, ok=false until it exists.
+func (e *haEnv) satephEpoch() (int64, bool) {
+	got, err := e.dyn.Resource(satephGVR).Namespace(outageNS).Get(e.ctx, satephName, metav1.GetOptions{})
+	if err != nil {
+		return 0, false
+	}
+	states, found, err := unstructured.NestedSlice(got.Object, "status", "propagatedStates")
+	if err != nil || !found || len(states) == 0 {
+		return 0, false
+	}
+	first, ok := states[0].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	epoch, found, err := unstructured.NestedInt64(first, "epochUnixMs")
+	if err != nil || !found {
+		return 0, false
+	}
+	return epoch, true
+}
+
+// waitEpochAdvances blocks until the propagated epoch strictly exceeds beyond, returning the new value.
+func (e *haEnv) waitEpochAdvances(t *testing.T, beyond int64, timeout time.Duration, desc string) int64 {
+	t.Helper()
+	var latest int64
+	eventually(t, timeout, 5*time.Second, desc, func() (bool, string) {
+		ep, ok := e.satephEpoch()
+		if !ok {
+			return false, "no propagated epoch yet"
+		}
+		latest = ep
+		return ep > beyond, fmt.Sprintf("epoch=%d beyond=%d", ep, beyond)
+	})
+	return latest
+}
+
+// cacheConfigMapDigest returns the durable cache ConfigMap's payload digest, ok=false if absent.
+func (e *haEnv) cacheConfigMapDigest() (string, bool) {
+	cm, err := e.cs.CoreV1().ConfigMaps(outageNS).Get(e.ctx, satephName+"-omm-cache", metav1.GetOptions{})
+	if err != nil {
+		return "", false
+	}
+	return cm.Annotations["ntn.operators.dev/omm-digest"], true
+}
+
+// TestHAOutageContinuityAcrossFailover is the MANDATED acceptance test for the durable OMM cache:
+// warm the cache from the mock, force a TOTAL source outage, verify the epoch advances, KILL the
+// current leader, keep the source down beyond propagationEpochLead, and verify the NEW leader —
+// which starts with an EMPTY in-memory cache — restores the last-good OMMs from the durable
+// ConfigMap and KEEPS advancing the epoch (staying in the future = runtime-push ready).
+//
+// This is the only test that proves the property the unit integration test cannot: REAL leader
+// election + a REAL new process + REAL cross-process ConfigMap durability + real RBAC. Without the
+// durable cache the post-failover leader would have nothing to propagate once the last pushed epoch
+// expired, and the final assertions would fail.
+//
+// Precondition: the running chart must set --ephemeris-allowed-private-hosts to include
+// celestrak-mock.default.svc.cluster.local, or the SSRF-safe client blocks the warm fetch (the test
+// then fails fast at the warm step with that hint).
+func TestHAOutageContinuityAcrossFailover(t *testing.T) {
+	e := newHAEnv(t)
+	e.waitReadyManagerPods(t)
+
+	e.deployCelestrakMock(t)
+	e.createOutageSatEph(t)
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = e.dyn.Resource(satephGVR).Namespace(outageNS).Delete(bg, satephName, metav1.DeleteOptions{})
+		_ = e.cs.AppsV1().Deployments(outageNS).Delete(bg, mockName, metav1.DeleteOptions{})
+		_ = e.cs.CoreV1().Services(outageNS).Delete(bg, mockName, metav1.DeleteOptions{})
+		_ = e.cs.CoreV1().ConfigMaps(outageNS).Delete(bg, mockFixtureCM, metav1.DeleteOptions{})
+		// The <name>-omm-cache ConfigMap is owner-ref'd to the CR, so GC removes it with the CR.
+	})
+
+	// WARM: leader fetches, persists the durable cache, propagates.
+	warm := e.waitEpochAdvances(t, 0, 4*time.Minute,
+		"SatelliteEphemeris to warm — a stall here usually means the chart lacks "+
+			"--ephemeris-allowed-private-hosts=celestrak-mock.default.svc.cluster.local")
+	if _, ok := e.cacheConfigMapDigest(); !ok {
+		t.Fatalf("durable cache ConfigMap %s-omm-cache absent after warm — persist not wired or RBAC-denied", satephName)
+	}
+	t.Logf("warm: epoch=%d, durable cache present", warm)
+
+	// OUTAGE: mock to zero → every upstream fetch now fails.
+	e.scaleMock(t, 0)
+	eventually(t, time.Minute, 3*time.Second, "mock to report zero available replicas", func() (bool, string) {
+		d, err := e.cs.AppsV1().Deployments(outageNS).Get(e.ctx, mockName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return d.Status.AvailableReplicas == 0, fmt.Sprintf("available=%d", d.Status.AvailableReplicas)
+	})
+
+	// PRE-FAILOVER: the current leader keeps advancing the epoch from its in-memory cache.
+	preKill := e.waitEpochAdvances(t, warm, haPropagationCycle+3*time.Minute,
+		"epoch to advance under outage before failover (leader serving in-memory cache)")
+	t.Logf("pre-failover: epoch advanced to %d under outage", preKill)
+
+	// KILL THE LEADER: the standby takes over with an EMPTY in-memory cache; source stays DOWN.
+	holder0 := e.waitLeaseHolder(t)
+	if h, err := e.leaseHolder(); err == nil && h != holder0 {
+		holder0 = e.waitLeaseHolder(t)
+	}
+	leader0 := holderPodBase(holder0)
+	killTime := time.Now()
+	t.Logf("killing leader pod=%s while source is DOWN", leader0)
+	if err := e.cs.CoreV1().Pods(e.ns).Delete(e.ctx, leader0, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete leader pod: %v", err)
+	}
+	eventually(t, 90*time.Second, time.Second, "lease to fail over to a new holder", func() (bool, string) {
+		h, err := e.leaseHolder()
+		if err != nil {
+			return false, err.Error()
+		}
+		if h == "" || h == holder0 {
+			return false, "holder still " + h
+		}
+		return true, ""
+	})
+	e.waitReadyManagerPods(t)
+	newHolder, _ := e.leaseHolder()
+	t.Logf("failed over to new leader holder=%s", newHolder)
+
+	// THE PROOF: source STILL down, new leader started cold. Require ONE advance immediately (restore
+	// worked) and then a FURTHER advance only after more than propagationEpochLead of wall time has
+	// elapsed since the kill — by then the epoch pushed before the kill has expired, so the continued
+	// advance can ONLY come from the new leader re-propagating the RESTORED durable cache. (The
+	// window-expired → fetch-fails → fallback path cannot be reached in an e2e because minRefreshInterval
+	// clamps the fetch window to 2h; it is covered deterministically by the unit integration test.)
+	adv1 := e.waitEpochAdvances(t, preKill, 4*time.Minute,
+		"first epoch advance after cold failover (durable-cache restore)")
+
+	var adv2 int64
+	eventually(t, haEpochLead+3*haPropagationCycle, 5*time.Second,
+		"epoch to keep advancing until beyond the epoch-lead window after cold failover",
+		func() (bool, string) {
+			ep, ok := e.satephEpoch()
+			if !ok {
+				return false, "no propagated epoch"
+			}
+			adv2 = ep
+			elapsed := time.Since(killTime)
+			return ep > adv1 && elapsed >= haEpochLead,
+				fmt.Sprintf("epoch=%d adv1=%d elapsedSinceKill=%s", ep, adv1, elapsed.Round(time.Second))
+		})
+	t.Logf("post-failover under sustained outage: epoch %d -> %d over %s", adv1, adv2, time.Since(killTime).Round(time.Second))
+
+	// PUSH-READY: OCUDU ntn_config_update requires a FUTURE epoch, so a runtime push consumer always
+	// has valid, non-expired ephemeris to send.
+	if nowMs := time.Now().UnixMilli(); adv2 <= nowMs {
+		t.Fatalf("post-failover epoch %d is not in the future (now=%d) — runtime push would have no valid ephemeris", adv2, nowMs)
+	}
 }


### PR DESCRIPTION
## What

Adds a **durable last-good OMM cache** so `SatelliteEphemeris` outage continuity survives a controller restart or a leader-election failover — not just a single process's lifetime.

## Why

The reconciler already serves the last-good OMMs from an in-memory cache (`ommCache`) when an upstream fetch fails, keeping SIB19 fresh through a source outage (I-18). But that cache is **in-memory only**: a restart or leader failover starts the new active reconciler cold. `status.propagatedStates` holds the ECEF *output* of past propagation but **not** the orbital *elements* (the SGP4 input), so status alone cannot re-propagate. Concretely — if the leader dies *during* an outage, the standby takes over with nothing to propagate, and once the last-pushed epoch expires (~5 min) SIB19 goes stale for the rest of the outage even though the operator is healthy. That is a single-process-memory dependency in an otherwise active-passive HA design.

## How

Per-CR, owner-ref'd ConfigMap (`<name>-omm-cache`) holding the tracked, capped OMM set as JSON. Design (full rationale + alternatives in **ADR-0007**):

- **On successful fetch** → persist the filtered/capped OMMs (never the full response); `sgp4.OMM`'s CelesTrak JSON tags round-trip losslessly through `ParseOMMs` (string `EPOCH`, no time-precision loss).
- **On cold reconcile** → hydrate the in-memory cache from the ConfigMap *before* the fetch-vs-serve decision.
- **Integrity + identity gates**: restore refuses unless the sha256 digest is intact **and** the source `fetchKey` and owner UID match the live object — a hand-edit, source change, or delete-recreate never restores wrong/orphaned data.
- **Freshness preserved**: the restored entry keeps its ORIGINAL fetch time, so the normal window / backoff / `maxEpochAge` gates still apply — restore removes the cold-start cliff and nothing more.
- **GC** via owner reference (needs `configmaps get;create;update` — no delete); **no resourceVersion churn** (no-op on unchanged digest); **uncached `APIReader` reads** (no cluster-wide ConfigMap informer, and a cold leader reads the previous leader's write before its cache would sync).

## Testing

- **Unit** (`satelliteephemeris_ommcache_persist_test.go`, all green under `make test` + `-race`): round-trip incl. ns fetch-time + digest integrity; restore rejects digest-corrupt / missing-label / empty / UID-mismatch / fetchKey-mismatch; no-op on identical digest; owner-ref for GC; oversize skip; name truncation; payload filter+cap; and a **cold-start integration test** that reconciles a fresh reconciler against a simulated outage and asserts the epoch keeps advancing — it fails if the restore hook is removed.
- **E2E acceptance** (`TestHAOutageContinuityAcrossFailover`, tag `e2e_ha`): warm from the in-cluster mock → scale mock to zero (total outage) → verify epoch advances → **kill the current leader** → verify the cold new leader restores from the durable ConfigMap and keeps advancing the epoch **beyond `propagationEpochLead`** while staying in the future (runtime-push ready). Ran green against a 2-replica Kind release.

## Notes

- Element sets are public catalog data → ConfigMap, not Secret (and `NTNCellConfig` already persists derived ephemeris to a ConfigMap, so no new exposure). Secret migration is a documented mechanical follow-up if a deployment classifies its catalog as sensitive.
- Known limitation (ADR-0007): CR names > 243 chars sharing a 243-char prefix map to one cache ConfigMap; the UID gate prevents wrong-data restore, so the only effect is the loser forgoes restart-continuity (pathological, k8s names ≤ 253).
