### PR TITLE
fix(ephemeris): bound external OMM ObjectName (status-amplification DoS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Runtime NTN push no longer follows redirects on the WebSocket handshake.** A
+- **External OMM `OBJECT_NAME` can no longer amplify the SatelliteEphemeris status past the etcd object
+  limit.** `PropagatedState.satellite` was already bounded (MaxLength 64), but `PassWindow.satellite`
+  copied the full external name into up to `MaxPassWindows` (500) windows, the pass-prediction
+  TLE-conversion error embedded it unbounded (→ `PassesPredicted` condition), and the deep-space
+  rejection summary named satellites unbounded (→ `UnsupportedOrbitRegime` condition). A single long name
+  (GP responses allow up to 50 MB) could thus inflate a bounded input into a status object exceeding
+  etcd's ~1.5 MB limit — the status write then fails and the reconcile stalls — or pressure controller
+  memory. Because the source URL is CR-controlled, the SSRF guard does not imply trusted response content
+  (a legitimate public HTTPS endpoint can return a malicious OMM). A shared, rune-safe
+  `ephemeris.BoundedSatelliteLabel` now bounds the name to 64 code points at every persist/surface site
+  (pass windows, propagated states, and error/condition messages); `PassWindow.satellite` gains a CRD
+  `MaxLength=64` as a defense-in-depth apiserver gate; and the canonical satellite identity is the NORAD ID
+  (the name is a display label only). The rune-safe truncation also fixes a latent byte truncation that
+  could split a multibyte rune into a U+FFFD replacement char. Mutation-tested with a 1 MB `OBJECT_NAME`.
   gNB/proxy `302` from `wss://` to a plaintext `http://` on the same host could
   otherwise make the client re-send the `Authorization: Bearer` shared secret over
   cleartext (`coder/websocket` follows redirects by default, and Go preserves the

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -133,7 +133,9 @@ type SatelliteEphemerisSpec struct {
 
 // PassWindow represents a predicted contact opportunity between a satellite and ground station.
 type PassWindow struct {
-	// satellite is the name or NORAD ID of the satellite.
+	// satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+	// rune-safe. The canonical identity is noradID; treat this as a label only.
+	// +kubebuilder:validation:MaxLength=64
 	Satellite string `json:"satellite"`
 
 	// noradID is the satellite's NORAD catalog number — the canonical key that maps this window

--- a/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/bundle/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -304,7 +304,10 @@ spec:
                         windows written before this field existed (freshness then treated as unverifiable).
                       type: integer
                     satellite:
-                      description: satellite is the name or NORAD ID of the satellite.
+                      description: |-
+                        satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+                        rune-safe. The canonical identity is noradID; treat this as a label only.
+                      maxLength: 64
                       type: string
                   required:
                   - aos

--- a/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
+++ b/config/crd/bases/ntn.operators.dev_satelliteephemeris.yaml
@@ -304,7 +304,10 @@ spec:
                         windows written before this field existed (freshness then treated as unverifiable).
                       type: integer
                     satellite:
-                      description: satellite is the name or NORAD ID of the satellite.
+                      description: |-
+                        satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+                        rune-safe. The canonical identity is noradID; treat this as a label only.
+                      maxLength: 64
                       type: string
                   required:
                   - aos

--- a/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/satelliteephemeris.ntn.operators.dev.yaml
@@ -307,7 +307,10 @@ spec:
                         windows written before this field existed (freshness then treated as unverifiable).
                       type: integer
                     satellite:
-                      description: satellite is the name or NORAD ID of the satellite.
+                      description: |-
+                        satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+                        rune-safe. The canonical identity is noradID; treat this as a label only.
+                      maxLength: 64
                       type: string
                   required:
                   - aos

--- a/internal/controller/satelliteephemeris_boundname_test.go
+++ b/internal/controller/satelliteephemeris_boundname_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/akhenakh/sgp4"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+)
+
+// TestPropagateStates_BoundsHugeObjectName is the mandated 1 MB OBJECT_NAME test at the
+// propagated-state layer: a huge external name is truncated (rune-safe, shared with pass windows)
+// before it is written to status, so one bounded GP input cannot amplify the status object past the
+// etcd limit.
+func TestPropagateStates_BoundsHugeObjectName(t *testing.T) {
+	r := &SatelliteEphemerisReconciler{}
+	omm := issOMMForTest()
+	omm.ObjectName = strings.Repeat("A", 1<<20) // 1 MB
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{omm}}, time.Now().Add(2*time.Hour))
+
+	if len(eph.Status.PropagatedStates) != 1 {
+		t.Fatalf("expected 1 propagated state, got %d", len(eph.Status.PropagatedStates))
+	}
+	name := eph.Status.PropagatedStates[0].Satellite
+	if n := utf8.RuneCountInString(name); n > ephemeris.MaxSatelliteNameLen {
+		t.Fatalf("propagated state satellite = %d runes, exceeds bound %d", n, ephemeris.MaxSatelliteNameLen)
+	}
+	if !utf8.ValidString(name) {
+		t.Fatalf("propagated state satellite is not valid UTF-8: %q", name)
+	}
+}

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -952,10 +952,6 @@ func (r *SatelliteEphemerisReconciler) cachedOMMResult(key client.ObjectKey) (ca
 	return c, ok
 }
 
-// maxSatelliteNameLen bounds the externally-sourced OMM ObjectName stored per
-// propagated state, so a malformed GP feed cannot bloat the status object.
-const maxSatelliteNameLen = 64
-
 // maxEpochAge and maxSourceEpochFutureSkew, and the sourceEpochUsable rule that applies
 // them, live in the shared layer (ephemeris_freshness.go) so the producer and the consumer
 // cannot drift apart.
@@ -1144,14 +1140,10 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 		if err != nil {
 			continue // skip satellites whose SGP4 propagation fails / goes out of range
 		}
-		// ObjectName comes from external GP data; bound it so a malformed/huge
-		// name can't bloat the status object past the etcd size limit.
-		name := omms[i].ObjectName
-		if len(name) > maxSatelliteNameLen {
-			name = name[:maxSatelliteNameLen]
-		}
+		// ObjectName comes from external GP data; bound it (rune-safe) so a malformed/huge
+		// name can't bloat the status object past the etcd size limit — shared with pass windows.
 		states = append(states, ntnv1alpha1.PropagatedState{
-			Satellite:         name,
+			Satellite:         ephemeris.BoundedSatelliteLabel(omms[i].ObjectName),
 			NoradID:           omms[i].NoradCatID,
 			EpochUnixMs:       epochMs,
 			SourceEpochUnixMs: srcEpochMs,

--- a/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/satelliteephemeris-crd.yaml
@@ -304,7 +304,10 @@ spec:
                         windows written before this field existed (freshness then treated as unverifiable).
                       type: integer
                     satellite:
-                      description: satellite is the name or NORAD ID of the satellite.
+                      description: |-
+                        satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+                        rune-safe. The canonical identity is noradID; treat this as a label only.
+                      maxLength: 64
                       type: string
                   required:
                   - aos

--- a/pkg/ephemeris/bounded_label_test.go
+++ b/pkg/ephemeris/bounded_label_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/akhenakh/sgp4"
+)
+
+// TestBoundedSatelliteLabel pins the status-amplification guard: an external OMM ObjectName is
+// truncated to MaxSatelliteNameLen RUNES and stays valid UTF-8 (byte truncation would split a
+// multi-byte rune into a U+FFFD on marshal).
+func TestBoundedSatelliteLabel(t *testing.T) {
+	multibyte := strings.Repeat("衛", 100) // 100 runes, 300 bytes
+	cases := []struct {
+		name     string
+		in       string
+		wantRune int  // expected rune count of the result
+		wantSame bool // result must be byte-identical to input
+	}{
+		{"empty", "", 0, true},
+		{"short ascii", "ISS (ZARYA)", 11, true},
+		{"exactly max ascii", strings.Repeat("A", MaxSatelliteNameLen), MaxSatelliteNameLen, true},
+		{"over max ascii truncated", strings.Repeat("A", MaxSatelliteNameLen+1), MaxSatelliteNameLen, false},
+		{"1MB ascii truncated", strings.Repeat("A", 1<<20), MaxSatelliteNameLen, false},
+		{"multibyte over max truncated", multibyte, MaxSatelliteNameLen, false},
+		// byte length > max but rune count <= max: kept as-is (maxLength counts code points).
+		{"multibyte under max kept", strings.Repeat("衛", 40), 40, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BoundedSatelliteLabel(tc.in)
+			if n := utf8.RuneCountInString(got); n != tc.wantRune {
+				t.Fatalf("rune count = %d, want %d", n, tc.wantRune)
+			}
+			if n := utf8.RuneCountInString(got); n > MaxSatelliteNameLen {
+				t.Fatalf("result exceeds MaxSatelliteNameLen: %d runes", n)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("result is not valid UTF-8 (a rune was split): %q", got)
+			}
+			if tc.wantSame && got != tc.in {
+				t.Fatalf("result should be unchanged, got %q", got)
+			}
+		})
+	}
+}
+
+// TestPredictPasses_BoundsHugeObjectName is the mandated 1 MB OBJECT_NAME test at the pass-prediction
+// layer: a valid OMM with a 1 MB name still produces passes, but each window's satellite label is
+// bounded — so a single external name cannot be amplified across up to MaxPassWindows windows.
+func TestPredictPasses_BoundsHugeObjectName(t *testing.T) {
+	omm := issOMM()
+	omm.ObjectName = strings.Repeat("A", 1<<20) // 1 MB
+	passes, err := PredictPasses(context.Background(),
+		[]sgp4.OMM{omm}, []GroundStation{montrealStation}, 0, 24*time.Hour, nil, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(passes) == 0 {
+		t.Fatal("expected at least one pass to exercise the label bound")
+	}
+	for _, p := range passes {
+		if n := utf8.RuneCountInString(p.Satellite); n > MaxSatelliteNameLen {
+			t.Fatalf("pass window satellite label = %d runes, exceeds bound %d", n, MaxSatelliteNameLen)
+		}
+	}
+}

--- a/pkg/ephemeris/orbit_regime.go
+++ b/pkg/ephemeris/orbit_regime.go
@@ -101,7 +101,7 @@ func DeepSpaceSummary(deepSpace []sgp4.OMM) string {
 		if len(examples) >= deepSpaceSummaryMaxExamples {
 			break
 		}
-		name := deepSpace[i].ObjectName
+		name := BoundedSatelliteLabel(deepSpace[i].ObjectName) // external; bound so it can't bloat the condition/event
 		if name == "" {
 			name = fmt.Sprintf("NORAD %d", deepSpace[i].NoradCatID)
 		}

--- a/pkg/ephemeris/pass_predictor.go
+++ b/pkg/ephemeris/pass_predictor.go
@@ -32,6 +32,27 @@ import (
 // to stay within etcd object size limits (~1.5 MB).
 const MaxPassWindows = 500
 
+// MaxSatelliteNameLen bounds the externally-sourced OMM ObjectName wherever it is persisted or
+// surfaced (pass windows, propagated states, condition/error messages). OMM data is CR-controlled
+// (the source URL is), so an unbounded name — copied into up to MaxPassWindows windows — could
+// amplify a bounded input into a status object past the etcd limit. Measured in runes to match the
+// CRD maxLength (code points). The canonical satellite identity is the NORAD ID; the name is a label.
+const MaxSatelliteNameLen = 64
+
+// BoundedSatelliteLabel truncates an external satellite name to MaxSatelliteNameLen runes. Rune-safe:
+// it never splits a multi-byte rune (byte truncation would, yielding U+FFFD replacement chars on
+// JSON marshal). Shared by pass windows, propagated states, and error/condition messages so one
+// external name cannot inflate the status object.
+func BoundedSatelliteLabel(name string) string {
+	if len(name) <= MaxSatelliteNameLen { // byte length <= max ⇒ rune count <= max
+		return name
+	}
+	if r := []rune(name); len(r) > MaxSatelliteNameLen {
+		return string(r[:MaxSatelliteNameLen])
+	}
+	return name
+}
+
 // DefaultStepSeconds is the propagation step size for pass prediction.
 const DefaultStepSeconds = 60
 
@@ -242,7 +263,7 @@ func predictSingle(
 	tle, err := omm.ToTLE()
 	if err != nil {
 		return nil, fmt.Errorf("converting OMM to TLE for %s (NORAD %d): %w",
-			omm.ObjectName, omm.NoradCatID, err)
+			BoundedSatelliteLabel(omm.ObjectName), omm.NoradCatID, err)
 	}
 
 	passes, err := tle.GeneratePasses(
@@ -286,7 +307,7 @@ func predictSingle(
 			continue
 		}
 		results = append(results, PassResult{
-			Satellite:     omm.ObjectName,
+			Satellite:     BoundedSatelliteLabel(omm.ObjectName),
 			NoradID:       omm.NoradCatID,
 			GroundStation: gs.Name,
 			AOS:           aos,


### PR DESCRIPTION
## What

Bounds the externally-sourced OMM `OBJECT_NAME` everywhere it is persisted or surfaced, closing a status-amplification DoS.

## Why

`PropagatedState.satellite` was already bounded (`MaxLength=64` + controller truncation), but three sinks copied the full external name **unbounded**:

- `PassWindow.satellite` — `PredictPasses` copied `omm.ObjectName` verbatim into **up to `MaxPassWindows` (500)** windows (`pass_predictor.go:310`); `PassWindow.satellite` had no `MaxLength`.
- The pass-prediction TLE-conversion error embedded the raw name (`pass_predictor.go:266`) → wrapped into the `PassesPredicted` condition/event.
- `DeepSpaceSummary` named rejected satellites by raw `ObjectName` (`orbit_regime.go`) → `UnsupportedOrbitRegime` condition/event.

GP responses are capped at 50 MB, so a single long `OBJECT_NAME` amplifies a bounded input into a status object that exceeds etcd's ~1.5 MB limit (the status write fails, the reconcile stalls) or pressures controller memory. The source URL is CR-controlled, so the SSRF guard does **not** imply trusted response content — a legitimate public HTTPS endpoint can return a malicious OMM. Multi-tenant P1 / trusted-source P2.

## How

A shared, rune-safe `ephemeris.BoundedSatelliteLabel(name)` (truncates to `MaxSatelliteNameLen=64` **code points**) is now used at every site: pass windows, propagated states, and the TLE-error and deep-space-summary messages. `PassWindow.satellite` gains a CRD `MaxLength=64` as a defense-in-depth apiserver gate. The canonical satellite identity is the NORAD ID (`PassWindow.noradID`, added in #275); the name is a display label. Rune-safe truncation also fixes a **latent byte truncation** (`name[:64]`) that could split a multibyte rune into U+FFFD on marshal.

**Deliberate scope (flagging the review's item I did *not* adopt):** no "overall status budget guard before marshal." Once every external string is bounded per-field (≤64 runes/name, ≤500 windows, ≤128 states, bounded messages), the whole status is inherently bounded (worst case well under 250 KB), so a global marshal-time guard is redundant and truncates opaquely. I swept every non-test `ObjectName` usage to confirm there is no other unbounded external string reaching status. (That sweep is what caught the `DeepSpaceSummary` sink — a fourth vector beyond the two the review named.)

## Testing

- `TestBoundedSatelliteLabel`: empty / short / exactly-64 / over-64 / 1 MB / multibyte-over / multibyte-under-kept — asserts ≤64 runes and valid UTF-8 (catches a rune split).
- `TestPredictPasses_BoundsHugeObjectName`: a 1 MB `OBJECT_NAME` still yields passes, every window label ≤64 runes.
- `TestPropagateStates_BoundsHugeObjectName`: a 1 MB name → `PropagatedState.satellite` ≤64 runes, valid UTF-8.
- Full gate: `make test`, `golangci-lint`, `-race`. All 4 CRD copies synced (`PassWindow.satellite maxLength: 64`).
