### PR TITLE
fix(ntncellconfig): skip the terminal status write on a no-op reconcile

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,6 +191,12 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.Get(ctx, req.NamespacedName, cc); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Snapshot the persisted status so the terminal write below can be skipped when this reconcile
+	// leaves it byte-for-byte unchanged (e.g. an ephemeris-watch fan-out that finds the config
+	// already applied and the marker fresh). Avoids a no-op status update on the hot path
+	// (producer-side churn, #188).
+	oldStatus := cc.Status.DeepCopy()
 
 	// Step 2: Look up provider from registry (may be nil).
 	prov := r.Providers[cc.Spec.Provider.Type]
@@ -412,8 +419,15 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}).Set(1)
 	}
 
-	if err := r.Status().Update(ctx, cc); err != nil {
-		return ctrl.Result{}, err
+	// Skip the write when this reconcile did not change the status (an ephemeris-watch fan-out or a
+	// periodic requeue that found nothing to do): a byte-identical Status().Update is producer churn
+	// the API server, admission and the watch stream still process. The events below stay
+	// episode-gated, so they self-limit independently of whether the write happened, and the state
+	// they describe is already persisted.
+	if !equality.Semantic.DeepEqual(oldStatus, &cc.Status) {
+		if err := r.Status().Update(ctx, cc); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if configApplyChanged {

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -550,6 +551,36 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(mock.EphemerisCalls).To(Equal(1))
 		})
 
+		It("should not re-write status on a steady no-op reconcile (#188 producer churn)", func() {
+			createReferencedEphemeris()
+			createCellConfig()
+
+			// Count Status().Update REQUESTS rather than checking resourceVersion: the API server
+			// short-circuits a byte-identical status write (no version bump), so resourceVersion
+			// cannot see the redundant request the controller still sends through API handling,
+			// validation and admission. Wrap the envtest client to count the calls the reconciler makes.
+			statusUpdates := 0
+			reconciler := &NTNCellConfigReconciler{
+				Client:    &countingStatusClient{Client: k8sClient, statusUpdates: &statusUpdates},
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(10),
+				Providers: map[string]provider.NTNProvider{"ocudu": &provider.MockProvider{}},
+			}
+
+			// Drive the config to steady state (applied + pushed, then settled).
+			for range 3 {
+				_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// A further reconcile that changes nothing must issue no status write request.
+			statusUpdates = 0
+			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+			Expect(statusUpdates).To(Equal(0), "a steady no-op reconcile must not issue a Status().Update request")
+		})
+
 		It("should keep ConfigApplied true and set EphemerisPushed=false when push fails", func() {
 			createReferencedEphemeris()
 			createCellConfig()
@@ -913,3 +944,25 @@ var _ = Describe("NTNCellConfig Controller", func() {
 		})
 	})
 })
+
+// countingStatusClient wraps a client.Client and counts Status().Update requests so a test can
+// assert a steady no-op reconcile issues none. resourceVersion cannot detect the request: the API
+// server short-circuits a byte-identical status write without bumping the version.
+type countingStatusClient struct {
+	client.Client
+	statusUpdates *int
+}
+
+func (c *countingStatusClient) Status() client.SubResourceWriter {
+	return &countingStatusWriter{SubResourceWriter: c.Client.Status(), n: c.statusUpdates}
+}
+
+type countingStatusWriter struct {
+	client.SubResourceWriter
+	n *int
+}
+
+func (w *countingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	*w.n++
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}


### PR DESCRIPTION
## Problem

A successful `NTNCellConfig` reconcile always called `r.Status().Update` at the end, even when nothing changed: `ApplyCellConfig` was a no-op, the `ConfigApplied` condition and the ephemeris marker were already current, and no other status field moved. The controller still issued the write request, which the API server, admission and the watch stream all have to process. The project already treats identical status rewrites as producer churn (#188 and the WO-20 episode gates), so this is the remaining gap in the reconcile write path after #224 closed the ConfigMap churn.

An exactly-identical status write may be short-circuited by the API server (no resourceVersion bump), but the controller still sends the request through API handling, validation and admission, and a write that does land enters the resourceVersion / watch stream.

## Fix

Snapshot the status right after the Get and skip the terminal write when the reconcile leaves it equal (`equality.Semantic.DeepEqual`). Only the write is guarded: the episode-gated events below (`emitConfigApplied`, `emitCadenceWarn`) still run, so their gating is unchanged and the state they describe is already persisted.

This deliberately does not touch the accepted pass-prediction cadence write (#234 / ADR-0006). That write lives in the `SatelliteEphemeris` controller and always advances its `lastPassPredictionTime`, so a diff guard would not help there; here the no-op reconcile genuinely leaves the status unchanged, so the guard does help.

## Tests

Adds a test asserting a steady no-op reconcile issues no status write. It counts `Status().Update` requests through a wrapping client rather than checking `resourceVersion`: the API server short-circuits a byte-identical status write without a version bump, so `resourceVersion` cannot see the redundant request the controller still sends. Mutation-checked: forcing the write unconditional fails it.

Full controller envtest suite (156 specs) and all `pkg/...` suites pass; `gofmt` and `go vet` clean.

Follow-up to #224 (ConfigMap churn) and #188 (WO-20 episode gates); no separate issue.
