### PR TITLE
fix(ocudu): skip the ConfigMap push when the ephemeris is byte-identical

### DIFF
--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -318,6 +318,14 @@ func (p *Provider) PushEphemerisUpdate(
 			"ConfigMap %s/%s has no ephemeris block to replace",
 			namespace, ConfigMapNameFor(crName))
 	}
+	// No-op when the re-render is byte-identical to what is stored. On the ConfigMap
+	// bootstrap path ApplyCellConfig already wrote this same static spec ephemeris, yet the
+	// push marker keys on the GP fetch time (changes every ~2h), so an unconditional Update
+	// would churn the gNB's config source with identical bytes. Mirrors the ApplyCellConfig
+	// no-op guard (#204-G3).
+	if updated == yamlContent {
+		return nil
+	}
 	cm.Data[configDataKey] = updated
 
 	if err := p.client.Update(ctx, cm); err != nil {

--- a/pkg/provider/ocudu/provider_push_noop_test.go
+++ b/pkg/provider/ocudu/provider_push_noop_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ocudu
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestPushEphemerisUpdate_NoOpOnIdenticalEphemeris_G3 pins the byte-equality guard on the
+// ConfigMap bootstrap push. PushEphemerisUpdate must NOT rewrite the ConfigMap when the
+// re-rendered ephemeris block is byte-identical to what is already stored: on the ConfigMap
+// path ApplyCellConfig has already written this same static spec ephemeris, yet the push
+// gate marker keys on the SatelliteEphemeris GP fetch time (changes every ~2h fetch), so an
+// unconditional Update would rewrite identical bytes and churn the gNB's config source — the
+// exact resourceVersion churn #204-G3 removed from ApplyCellConfig. A genuine ephemeris
+// change must still write.
+//
+// Mutation: drop the `updated == yamlContent` skip in PushEphemerisUpdate → the identical
+// push bumps resourceVersion and the first assertion fails.
+func TestPushEphemerisUpdate_NoOpOnIdenticalEphemeris_G3(t *testing.T) {
+	p := newTestProvider(t)
+	ctx := context.Background()
+	owner := ownerFor("test-cr")
+	spec := geoSpec() // inline EphemerisECEF
+	key := types.NamespacedName{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var cm1 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm1); err != nil {
+		t.Fatalf("get after apply: %v", err)
+	}
+
+	// Push the SAME ephemeris the spec already carries (the steady-state fan-out: the marker
+	// advanced on a GP fetch, but the static spec ephemeris is unchanged). The re-render is
+	// byte-identical to what ApplyCellConfig wrote, so the guard must skip the Update.
+	same := provider.EphemerisUpdate{ECEF: spec.NTN.EphemerisECEF}
+	if err := p.PushEphemerisUpdate(ctx, owner, same); err != nil {
+		t.Fatalf("push (identical): %v", err)
+	}
+	var cm2 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm2); err != nil {
+		t.Fatalf("get after identical push: %v", err)
+	}
+	if cm1.ResourceVersion != cm2.ResourceVersion {
+		t.Fatalf("PushEphemerisUpdate on a byte-identical ephemeris must NOT rewrite the ConfigMap "+
+			"(#204-G3): resourceVersion %q -> %q", cm1.ResourceVersion, cm2.ResourceVersion)
+	}
+
+	// A genuine ephemeris change must still write → resourceVersion advances.
+	changed := provider.EphemerisUpdate{ECEF: &ntnv1alpha1.EphemerisECEF{PosX: 99999, PosY: 88888, PosZ: 77777}}
+	if err := p.PushEphemerisUpdate(ctx, owner, changed); err != nil {
+		t.Fatalf("push (changed): %v", err)
+	}
+	var cm3 corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm3); err != nil {
+		t.Fatalf("get after changed push: %v", err)
+	}
+	if cm2.ResourceVersion == cm3.ResourceVersion {
+		t.Fatal("a changed ephemeris must rewrite the ConfigMap: resourceVersion did not advance")
+	}
+}


### PR DESCRIPTION
## What

`PushEphemerisUpdate` did an unconditional `client.Update` after re-rendering the ephemeris block. This adds a byte-equality guard so it skips the write when the re-rendered content is identical to what is already stored, matching the `ApplyCellConfig` #204-G3 no-op guard.

## The churn

On the ConfigMap bootstrap path (a deployment with no runtime remote-control endpoint):

- Step 5 `ApplyCellConfig` writes `GenerateConfig(spec)`, which includes the CR's static `spec.ntn` ephemeris.
- Step 8 `PushEphemerisUpdate` then re-renders that same static ephemeris via `replaceEphemeris`, byte-identical to what Step 5 wrote (the two renderers agree; see #274).
- But the push gate marker (`ephemerisPushMarker`) keys on the SatelliteEphemeris GP fetch time (`lastUpdated`), which changes every ~2h fetch. So every fetch fan-out re-entered the push and rewrote the ConfigMap with identical bytes.

The ConfigMap is the gNB's config source, so this was a resourceVersion bump plus a watch event on every fetch for no content change. It is the same churn #204-G3 removed from `ApplyCellConfig`. Not covered by #273, which re-keys only the runtime WebSocket marker.

## Fix

`if updated == yamlContent { return nil }` before the `Update`. The ownership re-check and the "no ephemeris block" error path are unchanged; only the redundant write is skipped. A genuine ephemeris change still writes.

## Tests

`TestPushEphemerisUpdate_NoOpOnIdenticalEphemeris_G3`: an identical push leaves resourceVersion untouched, a changed push still advances it. Mutation-verified by disabling the guard (the identical push then bumps resourceVersion and the test fails). Full controller envtest and the ocudu provider suites pass; `golangci-lint`, `gofmt`, `go vet` clean.

## Scope

Deliberately minimal and provider-level. Two adjacent items I left out, for separate discussion:

- The ConfigMap-path marker keys on the GP fetch time even though the pushed content is static. Re-keying it off the content (like #273 does for the runtime path) would also stop a residual status-condition write each fetch, but it overlaps #273's marker code and changes the documented freshness semantics.
- The ConfigMap-path push is arguably redundant with `ApplyCellConfig` (same source, same bytes, same reconcile). Removing it would change the `EphemerisPushed` condition semantics for ConfigMap-path cells.
