### PR TITLE
test(ocudu): pin the two-renderer ephemeris byte-equality contract

### DIFF
--- a/pkg/provider/ocudu/provider_noop_test.go
+++ b/pkg/provider/ocudu/provider_noop_test.go
@@ -18,6 +18,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
 // TestApplyCellConfig_NoOpOnIdenticalContent_G3 pins #204-G3a: re-applying an identical
@@ -184,4 +187,112 @@ func TestApplyCellConfig_NoOp_AnnotationRepaired_M2(t *testing.T) {
 	if after.ResourceVersion == before.ResourceVersion {
 		t.Fatal("repairing the annotation must Update (the annotation equality clause must be required independently)")
 	}
+}
+
+// orbitalSpec returns a spec whose ephemeris is the Keplerian orbital variant, so the
+// tests exercise the renderEphemerisBlock / GenerateConfig orbital branch (semi_major_axis,
+// eccentricity, inclination, longitude, periapsis, mean_anomaly) alongside the ECEF branch.
+// Values are in-range per the CRD kubebuilder bounds and chosen so the codepoint→physical-SI
+// conversions produce non-integer floats: a float-format divergence between the two renderers
+// would then surface in the byte comparison, not hide behind round numbers.
+func orbitalSpec() *ntnv1alpha1.NTNCellConfigSpec {
+	return &ntnv1alpha1.NTNCellConfigSpec{
+		Provider: ntnv1alpha1.ProviderRef{Type: "ocudu", Namespace: "ntn-system"},
+		NTN: ntnv1alpha1.NTNParams{
+			CellSpecificKoffset: 150,
+			EphemerisOrbital: &ntnv1alpha1.EphemerisOrbital{
+				SemiMajorAxis:  6900000, // metres (LEO ~520 km) — passthrough int
+				Eccentricity:   1000,    // ×1e-6 → 0.001
+				Inclination:    530000,  // 1e-4 deg (53°) → radians
+				RightAscension: 1200000, // 1e-4 deg (120°) → radians
+				ArgOfPeriapsis: 900000,  // 1e-4 deg (90°) → radians
+				MeanAnomaly:    450000,  // 1e-4 deg (45°) → radians
+			},
+			PayloadType: "transparent",
+		},
+	}
+}
+
+// assertPushRoundTripNoChurn drives the REAL bootstrap workflow for one ephemeris variant
+// and pins the two-renderer byte-equality contract end to end. PushEphemerisUpdate re-renders
+// the ephemeris block with a SEPARATE renderer (renderEphemerisBlock + replaceEphemeris's line
+// surgery) from the full-config GenerateConfig that ApplyCellConfig writes; renderEphemerisBlock
+// only promises in a comment to apply "the SAME codepoint→physical-SI conversions as
+// GenerateConfig". Nothing pinned that the two agree byte-for-byte. If they ever diverge
+// (whitespace, float format, key name/order, a scale, or replaceEphemeris eating a surrounding
+// line), the bytes Push writes stop equalling GenerateConfig(spec), so the NEXT Apply on every
+// SatelliteEphemeris fan-out rewrites the byte-different ConfigMap and churns every watcher on
+// the ~3-minute cadence (#204-G3) — silently, since no error is raised.
+//
+// It asserts BOTH halves the churn depends on:
+//
+//	(contract) the post-Push ConfigMap byte-equals GenerateConfig(spec); AND
+//	(no churn) a second Apply on the same spec is a no-op (resourceVersion unchanged).
+//
+// The resourceVersion check is meaningful here (unlike a redundant identical write, which the
+// store would short-circuit) because a renderer divergence is a REAL byte change: the post-Push
+// Apply would genuinely rewrite and bump resourceVersion. Mutation: perturb renderEphemerisBlock
+// (rename a key, drop a scale factor, or change the indent) → the contract assertion fails first,
+// and the round-trip assertion independently catches the same divergence (the post-Push Apply
+// then rewrites and bumps resourceVersion).
+func assertPushRoundTripNoChurn(t *testing.T, spec *ntnv1alpha1.NTNCellConfigSpec, update provider.EphemerisUpdate) {
+	t.Helper()
+	p := newTestProvider(t)
+	ctx := context.Background()
+	owner := ownerFor("test-cr")
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Push the SAME ephemeris the spec already carries (the steady-state fan-out: a
+	// re-resolved SatelliteEphemeris with unchanged elements). The re-render must
+	// reproduce exactly what GenerateConfig emitted for that ephemeris.
+	if err := p.PushEphemerisUpdate(ctx, owner, update); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	want, err := GenerateConfig(spec)
+	if err != nil {
+		t.Fatalf("GenerateConfig: %v", err)
+	}
+	var afterPush corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &afterPush); err != nil {
+		t.Fatalf("get after push: %v", err)
+	}
+	if got := afterPush.Data[configDataKey]; got != string(want) {
+		t.Fatalf("PushEphemerisUpdate must reproduce GenerateConfig(spec) byte-for-byte "+
+			"(the two ephemeris renderers must agree, else every fan-out re-Apply churns the ConfigMap)"+
+			":\n--- push wrote ---\n%s\n--- GenerateConfig ---\n%s", got, want)
+	}
+
+	// Round-trip: the next Apply on the same spec finds byte-identical stored content, so the
+	// #204-G3 no-op guard skips the write and resourceVersion does not advance.
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	var afterApply corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &afterApply); err != nil {
+		t.Fatalf("get after re-apply: %v", err)
+	}
+	if afterPush.ResourceVersion != afterApply.ResourceVersion {
+		t.Fatalf("a post-Push Apply on the same spec must be a round-trip no-op: "+
+			"resourceVersion %q -> %q", afterPush.ResourceVersion, afterApply.ResourceVersion)
+	}
+}
+
+// TestRoundTrip_PushMatchesGenerateConfig_ECEF pins the two-renderer contract for the ECEF
+// state-vector path (pos_x…vel_z, ×1.3 m / ×0.06 m·s⁻¹). See assertPushRoundTripNoChurn.
+func TestRoundTrip_PushMatchesGenerateConfig_ECEF(t *testing.T) {
+	spec := geoSpec()
+	assertPushRoundTripNoChurn(t, spec, provider.EphemerisUpdate{ECEF: spec.NTN.EphemerisECEF})
+}
+
+// TestRoundTrip_PushMatchesGenerateConfig_Orbital pins the two-renderer contract for the
+// Keplerian orbital path (semi_major_axis, eccentricity, inclination, longitude, periapsis,
+// mean_anomaly). It is a distinct branch of both renderers from ECEF, so it needs its own
+// pin. See assertPushRoundTripNoChurn.
+func TestRoundTrip_PushMatchesGenerateConfig_Orbital(t *testing.T) {
+	spec := orbitalSpec()
+	assertPushRoundTripNoChurn(t, spec, provider.EphemerisUpdate{Orbital: spec.NTN.EphemerisOrbital})
 }


### PR DESCRIPTION
## What

`PushEphemerisUpdate` re-renders the ephemeris block with a separate renderer (`renderEphemerisBlock` + `replaceEphemeris`'s in-place line surgery) from the full-config `GenerateConfig` that `ApplyCellConfig` writes. `renderEphemerisBlock` only promises, in a code comment, to apply "the SAME codepoint→physical-SI conversions as GenerateConfig". Nothing pinned that the two actually agree byte-for-byte.

The existing no-op tests in `provider_noop_test.go` all exercise `Apply → Apply` through the same renderer, so they can't catch a drift between the two. This adds the missing `Apply → Push → Apply` round-trip for both ephemeris variants (ECEF state vector and Keplerian orbital).

## Why it matters

`ApplyCellConfig` skips its write when the stored ConfigMap already byte-equals `GenerateConfig(spec)` (the #204-G3 churn guard). After a `PushEphemerisUpdate`, the ConfigMap's ephemeris block is whatever `renderEphemerisBlock` produced. If that ever diverges from `GenerateConfig` (whitespace, float format, a key name or order, a scale factor, or `replaceEphemeris` consuming a surrounding line), the stored bytes stop equalling `GenerateConfig(spec)`, and the next `ApplyCellConfig` on every SatelliteEphemeris fan-out rewrites the byte-different ConfigMap. That reintroduces the exact per-fan-out churn #204-G3 removed, silently, with no error raised.

The two renderers agree today, so this is a regression guard, not a bug fix.

## The tests

Each test asserts both halves the churn outcome depends on:

- **contract**: the post-Push ConfigMap byte-equals `GenerateConfig(spec)`
- **no churn**: the next `ApplyCellConfig` on the same spec is a no-op (`resourceVersion` unchanged)

The `resourceVersion` check is meaningful here because a renderer divergence is a real byte change: the post-Push Apply would genuinely rewrite and bump `resourceVersion`. (A redundant *identical* write would be short-circuited by the store and stay invisible to `resourceVersion`, which is why the contract assertion is the primary check.)

## Verification

- Test-only, no production change.
- `go test ./pkg/provider/ocudu/...`, `go vet`, `gofmt`, and `golangci-lint run` are all clean.
- Mutation-verified for the right reason: perturbing the ECEF branch (a key name) fails only the ECEF test; perturbing the orbital branch (a scale factor) fails only the orbital test. Both fail via the byte-contract assertion.
