### PR TITLE
fix(ntnslice): gate satellite availability on ephemeris delivery freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **NTNSlice no longer fails over to a satellite whose ephemeris is too stale to deliver.** NTNSlice
+  keyed satellite availability on the producer's `PassesPredicted` condition plus an active pass window,
+  while NTNCellConfig gates the runtime push on the element set's source-epoch freshness
+  (`sourceEpochFresh` / `maxEpochAge`). During a `>maxEpochAge` upstream outage the two consumers of
+  `PropagatedStates` disagreed: pass prediction kept succeeding off the stale, drifting OMM so NTNSlice
+  reported the satellite available and steered traffic onto it, but NTNCellConfig then refused to push
+  its stale ephemeris to the gNB — a control-plane split that stranded traffic on an unconfigurable
+  path. `checkSatelliteAvailability` now demotes an active window whose satellite has a present-but-stale
+  propagated state (correlated by NORAD — `PassWindow` gains a `noradID` field), so both consumers share
+  one freshness contract; the `FailoverReady=SatelliteUnavailable` message cites the staleness.
+  Mutation-tested, including an end-to-end reconcile proving a fired terrestrial trigger does not fail
+  over to a stale satellite.
+
 - **Runtime satellite selection is now deterministic and fails closed instead of silently switching
   satellites.** `SatelliteEphemeris` propagated states inherited the upstream response order
   (`FilterOMMs` preserves it; no dedup, no sort), so with a multi-satellite ephemeris and no
@@ -342,6 +355,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade notes
 
+- **A satellite whose element set is stale beyond `maxEpochAge` now holds NTNSlice on terrestrial**
+  instead of failing over to it — previously NTNSlice could steer traffic onto a satellite whose stale
+  ephemeris NTNCellConfig refused to push. No action needed; refresh the `SatelliteEphemeris` source to
+  restore satellite availability. `PassWindow` gains an optional `noradID` field (additive, backward
+  compatible; existing windows repopulate it on the next prediction).
 - **Runtime push now fails closed for a multi-satellite ephemeris with no `ephemerisNoradID`.** An
   existing `NTNCellConfig` on the runtime-push path that left `spec.ephemerisNoradID` unset while its
   referenced `SatelliteEphemeris` tracks more than one satellite will now hold with

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -136,6 +136,13 @@ type PassWindow struct {
 	// satellite is the name or NORAD ID of the satellite.
 	Satellite string `json:"satellite"`
 
+	// noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+	// to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+	// backing element set's delivery freshness (same contract as the runtime push). 0 only for
+	// windows written before this field existed (freshness then treated as unverifiable).
+	// +optional
+	NoradID int `json:"noradID,omitempty"`
+
 	// groundStation is the name of the GroundStationLifecycle resource.
 	GroundStation string `json:"groundStation"`
 

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -296,6 +296,13 @@ spec:
                         the pass in degrees (string, e.g., "72.5").
                       pattern: ^-?[0-9]+\.?[0-9]*$
                       type: string
+                    noradID:
+                      description: |-
+                        noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+                        to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+                        backing element set's delivery freshness (same contract as the runtime push). 0 only for
+                        windows written before this field existed (freshness then treated as unverifiable).
+                      type: integer
                     satellite:
                       description: satellite is the name or NORAD ID of the satellite.
                       type: string

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -296,6 +296,13 @@ spec:
                         the pass in degrees (string, e.g., "72.5").
                       pattern: ^-?[0-9]+\.?[0-9]*$
                       type: string
+                    noradID:
+                      description: |-
+                        noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+                        to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+                        backing element set's delivery freshness (same contract as the runtime push). 0 only for
+                        windows written before this field existed (freshness then treated as unverifiable).
+                      type: integer
                     satellite:
                       description: satellite is the name or NORAD ID of the satellite.
                       type: string

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -299,6 +299,13 @@ spec:
                         the pass in degrees (string, e.g., "72.5").
                       pattern: ^-?[0-9]+\.?[0-9]*$
                       type: string
+                    noradID:
+                      description: |-
+                        noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+                        to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+                        backing element set's delivery freshness (same contract as the runtime push). 0 only for
+                        windows written before this field existed (freshness then treated as unverifiable).
+                      type: integer
                     satellite:
                       description: satellite is the name or NORAD ID of the satellite.
                       type: string

--- a/internal/controller/ephemeris_pass_contract_round5_test.go
+++ b/internal/controller/ephemeris_pass_contract_round5_test.go
@@ -100,7 +100,7 @@ func TestCheckSatelliteAvailability_PassesPredictedGate(t *testing.T) {
 			}
 			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph, slice).Build()
 			r := &NTNSliceReconciler{Client: cli, Scheme: sch}
-			available, known := r.checkSatelliteAvailability(context.Background(), slice, now)
+			available, known, _ := r.checkSatelliteAvailability(context.Background(), slice, now)
 			if available != tc.wantAvailable || known != tc.wantKnown {
 				t.Fatalf("checkSatelliteAvailability = (available=%v, known=%v), want (available=%v, known=%v)",
 					available, known, tc.wantAvailable, tc.wantKnown)

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -297,9 +297,9 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Step 3: Check satellite availability via SatelliteEphemeris. satelliteKnown is
 	// false on a transient ephemeris read error — availability is unknown and the
 	// current path is held rather than switched off satellite (I-13).
-	satelliteAvailable, satelliteKnown := r.checkSatelliteAvailability(ctx, ns, now)
+	satelliteAvailable, satelliteKnown, satelliteDetail := r.checkSatelliteAvailability(ctx, ns, now)
 	log.V(1).Info("satellite availability", "available", satelliteAvailable, "known", satelliteKnown,
-		"ephemerisRef", ns.Spec.SatellitePath.EphemerisRef)
+		"ephemerisRef", ns.Spec.SatellitePath.EphemerisRef, "detail", satelliteDetail)
 
 	// FailoverReady tracks whether quality-driven failover can operate. When metrics
 	// are reliable it reflects satellite availability; when they are not,
@@ -316,8 +316,11 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			c = metav1.Condition{Status: metav1.ConditionTrue, Reason: "SatelliteAvailable",
 				Message: "Satellite pass window active"}
 		default:
-			c = metav1.Condition{Status: metav1.ConditionFalse, Reason: "SatelliteUnavailable",
-				Message: "No satellite pass window active or SatelliteEphemeris not found"}
+			msg := satelliteDetail
+			if msg == "" {
+				msg = "No satellite pass window active or SatelliteEphemeris not found"
+			}
+			c = metav1.Condition{Status: metav1.ConditionFalse, Reason: "SatelliteUnavailable", Message: msg}
 		}
 		c.Type = ntnv1alpha1.ConditionFailoverReady
 		c.ObservedGeneration = ns.Generation
@@ -773,20 +776,20 @@ func (r *NTNSliceReconciler) checkSatelliteAvailability(
 	ctx context.Context,
 	ns *ntnv1alpha1.NTNSlice,
 	now time.Time,
-) (available, known bool) {
+) (available, known bool, detail string) {
 	eph := &ntnv1alpha1.SatelliteEphemeris{}
 	key := client.ObjectKey{Namespace: ns.Namespace, Name: ns.Spec.SatellitePath.EphemerisRef}
 	if err := r.Get(ctx, key, eph); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Dangling ephemerisRef: no ephemeris to drive the satellite path. This
 			// is a genuine (persistent) signal, not a transient blip — allow switchback.
-			return false, true
+			return false, true, "referenced SatelliteEphemeris not found"
 		}
 		// Transient read error: availability is UNKNOWN. Do NOT force a switch off
 		// satellite; the caller holds the current path (I-13).
 		logf.FromContext(ctx).Error(err, "failed to get SatelliteEphemeris; holding current path",
 			"ref", ns.Spec.SatellitePath.EphemerisRef)
-		return false, false
+		return false, false, ""
 	}
 
 	// The pass windows are trustworthy ONLY when the producer's most recent prediction SUCCEEDED. If
@@ -796,14 +799,49 @@ func (r *NTNSliceReconciler) checkSatelliteAvailability(
 	// completes the SatelliteEphemeris(producer) -> NTNSlice(consumer) pass-status contract (ADR 0006 /
 	// #234): the producer leaves PassesPredicted=True only while NextPassWindows reflects the live inputs.
 	if !meta.IsStatusConditionTrue(eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted) {
-		return false, false
+		return false, false, ""
 	}
-	for _, pw := range eph.Status.NextPassWindows {
-		if !pw.AOS.After(now) && pw.LOS.After(now) {
-			return true, true // currently in a pass window
+
+	// An active pass makes the satellite AVAILABLE unless its backing element set is present but too
+	// STALE to DELIVER — the same sourceEpochFresh (maxEpochAge) gate NTNCellConfig enforces at the
+	// runtime push. Without this the two consumers of PropagatedStates disagree during a >maxEpochAge
+	// outage: NTNSlice fails over to a satellite whose stale ephemeris NTNCellConfig then refuses to push
+	// (a control-plane split that strands traffic on an unconfigurable path). Pass prediction is itself
+	// SGP4 propagation, so an element set too stale to push is equally untrustworthy for the window.
+	// Correlate by NORAD — the canonical key; PropagatedState.Satellite is a truncated, non-unique name.
+	//
+	// Scope: only a PRESENT-but-stale state demotes the window (that IS the reported split — NTNCellConfig
+	// has the state but refuses it). A window whose satellite has a fresh state, no state, or predates the
+	// noradID field stays available: a window and its propagatedState are produced together from one
+	// reconcile's OMMs, so "window but no state" is not the stale-outage case this closes.
+	stale := make(map[int]bool)
+	for i := range eph.Status.PropagatedStates {
+		ps := &eph.Status.PropagatedStates[i]
+		if sourceEpochFresh(now, time.UnixMilli(ps.SourceEpochUnixMs)) != nil {
+			stale[ps.NoradID] = true
 		}
 	}
-	return false, true // prediction current, no active pass — a genuine end-of-pass signal
+	activeDeliverable, activeStale := false, false
+	for i := range eph.Status.NextPassWindows {
+		pw := &eph.Status.NextPassWindows[i]
+		if pw.AOS.After(now) || !pw.LOS.After(now) {
+			continue // not currently in this window
+		}
+		if pw.NoradID != 0 && stale[pw.NoradID] {
+			activeStale = true // overhead but its element set is too stale to deliver
+		} else {
+			activeDeliverable = true
+		}
+	}
+	switch {
+	case activeDeliverable:
+		return true, true, "" // a deliverable satellite is overhead (fresh wins over any stale sibling)
+	case activeStale:
+		return false, true, fmt.Sprintf(
+			"satellite overhead but its element set is stale beyond the %s freshness bound — not deliverable to the gNB", maxEpochAge)
+	default:
+		return false, true, "no active satellite pass window"
+	}
 }
 
 // now returns the current time (injectable for testing).

--- a/internal/controller/ntnslice_ephemeris_freshness_test.go
+++ b/internal/controller/ntnslice_ephemeris_freshness_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestCheckSatelliteAvailability_SourceEpochFreshnessGate pins the fix for the control-plane split:
+// NTNSlice must NOT report a satellite available off a pass window whose backing element set is too
+// stale to DELIVER — otherwise it fails over to a satellite whose ephemeris NTNCellConfig then refuses
+// to push (both use maxEpochAge, but only the consumer used to enforce it). The gate correlates the
+// active window to its propagatedState by NORAD.
+func TestCheckSatelliteAvailability_SourceEpochFreshnessGate(t *testing.T) {
+	const ns = "default"
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	freshMs := now.Add(-time.Hour).UnixMilli()               // well within maxEpochAge
+	staleMs := now.Add(-maxEpochAge - time.Hour).UnixMilli() // just past maxEpochAge
+
+	window := func(norad int) ntnv1alpha1.PassWindow {
+		return ntnv1alpha1.PassWindow{
+			Satellite: "SAT", NoradID: norad, GroundStation: "gs",
+			AOS: metav1.Time{Time: now.Add(-5 * time.Minute)}, LOS: metav1.Time{Time: now.Add(5 * time.Minute)},
+		}
+	}
+	state := func(norad int, srcMs int64) ntnv1alpha1.PropagatedState {
+		return ntnv1alpha1.PropagatedState{NoradID: norad, EpochUnixMs: now.Add(5 * time.Minute).UnixMilli(), SourceEpochUnixMs: srcMs}
+	}
+	predictedTrue := []metav1.Condition{{Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue, Reason: "x"}}
+
+	cases := []struct {
+		name          string
+		windows       []ntnv1alpha1.PassWindow
+		states        []ntnv1alpha1.PropagatedState
+		wantAvailable bool
+		wantKnown     bool
+		detailHas     string // substring required in the returned detail (empty = no check)
+	}{
+		{"active window backed by a FRESH element set → available",
+			[]ntnv1alpha1.PassWindow{window(25544)}, []ntnv1alpha1.PropagatedState{state(25544, freshMs)}, true, true, ""},
+		{"active window backed by a STALE element set → unavailable (genuine, not hold)",
+			[]ntnv1alpha1.PassWindow{window(25544)}, []ntnv1alpha1.PropagatedState{state(25544, staleMs)}, false, true, "stale"},
+		{"active window whose NORAD has no propagatedState → available (no-state out of scope; only present-but-stale demotes)",
+			[]ntnv1alpha1.PassWindow{window(25544)}, []ntnv1alpha1.PropagatedState{state(40000, freshMs)}, true, true, ""},
+		{"legacy window (noradID=0) is never demoted, even against a stale state → available",
+			[]ntnv1alpha1.PassWindow{window(0)}, []ntnv1alpha1.PropagatedState{state(25544, staleMs)}, true, true, ""},
+		{"two active windows, one fresh one stale → fresh wins (a deliverable satellite is overhead)",
+			[]ntnv1alpha1.PassWindow{window(40000), window(25544)},
+			[]ntnv1alpha1.PropagatedState{state(40000, staleMs), state(25544, freshMs)}, true, true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sch := makeScheme(t)
+			eph := &ntnv1alpha1.SatelliteEphemeris{
+				ObjectMeta: metav1.ObjectMeta{Name: "eph", Namespace: ns},
+				Status:     ntnv1alpha1.SatelliteEphemerisStatus{NextPassWindows: tc.windows, PropagatedStates: tc.states, Conditions: predictedTrue},
+			}
+			slice := &ntnv1alpha1.NTNSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "slice", Namespace: ns},
+				Spec:       ntnv1alpha1.NTNSliceSpec{SatellitePath: ntnv1alpha1.SatellitePathSpec{EphemerisRef: "eph"}},
+			}
+			cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph, slice).Build()
+			r := &NTNSliceReconciler{Client: cli, Scheme: sch}
+
+			available, known, detail := r.checkSatelliteAvailability(context.Background(), slice, now)
+			if available != tc.wantAvailable || known != tc.wantKnown {
+				t.Fatalf("got (available=%v, known=%v), want (available=%v, known=%v); detail=%q",
+					available, known, tc.wantAvailable, tc.wantKnown, detail)
+			}
+			if tc.detailHas != "" && !strings.Contains(detail, tc.detailHas) {
+				t.Fatalf("detail %q does not contain %q", detail, tc.detailHas)
+			}
+		})
+	}
+}
+
+// TestReconcile_NoFailoverToStaleSatellite is the MANDATED acceptance test for the control-plane
+// split: warm cache → sustained upstream outage → the element-set age crosses maxEpochAge → an active
+// pass window is still present (pass prediction keeps succeeding off the stale, drifting OMM, so
+// PassesPredicted stays True) → a terrestrial failover trigger fires → the slice must NOT fail over to
+// the satellite, because its stale ephemeris is not deliverable (NTNCellConfig would refuse the push).
+// Before the fix, NTNSlice reported the satellite available off the active window and steered traffic
+// onto a path the gNB cannot be configured for.
+func TestReconcile_NoFailoverToStaleSatellite(t *testing.T) {
+	fixedNow := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: "terrestrial"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+
+	// Active pass window around now, but its backing element set is STALE beyond maxEpochAge — pass
+	// prediction still "succeeds" off the drifting OMM (PassesPredicted=True) yet the state is not
+	// deliverable (same sourceEpochFresh bound NTNCellConfig enforces at the push).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", NoradID: 44057, GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-time.Hour)}, LOS: metav1.Time{Time: fixedNow.Add(time.Hour)},
+	}}
+	eph.Status.PropagatedStates = []ntnv1alpha1.PropagatedState{{
+		NoradID: 44057, EpochUnixMs: fixedNow.Add(5 * time.Minute).UnixMilli(),
+		SourceEpochUnixMs: fixedNow.Add(-maxEpochAge - time.Hour).UnixMilli(),
+	}}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue, Reason: "Predicted"})
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris: %v", err)
+	}
+
+	// FRESH metrics that DO fire "rsrp < -100" — failover to satellite is genuinely wanted, so the ONLY
+	// thing that can hold the slice on terrestrial is the satellite being (correctly) unavailable.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics: slice.Metrics{RSRP: -120, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:   false, LastFreshAt: fixedNow,
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+
+	if got := updated.Status.ActivePathType; got != "terrestrial" {
+		t.Fatalf("must NOT fail over to a stale satellite: ActivePathType=%q, want terrestrial", got)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionFailoverReady)
+	if cond == nil || cond.Reason != "SatelliteUnavailable" || !strings.Contains(cond.Message, "stale") {
+		t.Fatalf("FailoverReady must be SatelliteUnavailable citing staleness, got %+v", cond)
+	}
+}
+
+// TestReconcile_SwitchesBackFromStaleSatellite is the companion to NoFailoverToStaleSatellite: a slice
+// ALREADY on satellite whose element set ages past maxEpochAge must be moved BACK to terrestrial —
+// leaving it on a satellite whose ephemeris NTNCellConfig can no longer push would strand it. Metrics
+// are fresh and GOOD (no quality trigger fires), so the ONLY driver of the switch is the staleness gate.
+func TestReconcile_SwitchesBackFromStaleSatellite(t *testing.T) {
+	fixedNow := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"}}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath:   ntnv1alpha1.SatellitePathSpec{PathSpec: ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"}, EphemerisRef: "oneweb-constellation"},
+			FailoverPolicy:  ntnv1alpha1.FailoverPolicy{Triggers: []string{"rsrp < -100"}, SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second}},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: "satellite"}, // currently ON satellite
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", NoradID: 44057, GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-time.Hour)}, LOS: metav1.Time{Time: fixedNow.Add(time.Hour)},
+	}}
+	eph.Status.PropagatedStates = []ntnv1alpha1.PropagatedState{{
+		NoradID: 44057, EpochUnixMs: fixedNow.Add(5 * time.Minute).UnixMilli(),
+		SourceEpochUnixMs: fixedNow.Add(-maxEpochAge - time.Hour).UnixMilli(),
+	}}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue, Reason: "Predicted"})
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris: %v", err)
+	}
+	fr := fakeReader{res: slicemetrics.Result{Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow}}
+	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }, ReaderProvider: fakeReaderProvider{reader: fr}}
+	key := client.ObjectKeyFromObject(nsObj)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if got := updated.Status.ActivePathType; got != "terrestrial" {
+		t.Fatalf("a slice on a now-stale satellite must switch back to terrestrial: ActivePathType=%q", got)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionFailoverReady)
+	if cond == nil || cond.Reason != "SatelliteUnavailable" || !strings.Contains(cond.Message, "stale") {
+		t.Fatalf("FailoverReady must be SatelliteUnavailable citing staleness, got %+v", cond)
+	}
+}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -1431,6 +1431,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	for _, p := range passes {
 		windows = append(windows, ntnv1alpha1.PassWindow{
 			Satellite:     p.Satellite,
+			NoradID:       p.NoradID,
 			GroundStation: p.GroundStation,
 			AOS:           metav1.Time{Time: p.AOS},
 			LOS:           metav1.Time{Time: p.LOS},

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -296,6 +296,13 @@ spec:
                         the pass in degrees (string, e.g., "72.5").
                       pattern: ^-?[0-9]+\.?[0-9]*$
                       type: string
+                    noradID:
+                      description: |-
+                        noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+                        to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+                        backing element set's delivery freshness (same contract as the runtime push). 0 only for
+                        windows written before this field existed (freshness then treated as unverifiable).
+                      type: integer
                     satellite:
                       description: satellite is the name or NORAD ID of the satellite.
                       type: string

--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -46,6 +46,7 @@ type GroundStation struct {
 // PassResult holds a predicted pass window.
 type PassResult struct {
 	Satellite     string
+	NoradID       int
 	GroundStation string
 	AOS           time.Time
 	LOS           time.Time
@@ -286,6 +287,7 @@ func predictSingle(
 		}
 		results = append(results, PassResult{
 			Satellite:     omm.ObjectName,
+			NoradID:       omm.NoradCatID,
 			GroundStation: gs.Name,
 			AOS:           aos,
 			LOS:           los,


### PR DESCRIPTION
## What

Closes a control-plane split where NTNSlice could fail over to a satellite whose ephemeris NTNCellConfig then refuses to push — stranding traffic on an unconfigurable path.

## Why

The two consumers of `SatelliteEphemeris.status.propagatedStates` used **divergent freshness contracts**:

- **NTNSlice** (`checkSatelliteAvailability`) keyed satellite availability on `PassesPredicted=True` + an active pass window — no source-epoch check.
- **NTNCellConfig** (`pushRuntimeEphemeris`) gates the runtime push on `sourceEpochFresh` (`maxEpochAge`).

During a `>maxEpochAge` upstream outage the producer keeps propagating the stale, drifting OMM (`EphemerisEpochStale`, by design — I-17) and pass prediction keeps succeeding, so `PassesPredicted` stays `True`. NTNSlice then reports the satellite available and steers traffic onto it, while NTNCellConfig refuses to push the stale ephemeris (`EphemerisStale`). Verified against the code (`checkSatelliteAvailability:798-806`, `sourceEpochFresh` is called only at `ntncellconfig_controller.go:688`, pass prediction has no freshness gate).

Domain grounding: SGP4 position error stays ~1 km for ~7 days from epoch but degrades to km/tens-of-km afterward; **pass prediction is itself SGP4 propagation**, so an element set too stale to *push* is equally untrustworthy for the *pass window* — one shared `maxEpochAge` bound is physically correct ([AFIT SGP4/TLE accuracy study](https://amostech.com/TechnicalPapers/2014/Poster/OLTROGGE.pdf), [MDPI CubeSat TLE accuracy](https://www.mdpi.com/1424-8220/22/8/2902)).

## How

`checkSatelliteAvailability` now demotes an active pass window whose satellite has a **present-but-stale** propagated state — the same `sourceEpochFresh` bound the push enforces — so both consumers share one freshness contract. Correlation is by **NORAD** (`PassWindow`/`PassResult` gain a `noradID` field, populated by pass prediction; `PropagatedState.Satellite` is a truncated, non-unique name). When all active windows are stale it returns `available=false, known=true` and the `FailoverReady=SatelliteUnavailable` message cites the staleness.

**Deliberate scope / deviations from the review's suggestion (flagged for the record):**
- The gate is **consumer-side (NTNSlice)**, not in pass prediction — matching NTNCellConfig and the codebase's "producer propagates, consumer gates" pattern (keeps `EphemerisEpochStale` observability and the pass-prediction path unchanged). The review's "pass prediction excludes stale OMMs" would be the wrong layer.
- Only a **present-but-stale** state demotes; a fresh state, no state, or a pre-`noradID` window stays available (a window and its state are co-produced from one reconcile's OMMs, so "window but no state" is not the stale-outage case). This is why the fix touches no existing test's expectations.
- No "satellite selector match" — NTNSlice has no satellite selector (that lives on NTNCellConfig).

## Testing

- `TestCheckSatelliteAvailability_SourceEpochFreshnessGate` (`-race`): fresh→available, present-stale→unavailable+detail, no-state→available (scoped), legacy `noradID=0`→available, mixed fresh+stale→available (fresh wins).
- **Mandated** `TestReconcile_NoFailoverToStaleSatellite`: warm → outage past `maxEpochAge` → active pass still present → a fired `rsrp < -100` terrestrial trigger → the slice stays terrestrial (does not fail over to the stale satellite), `FailoverReady=SatelliteUnavailable` citing staleness.
- Full gate green: `make test` (controller 89.6%), `golangci-lint` (0 issues), `-race`. All 4 CRD copies synced with the additive `noradID` field.
