### PR TITLE
fix(ephemeris): deterministic + fail-closed runtime satellite selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Runtime satellite selection is now deterministic and fails closed instead of silently switching
+  satellites.** `SatelliteEphemeris` propagated states inherited the upstream response order
+  (`FilterOMMs` preserves it; no dedup, no sort), so with a multi-satellite ephemeris and no
+  `NTNCellConfig.spec.ephemerisNoradID` the cell pushed "the first" state — and a reordered upstream
+  response (`[A,B]`→`[B,A]`, which neither CelesTrak nor Space-Track guarantees stable) silently
+  switched which satellite was pushed, while a duplicate NORAD (e.g. a `GP_HISTORY` query) could serve
+  an older element set. The producer now keeps, per NORAD, the latest-epoch element set and sorts by
+  NORAD ascending; the runtime-push consumer fails **closed** (`EphemerisPushed=False`, reason
+  `EphemerisSelectionAmbiguous`) when `ephemerisNoradID` is unset against more than one satellite,
+  rather than guess. A single-satellite ephemeris still resolves implicitly. Mutation-tested.
+
 - **The manager waits indefinitely for runnables on shutdown, so the leader lease is never released
   early.** `GracefulShutdownTimeout` was unset (controller-runtime default 30s). A *finite* timeout is
   unsafe with `LeaderElectionReleaseOnCancel`: `runnableGroup.StopAndWait` returns on ctx-expiry
@@ -320,6 +331,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade notes
 
+- **Runtime push now fails closed for a multi-satellite ephemeris with no `ephemerisNoradID`.** An
+  existing `NTNCellConfig` on the runtime-push path that left `spec.ephemerisNoradID` unset while its
+  referenced `SatelliteEphemeris` tracks more than one satellite will now hold with
+  `EphemerisPushed=False` (reason `EphemerisSelectionAmbiguous`) instead of pushing whichever
+  satellite the upstream listed first. Set `spec.ephemerisNoradID` to the intended satellite to
+  restore pushing. Single-satellite ephemerides are unaffected.
 - **`passPrediction.horizon`: negative is rejected, over-7-days is clamped.** A horizon > 7 days is
   clamped to 7 days (surfaced on the `PassesPredicted` condition message, not silently), so a spec
   relying on windows beyond 7 days will see them truncated (`MaxPassWindows` already capped the

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -54,7 +54,10 @@ type NTNCellConfigSpec struct {
 
 	// ephemerisNoradID selects which satellite's propagated state vector, from the
 	// referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-	// unset, the referenced ephemeris's first propagated state is used.
+	// unset, the single tracked satellite's state is used; if the referenced ephemeris
+	// exposes more than one satellite the push fails closed (EphemerisPushed=False,
+	// reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+	// never guesses which satellite to serve.
 	// +optional
 	EphemerisNoradID *int `json:"ephemerisNoradID,omitempty"`
 }

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -152,7 +152,10 @@ spec:
                 description: |-
                   ephemerisNoradID selects which satellite's propagated state vector, from the
                   referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-                  unset, the referenced ephemeris's first propagated state is used.
+                  unset, the single tracked satellite's state is used; if the referenced ephemeris
+                  exposes more than one satellite the push fails closed (EphemerisPushed=False,
+                  reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+                  never guesses which satellite to serve.
                 type: integer
               ephemerisRef:
                 description: |-

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -152,7 +152,10 @@ spec:
                 description: |-
                   ephemerisNoradID selects which satellite's propagated state vector, from the
                   referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-                  unset, the referenced ephemeris's first propagated state is used.
+                  unset, the single tracked satellite's state is used; if the referenced ephemeris
+                  exposes more than one satellite the push fails closed (EphemerisPushed=False,
+                  reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+                  never guesses which satellite to serve.
                 type: integer
               ephemerisRef:
                 description: |-

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -155,7 +155,10 @@ spec:
                 description: |-
                   ephemerisNoradID selects which satellite's propagated state vector, from the
                   referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-                  unset, the referenced ephemeris's first propagated state is used.
+                  unset, the single tracked satellite's state is used; if the referenced ephemeris
+                  exposes more than one satellite the push fails closed (EphemerisPushed=False,
+                  reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+                  never guesses which satellite to serve.
                 type: integer
               ephemerisRef:
                 description: |-

--- a/internal/controller/ephemeris_selection_determinism_test.go
+++ b/internal/controller/ephemeris_selection_determinism_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+func ommAt(norad int, epoch, name string) sgp4.OMM {
+	return sgp4.OMM{NoradCatID: norad, EpochStr: epoch, ObjectName: name}
+}
+
+// TestCanonicalizeOMMs_DeterministicOrderAcrossReorder is the producer half of the silent-switch
+// fix: whatever order the upstream lists satellites in, the canonical order (hence states[0], the
+// implicit-selection target) must be identical — so a reordered response cannot switch the pushed
+// satellite. Mutation target: dropping the sort makes the two outputs differ.
+func TestCanonicalizeOMMs_DeterministicOrderAcrossReorder(t *testing.T) {
+	ep := "2026-07-10T00:00:00.000000"
+	ab := canonicalizeOMMs([]sgp4.OMM{ommAt(200, ep, "B"), ommAt(100, ep, "A")})
+	ba := canonicalizeOMMs([]sgp4.OMM{ommAt(100, ep, "A"), ommAt(200, ep, "B")})
+	if len(ab) != 2 || len(ba) != 2 {
+		t.Fatalf("want 2 states each, got %d and %d", len(ab), len(ba))
+	}
+	if ab[0].NoradCatID != 100 || ab[1].NoradCatID != 200 {
+		t.Fatalf("not sorted ascending by NORAD: %d,%d", ab[0].NoradCatID, ab[1].NoradCatID)
+	}
+	if ab[0].NoradCatID != ba[0].NoradCatID || ab[1].NoradCatID != ba[1].NoradCatID {
+		t.Fatalf("order not stable across upstream reorder: %v vs %v",
+			[]int{ab[0].NoradCatID, ab[1].NoradCatID}, []int{ba[0].NoradCatID, ba[1].NoradCatID})
+	}
+}
+
+// TestCanonicalizeOMMs_KeepsLatestEpochPerNorad is the producer half of the duplicate-NORAD fix
+// (e.g. a GP_HISTORY feed): a NORAD appearing more than once collapses to its LATEST element set,
+// never the first-listed. Mutation target: keeping the first (or dropping the After() comparison)
+// surfaces the OLD epoch.
+func TestCanonicalizeOMMs_KeepsLatestEpochPerNorad(t *testing.T) {
+	got := canonicalizeOMMs([]sgp4.OMM{
+		ommAt(25544, "2026-07-01T00:00:00.000000", "OLD"),
+		ommAt(25544, "2026-07-20T00:00:00.000000", "NEW"),
+		ommAt(100, "2026-07-10T00:00:00.000000", "X"),
+	})
+	if len(got) != 2 {
+		t.Fatalf("duplicate NORAD not collapsed: want 2, got %d", len(got))
+	}
+	// Sorted: 100 then 25544; the 25544 entry must be the NEWER one.
+	if got[1].NoradCatID != 25544 || got[1].ObjectName != "NEW" {
+		t.Fatalf("did not keep latest EPOCH for NORAD 25544: %+v", got[1])
+	}
+}
+
+// TestCanonicalizeOMMs_PrefersParseableEpoch: a NORAD with one unparseable and one parseable epoch
+// keeps the parseable one (so a garbage duplicate can't shadow a good element set).
+func TestCanonicalizeOMMs_PrefersParseableEpoch(t *testing.T) {
+	got := canonicalizeOMMs([]sgp4.OMM{
+		ommAt(300, "not-a-timestamp", "BAD"),
+		ommAt(300, "2026-07-05T00:00:00.000000", "GOOD"),
+	})
+	if len(got) != 1 || got[0].ObjectName != "GOOD" {
+		t.Fatalf("did not prefer the parseable epoch: %+v", got)
+	}
+}
+
+func schemeForSelection(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(sch); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return sch
+}
+
+// TestPushEphemerisUpdateIfNeeded_NilNoradMultiSat_FailsClosed is the consumer half: with no
+// ephemerisNoradID and MORE THAN ONE tracked satellite, the push must fail CLOSED with
+// EphemerisSelectionAmbiguous — never silently push whichever satellite is first. Mutation target:
+// removing the guard lets the push proceed (pushed=true / RuntimeCalls=1).
+func TestPushEphemerisUpdateIfNeeded_NilNoradMultiSat_FailsClosed(t *testing.T) {
+	future := time.Now().Add(time.Hour).UnixMilli()
+	eph := ephWithPropagatedState(future) // one state: NORAD 25544, input hash stamped
+	eph.Status.PropagatedStates = append(eph.Status.PropagatedStates, ntnv1alpha1.PropagatedState{
+		Satellite: "SAT-B", NoradID: 40000, EpochUnixMs: future,
+		SourceEpochUnixMs: time.Now().Add(-time.Hour).UnixMilli(),
+		ECEF:              ntnv1alpha1.EphemerisECEF{PosX: 6000000, PosY: 5000000, PosZ: 4000000},
+	})
+	c := fake.NewClientBuilder().WithScheme(schemeForSelection(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+
+	cc := ccWithRemoteControl()
+	cc.Spec.EphemerisNoradID = nil // implicit selection against two satellites → ambiguous
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if pushed {
+		t.Fatal("expected fail-closed (pushed=false) for ambiguous implicit selection")
+	}
+	if err == nil {
+		t.Fatal("expected an error for ambiguous implicit selection")
+	}
+	if reason := ephemerisPushConditionReason(err); reason != ephemerisReasonSelectionAmbiguous {
+		t.Fatalf("reason = %q, want %q", reason, ephemerisReasonSelectionAmbiguous)
+	}
+	if mock.RuntimeCalls != 0 {
+		t.Fatalf("ambiguous selection must not push; RuntimeCalls=%d", mock.RuntimeCalls)
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_NilNoradSingleSat_Allowed proves the guard does NOT regress the
+// common single-satellite case: with one tracked satellite, no ephemerisNoradID still pushes it.
+func TestPushEphemerisUpdateIfNeeded_NilNoradSingleSat_Allowed(t *testing.T) {
+	future := time.Now().Add(time.Hour).UnixMilli()
+	eph := ephWithPropagatedState(future) // single state: NORAD 25544
+	c := fake.NewClientBuilder().WithScheme(schemeForSelection(t)).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+
+	cc := ccWithRemoteControl()
+	cc.Spec.EphemerisNoradID = nil // unambiguous: only one satellite
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil {
+		t.Fatalf("single-satellite implicit selection must be allowed, got err: %v", err)
+	}
+	if !pushed || mock.RuntimeCalls != 1 {
+		t.Fatalf("single-satellite push should proceed: pushed=%v RuntimeCalls=%d", pushed, mock.RuntimeCalls)
+	}
+}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -71,6 +71,12 @@ const (
 	ephemerisReasonProviderPushRejected = "ProviderPushRejected"
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
 	ephemerisReasonRemoteControlConfig  = "RemoteControlConfigInvalid"
+	// ephemerisReasonSelectionAmbiguous fails a push CLOSED when spec.ephemerisNoradID is unset but
+	// the referenced SatelliteEphemeris exposes more than one satellite: the controller refuses to
+	// guess which one to serve (silently pushing the first would switch satellites whenever the
+	// upstream response order changed). Clears when the cell selects a NORAD or the source narrows
+	// to one satellite.
+	ephemerisReasonSelectionAmbiguous = "EphemerisSelectionAmbiguous"
 	// ephemerisReasonInputsStale marks a push HELD because the referenced
 	// SatelliteEphemeris's propagatedStates were computed under DIFFERENT propagation
 	// inputs than the live spec (status.propagatedStatesInputHash != hash(spec)) — a
@@ -605,6 +611,18 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 			fmt.Errorf("SatelliteEphemeris %q propagatedStates were computed under different propagation inputs than the current spec; awaiting re-propagation", eph.Name),
 		)
 	}
+	// Fail CLOSED on an ambiguous implicit selection: with no ephemerisNoradID and more than one
+	// tracked satellite, "the first propagated state" is not a stable choice, so refuse rather than
+	// silently push whichever satellite the upstream happened to list first. spec.satellites.noradIDs
+	// is a tracking filter, not a runtime-target priority, so it is deliberately NOT consulted here.
+	if spec.EphemerisNoradID == nil {
+		if n := uniquePropagatedNorads(eph.Status.PropagatedStates); n > 1 {
+			return false, ephemerisPushMarker(eph), newEphemerisPushError(
+				ephemerisReasonSelectionAmbiguous,
+				fmt.Errorf("SatelliteEphemeris %q exposes %d satellites but this NTNCellConfig sets no spec.ephemerisNoradID; set it to select which satellite to push", eph.Name, n),
+			)
+		}
+	}
 	state := selectPropagatedState(eph.Status.PropagatedStates, spec.EphemerisNoradID)
 	if state == nil {
 		// A referenced satellite that the SatelliteEphemeris rejected as deep-space
@@ -841,8 +859,20 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	return cfg, string(secret.Data["token"]), nil
 }
 
+// uniquePropagatedNorads counts distinct NORAD IDs among the states. Used to fail closed when a cell
+// selects no ephemerisNoradID against a multi-satellite ephemeris, independent of whether the
+// producer has already de-duplicated (defense in depth across a rolling upgrade).
+func uniquePropagatedNorads(states []ntnv1alpha1.PropagatedState) int {
+	seen := make(map[int]struct{}, len(states))
+	for i := range states {
+		seen[states[i].NoradID] = struct{}{}
+	}
+	return len(seen)
+}
+
 // selectPropagatedState picks the propagated state matching noradID, or the first
-// available when noradID is nil. Returns nil when none match.
+// available when noradID is nil. Returns nil when none match. A nil noradID against a
+// multi-satellite ephemeris is rejected by the caller before this is reached.
 func selectPropagatedState(states []ntnv1alpha1.PropagatedState, noradID *int) *ntnv1alpha1.PropagatedState {
 	if len(states) == 0 {
 		return nil

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -338,11 +338,15 @@ func TestPropagateStates_TruncationCountsCapDropsNotPropagationFailures(t *testi
 	isTruncated := func(eph *ntnv1alpha1.SatelliteEphemeris) bool {
 		return meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionStatesTruncated)
 	}
+	// The SGP4-failing OMMs get LOWER NORADs than the good ones so propagateStates'
+	// canonicalizeOMMs (dedup + sort by NORAD) keeps them ahead of the cap boundary — i.e.
+	// they are ATTEMPTED and fail, which is the "failures before the cap" scenario this test
+	// pins (they must not be counted as cap-truncated). Good NORADs start at 25544.
 	build := func(nBad, nGood int) []sgp4.OMM {
 		omms := make([]sgp4.OMM, 0, nBad+nGood)
 		for i := range nBad {
 			b := badOMMForTest()
-			b.NoradCatID = 40000 + i
+			b.NoradCatID = 1000 + i
 			omms = append(omms, b)
 		}
 		for i := range nGood {

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -45,6 +45,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/akhenakh/sgp4"
 	"github.com/prometheus/client_golang/prometheus"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
@@ -1021,6 +1022,35 @@ func propagationInputHash(spec ntnv1alpha1.SatelliteEphemerisSpec) string {
 // future epoch and records the ECEF state vectors in status.propagatedStates for
 // downstream runtime ephemeris push (#176). The set is filtered by
 // spec.satellites.noradIDs and capped; un-propagatable satellites are skipped.
+// canonicalizeOMMs makes the propagated-state order DETERMINISTIC and one-per-NORAD, independent of
+// upstream response order (neither CelesTrak nor Space-Track guarantees it stable) and of a history
+// feed returning multiple element sets per object. Without it, status.propagatedStates inherits
+// upstream order, so states[0] — the state a cell with no ephemerisNoradID pushes — could silently
+// switch satellites between fetches, and a duplicate NORAD could serve an older element set. Keeps,
+// per NORAD, the OMM with the latest PARSEABLE epoch (a NORAD whose every epoch is unparseable keeps
+// one, to stay counted+skipped downstream), then sorts by NORAD ascending.
+func canonicalizeOMMs(omms []sgp4.OMM) []sgp4.OMM {
+	type pick struct {
+		omm   sgp4.OMM
+		epoch time.Time
+		ok    bool
+	}
+	best := make(map[int]pick, len(omms))
+	for _, o := range omms {
+		t, ok := parseOMMEpoch(o.EpochStr)
+		cur, seen := best[o.NoradCatID]
+		if !seen || (ok && (!cur.ok || t.After(cur.epoch))) {
+			best[o.NoradCatID] = pick{omm: o, epoch: t, ok: ok}
+		}
+	}
+	out := make([]sgp4.OMM, 0, len(best))
+	for _, p := range best {
+		out = append(out, p.omm)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].NoradCatID < out[j].NoradCatID })
+	return out
+}
+
 func (r *SatelliteEphemerisReconciler) propagateStates(
 	ctx context.Context,
 	eph *ntnv1alpha1.SatelliteEphemeris,
@@ -1031,7 +1061,7 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	if eph.Spec.Satellites != nil {
 		norad = eph.Spec.Satellites.NoradIDs
 	}
-	omms := ephemeris.FilterOMMs(result.OMMs, norad)
+	omms := canonicalizeOMMs(ephemeris.FilterOMMs(result.OMMs, norad))
 	epochMs := epoch.UnixMilli()
 
 	// Count element-set epoch health across the ENTIRE tracked set — independent of SGP4 success

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -152,7 +152,10 @@ spec:
                 description: |-
                   ephemerisNoradID selects which satellite's propagated state vector, from the
                   referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-                  unset, the referenced ephemeris's first propagated state is used.
+                  unset, the single tracked satellite's state is used; if the referenced ephemeris
+                  exposes more than one satellite the push fails closed (EphemerisPushed=False,
+                  reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+                  never guesses which satellite to serve.
                 type: integer
               ephemerisRef:
                 description: |-


### PR DESCRIPTION
## What

Makes runtime-push satellite selection **deterministic** and **fail-closed**, closing a P1 (under legal config) where a cell could silently push the wrong satellite.

## Why

When `NTNCellConfig.spec.ephemerisNoradID` is unset, the API used "the first propagated state", and `propagateStates` built that list in **upstream response order** (`FilterOMMs` is order-preserving; no dedup, no sort). Two legal-config failures followed:

- **A — response reorder → silent switch.** Neither CelesTrak nor Space-Track guarantees stable ordering across fetches. `[A,B]` then `[B,A]` flips `states[0]`, so the cell pushes A then B. The runtime dedup marker keys on the epoch (which changes every propagation), so the controller treats the selection drift as a normal update — spec and generation unchanged.
- **B — duplicate NORAD → stale element set.** The source URL only validates scheme/length/type, not `class/gp` vs `GP_HISTORY`. A history query returns multiple element sets per object; the consumer picked the **first**, not the latest EPOCH.

## How

**Producer (`propagateStates`)** — `canonicalizeOMMs` after `FilterOMMs`: keep, per NORAD, the OMM with the latest **parseable** EPOCH (a NORAD whose every epoch is unparseable keeps one, to stay counted+skipped downstream), then sort by NORAD ascending. Now `states[0]` is deterministic and each NORAD carries its newest element set, independent of upstream order or duplicates. (Applied in the propagation path only — `FilterOMMs` has 4 callers incl. pass-prediction, so its semantics are left unchanged.)

**Consumer (`pushRuntimeEphemeris`)** — when `ephemerisNoradID` is unset and the referenced ephemeris exposes **more than one** unique NORAD, fail **closed** with `EphemerisPushed=False`, reason `EphemerisSelectionAmbiguous`, rather than guess. A single-satellite ephemeris still resolves implicitly (no regression). `spec.satellites.noradIDs` is a tracking filter, not a runtime-target priority, so it is deliberately not consulted. Defense-in-depth: the consumer counts distinct NORADs itself, so it holds even against an old producer mid-upgrade.

API doc for `ephemerisNoradID` updated; all four CRD copies (config/crd, chart, nephio, bundle) synced.

## Testing

Mutation-oriented (all green, `-race`):
- `TestCanonicalizeOMMs_DeterministicOrderAcrossReorder` — `[A,B]`/`[B,A]` produce identical canonical order (kills the "drop the sort" mutation).
- `TestCanonicalizeOMMs_KeepsLatestEpochPerNorad` — duplicate NORAD collapses to the newest EPOCH (kills "keep first").
- `TestCanonicalizeOMMs_PrefersParseableEpoch` — a garbage duplicate can't shadow a good element set.
- `TestPushEphemerisUpdateIfNeeded_NilNoradMultiSat_FailsClosed` — nil selector + 2 satellites → no push, reason `EphemerisSelectionAmbiguous` (kills "remove the guard").
- `TestPushEphemerisUpdateIfNeeded_NilNoradSingleSat_Allowed` — single-satellite implicit selection still pushes (no regression).

Existing `TestSelectPropagatedState` unchanged: the pure pick function is untouched; the policy lives in the caller.
