### PR TITLE
fix(ntncellconfig): content-digest runtime-push dedup key (drop epoch-monotonicity assumption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EphemerisSelectionAmbiguous`) when `ephemerisNoradID` is unset against more than one satellite,
   rather than guess. A single-satellite ephemeris still resolves implicitly. Mutation-tested.
 
+- **Runtime-push dedup key is now a content digest, not a wall-clock epoch treated as monotonic.**
+  `runtimeEphemerisPushMarker` keyed on the propagated `EpochUnixMs` alone, whose comment claimed it
+  was a monotonic 1:1 proxy for the ECEF. But `EpochUnixMs` is serialized wall-clock time with no
+  monotonic reading, so across pods or an NTP step a repeated target epoch carrying a *different* ECEF
+  (a new OMM propagated to the same instant after a clock rewind/skew, with the ephemeris generation
+  unchanged) produced an identical marker and the fresh position/velocity was silently dedup'd. The
+  marker now digests the delivered content — owner UID, propagation-input hash, NORAD, both epochs, and
+  the full ECEF position+velocity — so it changes iff the payload changes (a fresh epoch is one such
+  change, preserving the per-propagation re-push cadence). Mutation-tested for the same-epoch/changed-ECEF
+  case the epoch-advances test (#260) did not cover.
+
 - **The manager waits indefinitely for runnables on shutdown, so the leader lease is never released
   early.** `GracefulShutdownTimeout` was unset (controller-runtime default 30s). A *finite* timeout is
   unsafe with `LeaderElectionReleaseOnCancel`: `runnableGroup.StopAndWait` returns on ctx-expiry
@@ -337,6 +348,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EphemerisPushed=False` (reason `EphemerisSelectionAmbiguous`) instead of pushing whichever
   satellite the upstream listed first. Set `spec.ephemerisNoradID` to the intended satellite to
   restore pushing. Single-satellite ephemerides are unaffected.
+- **One-time runtime re-push per cell after upgrade (harmless).** The runtime-push dedup marker format
+  changed (epoch → content digest), so an already-pushed `NTNCellConfig`'s stored marker will not match
+  the new one on the first reconcile, triggering a single re-push of the current (correct) propagated
+  state. It is idempotent and self-healing; no action needed.
 - **`passPrediction.horizon`: negative is rejected, over-7-days is clamped.** A horizon > 7 days is
   clamped to 7 days (surfaced on the `PassesPredicted` condition message, not silently), so a spec
   relying on windows beyond 7 days will see them truncated (`MaxPassWindows` already capped the

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -910,11 +912,18 @@ func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
 // push path. The ConfigMap path keys on the GP fetch time (ephemerisPushMarker),
 // but the runtime push delivers the SGP4-propagated state, which the
 // SatelliteEphemeris re-propagates to a fresh EPOCH every few minutes; keying on
-// that epoch (not the 2h-stable LastUpdated) is what makes the watch fan-out
-// re-push the live state between GP fetches and after a gNB restart (I-12). The
-// epoch is a monotonic 1:1 proxy for the propagated ECEF — each re-propagation
-// yields a new epoch and a new state — so a same-epoch reconcile dedups without
-// hashing the payload. Refreshing epoch/ephemeris/TA is SI-change-free per TS 38.331.
+// the propagated state (not the 2h-stable LastUpdated) is what makes the watch
+// fan-out re-push the live state between GP fetches and after a gNB restart (I-12).
+// The marker is a sha256 over the delivered content — owner UID, propagation-input
+// hash, NORAD, both epochs, and the full ECEF (position + velocity) — so it changes
+// iff the pushed payload changes, and a fresh re-propagation (new epoch and/or new
+// ECEF) is one such change. It deliberately does NOT treat EpochUnixMs as a
+// monotonic 1:1 proxy for the ECEF: EpochUnixMs is serialized wall-clock time with
+// no monotonic reading (see the time package docs), so across pods or an NTP step a
+// REPEATED epoch carrying a DIFFERENT ECEF (a new OMM propagated to the same target
+// instant after a clock rewind/skew) must still re-push — hashing the ECEF, not the
+// epoch alone, is what guarantees that. Refreshing epoch/ephemeris/TA is
+// SI-change-free per TS 38.331.
 //
 // #228 G4 resolution — the re-push cadence (bounded by the SatelliteEphemeris re-propagation interval, a
 // few minutes) versus ntn-UlSyncValidityDur (enum as low as 5 s; the old "NR max 240 s" note was wrong).
@@ -936,8 +945,16 @@ func ephemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris) string {
 // epoch-mode-independent, since re-reading a pinned epoch does not extend validity. This marker dedups by
 // epoch and decides neither.
 func runtimeEphemerisPushMarker(eph *ntnv1alpha1.SatelliteEphemeris, state *ntnv1alpha1.PropagatedState) string {
-	return fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
-		eph.Name, eph.Generation, state.NoradID, state.EpochUnixMs)
+	e := state.ECEF
+	// NUL-separated so field boundaries can't collide (e.g. a name ending in a digit + a NORAD).
+	// Generation and inputHash are both kept: generation forces a re-push on any spec bump (existing
+	// I-12 contract), inputHash pins the propagation inputs, and the ECEF closes the same-epoch gap.
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s\x00%d\x00%s\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d",
+		eph.UID, eph.Generation, eph.Status.PropagatedStatesInputHash,
+		state.NoradID, state.EpochUnixMs, state.SourceEpochUnixMs,
+		e.PosX, e.PosY, e.PosZ, e.VelX, e.VelY, e.VelZ))
+	// Readable prefix for operators; the digest is what the dedup compares.
+	return fmt.Sprintf("norad=%d epoch=%d digest=%s", state.NoradID, state.EpochUnixMs, hex.EncodeToString(sum[:]))
 }
 
 // radioFrameDuration is the NR radio-frame length (3GPP TS 38.211): 10 ms. siPeriod is expressed in

--- a/internal/controller/ntncellconfig_push_freshness_test.go
+++ b/internal/controller/ntncellconfig_push_freshness_test.go
@@ -68,6 +68,60 @@ func TestRuntimeEphemerisPushMarkerKeysOnEpoch(t *testing.T) {
 	}
 }
 
+// TestRuntimeEphemerisPushMarker_SameEpochDifferentPayload_NotDeduped covers the gap the
+// epoch-advances test (I-12 / #260) does not: EpochUnixMs is serialized wall-clock time with NO
+// monotonic reading, so a clock rewind or cross-pod skew can REPEAT a target epoch. A new OMM
+// propagated to that repeated epoch yields a DIFFERENT ECEF at the SAME epoch and generation; the
+// marker must still change so the fresh position/velocity is pushed, not silently dedup'd. This is
+// why the marker digests the payload, not just the epoch.
+func TestRuntimeEphemerisPushMarker_SameEpochDifferentPayload_NotDeduped(t *testing.T) {
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "eph-a", UID: "uid-1", Generation: 7},
+	}
+	eph.Status.PropagatedStatesInputHash = "hash-1"
+	base := &ntnv1alpha1.PropagatedState{
+		Satellite: "ISS", NoradID: 25544, EpochUnixMs: 1_700_000_000_000, SourceEpochUnixMs: 1_699_000_000_000,
+		ECEF: ntnv1alpha1.EphemerisECEF{PosX: 100, PosY: 200, PosZ: 300, VelX: 1, VelY: 2, VelZ: 3},
+	}
+	marker := func(e *ntnv1alpha1.SatelliteEphemeris, s ntnv1alpha1.PropagatedState) string {
+		return runtimeEphemerisPushMarker(e, &s)
+	}
+
+	// THE gap: same epoch + generation, different ECEF must change the marker.
+	movedPos := *base
+	movedPos.ECEF.PosX = 101
+	if marker(eph, *base) == marker(eph, movedPos) {
+		t.Fatal("same epoch + different ECEF position must change the marker (a clock rewind/skew would otherwise dedup the fresh position)")
+	}
+	movedVel := *base
+	movedVel.ECEF.VelZ = 99
+	if marker(eph, *base) == marker(eph, movedVel) {
+		t.Fatal("same epoch + different ECEF velocity must change the marker")
+	}
+	// A re-fetch (new source element-set epoch) at the same target epoch must change the marker.
+	newSrc := *base
+	newSrc.SourceEpochUnixMs += 60_000
+	if marker(eph, *base) == marker(eph, newSrc) {
+		t.Fatal("a different source element-set epoch must change the marker")
+	}
+	// Identical content → identical marker: dedup still works and is reproducible across a crash/restart.
+	d1, d2 := marker(eph, *base), marker(eph, *base)
+	if d1 != d2 {
+		t.Fatal("identical content must yield an identical (deterministic) marker")
+	}
+	// Owner UID (delete-recreate) and propagation-input hash each change the marker.
+	ephU := *eph
+	ephU.UID = "uid-2"
+	if marker(eph, *base) == marker(&ephU, *base) {
+		t.Fatal("an owner UID change must change the marker")
+	}
+	ephH := *eph
+	ephH.Status.PropagatedStatesInputHash = "hash-2"
+	if marker(eph, *base) == marker(&ephH, *base) {
+		t.Fatal("a propagation-input-hash change must change the marker")
+	}
+}
+
 // TestPushRuntime_RepushesOnFreshEpoch_I12 pins the end-to-end I-12 fix through
 // the reconciler helper: an already-pushed cell is NOT re-pushed for the same
 // epoch (dedup), but a fresh propagated epoch — with LastUpdated deliberately

--- a/internal/controller/ntncellconfig_runtime_push_envtest_test.go
+++ b/internal/controller/ntncellconfig_runtime_push_envtest_test.go
@@ -202,12 +202,13 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 		Eventually(prov.pushes, "10s").Should(Receive(&freshPush))
 		Expect(freshPush.EpochUnixMs).To(Equal(freshEpoch))
 
-		// Assert the persisted marker with a string built HERE, independent of runtimeEphemerisPushMarker — so
-		// a regression that drops epoch from that function's key is caught by THIS expectation rather than
-		// masked by it (the pre-existing catch-up assertion below computed its expectation with the function
-		// under test, so it could not). Also confirm the spec/generation/input-hash never moved.
-		freshMarker := fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
-			ephName, frozenGeneration, 25544, freshEpoch)
+		// Assert the persisted marker's readable prefix with a string built HERE, independent of
+		// runtimeEphemerisPushMarker — so a regression that drops epoch from that function's key is caught by
+		// THIS expectation rather than masked by it (the pre-existing catch-up assertion below computed its
+		// expectation with the function under test, so it could not). The marker is now
+		// "norad=<n> epoch=<ms> digest=<sha256>"; the digest is input-derived so we check the fresh-epoch
+		// prefix, not the full opaque hash. Also confirm the spec/generation/input-hash never moved.
+		freshMarkerPrefix := fmt.Sprintf("norad=%d epoch=%d digest=", 25544, freshEpoch)
 		Eventually(func(g Gomega) {
 			currentEph := &ntnv1alpha1.SatelliteEphemeris{}
 			g.Expect(k8sClient.Get(context.Background(), ephKey, currentEph)).To(Succeed())
@@ -222,7 +223,7 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 			g.Expect(fresh).NotTo(BeNil())
 			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(fresh.Reason).To(Equal("Pushed"))
-			g.Expect(fresh.Message).To(Equal(freshMarker))
+			g.Expect(fresh.Message).To(HavePrefix(freshMarkerPrefix))
 		}, "10s", "100ms").Should(Succeed())
 		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
 
@@ -252,7 +253,6 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 		// watch fans out exactly one fresh runtime push. The controller's own status
 		// write must not create a hot requeue or a fourth push (first, epoch-only, catch-up).
 		Expect(k8sClient.Get(context.Background(), ephKey, eph)).To(Succeed())
-		catchUpGeneration := eph.Generation
 		nextEpoch := freshEpoch + (3 * time.Minute).Milliseconds()
 		eph.Status.PropagatedStatesInputHash = propagationInputHash(eph.Spec)
 		eph.Status.PropagatedStates[0].EpochUnixMs = nextEpoch
@@ -269,8 +269,7 @@ var _ = Describe("NTNCellConfig runtime-push lifecycle (envtest)", func() {
 			g.Expect(fresh).NotTo(BeNil())
 			g.Expect(fresh.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(fresh.Reason).To(Equal("Pushed"))
-			g.Expect(fresh.Message).To(Equal(fmt.Sprintf("ephemerisRef=%s ephGeneration=%d norad=%d epoch=%d",
-				ephName, catchUpGeneration, 25544, nextEpoch)))
+			g.Expect(fresh.Message).To(HavePrefix(fmt.Sprintf("norad=%d epoch=%d digest=", 25544, nextEpoch)))
 		}, "10s", "100ms").Should(Succeed())
 		Consistently(prov.pushes, "2s", "100ms").ShouldNot(Receive())
 	})


### PR DESCRIPTION
## What

Replaces the runtime-push dedup marker's "epoch is a monotonic 1:1 proxy for the ECEF" assumption with a content digest, closing a low-probability HA/clock-anomaly correctness gap.

## Why

`runtimeEphemerisPushMarker` keyed the dedup on `EpochUnixMs` alone (plus name/generation/NORAD), and its comment claimed the epoch was a monotonic 1:1 proxy for the propagated ECEF. But `EpochUnixMs` is **serialized wall-clock time with no monotonic reading** (Go `time` package: the monotonic clock reading is stripped on serialization, and the wall clock can be corrected). So the epoch is not a global monotonic identity across pods or an NTP step. Constructible failure:

1. A new fetch yields a different OMM → a different ECEF at the same target epoch.
2. A node clock rewind, or an HA node time skew, makes the new target `EpochUnixMs` equal a previous marker's.
3. `eph.Generation` is unchanged (only upstream data updated).
4. The marker is byte-identical → the fresh ECEF is silently dedup'd (the gNB keeps the stale position).

#260 added an "epoch only advances" isolation test, but nothing covered "epoch identical, payload changed."

## How

`runtimeEphemerisPushMarker` now returns a readable prefix plus a sha256 over the delivered content: **owner UID, `propagatedStatesInputHash`, NORAD, `EpochUnixMs`, `SourceEpochUnixMs`, and the full ECEF (posX/Y/Z + velX/Y/Z)**. It changes iff the pushed payload changes — a fresh epoch is one such change, so the per-propagation re-push cadence (I-12) is preserved, and a same-epoch/different-ECEF push now correctly re-pushes. `Generation` is kept in the digest so the existing "spec bump → re-push" contract holds. The false monotonicity comment is rewritten to state why the epoch alone is insufficient.

The marker is a deterministic function of its inputs (fixed field order, NUL-separated), so it reproduces across a crash/restart — the idempotent-re-push behavior is unchanged.

## Testing

- `TestRuntimeEphemerisPushMarker_SameEpochDifferentPayload_NotDeduped` (new): same epoch + changed ECEF position, changed velocity, and changed source epoch each change the marker; identical content yields an identical (deterministic) marker; owner-UID and input-hash changes each change the marker.
- Existing `TestRuntimeEphemerisPushMarkerKeysOnEpoch` (epoch/NORAD/generation → different marker) and the crash-idempotency tests stay green.
- Full gate: `make test`, `golangci-lint`, `-race`.

## Notes

Marker is only ever compared (string-equality dedup) / persisted in the `EphemerisPushed` condition — never parsed — so the format change is safe. On upgrade, an already-pushed cell's stored (old-format) marker won't match, triggering one harmless, idempotent re-push of the current state (CHANGELOG upgrade note).
