### PR TITLE
fix(ephemeris): surface SGP4 propagation failures (PropagationFailed condition + metric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SGP4 propagation failures are now surfaced, not silently dropped.** A tracked element set that
+  passed the epoch checks but failed `PropagateToECEF` (OMM→TLE conversion, propagation, or ECEF range
+  validation) was dropped from `propagatedStates` with a bare `continue` — no condition, metric, or
+  count — so a malformed/non-propagatable element set looked like a generic downstream
+  `EphemerisPayloadMissing`. The producer now counts these and surfaces them via a `PropagationFailed`
+  status condition and the `ntn_operators_ephemeris_propagation_failed_count` gauge (cleaned up on CR
+  deletion). The condition message carries only a bounded reason and up to three example NORAD IDs —
+  never raw external fields. Mutation-tested.
+
 - **NTNSlice no longer fails over to a satellite whose ephemeris is too stale to deliver.** NTNSlice
   keyed satellite availability on the producer's `PassesPredicted` condition plus an active pass window,
   while NTNCellConfig gates the runtime push on the element set's source-epoch freshness

--- a/api/v1alpha1/satelliteephemeris_types.go
+++ b/api/v1alpha1/satelliteephemeris_types.go
@@ -288,6 +288,14 @@ const (
 	// means every tracked element set has a parseable, plausibly-dated epoch. Distinct from
 	// EphemerisEpochStale, which covers merely OLD (but still propagated) element sets.
 	ConditionSourceEpochRejected = "SourceEpochRejected"
+	// ConditionPropagationFailed is True when one or more tracked element sets passed the epoch
+	// checks but FAILED SGP4 propagation to ECEF (OMM->TLE conversion, propagation, or ECEF range
+	// validation). Such a satellite produces NO propagated state, so a cell selecting it reports a
+	// bare EphemerisPayloadMissing; this condition (and ntn_operators_ephemeris_propagation_failed_count)
+	// tells the operator the cause is a non-propagatable element set. The message carries only a
+	// bounded reason and example NORAD IDs, never raw external fields. Distinct from
+	// SourceEpochRejected (refused BEFORE propagation) and UnsupportedOrbitRegime (deep-space).
+	ConditionPropagationFailed = "PropagationFailed"
 	// ConditionRefreshIntervalClamped is True when spec.source.refreshInterval was
 	// outside [2h, 24h] and the controller clamped it (Reason BelowMinimum /
 	// AboveMaximum). False (Reason WithinBounds) means the controller evaluated the

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -190,6 +190,7 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			ntnmetrics.GPSatelliteCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.GPDeepSpaceRejectedCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.EphemerisEpochStaleCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.EphemerisPropagationFailedCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.GPFetchReady.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			r.ommCache.Delete(req.NamespacedName)
 		}
@@ -1093,6 +1094,8 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 
 	states := make([]ntnv1alpha1.PropagatedState, 0, min(len(omms), maxPropagatedStates))
 	skippedByCap := 0
+	propagationFailures := 0
+	var failedNorads []int // bounded sample of NORADs that failed SGP4, for the condition message
 	for i := range omms {
 		if len(states) >= maxPropagatedStates {
 			// The cap is reached; the remaining OMMs are NOT attempted. This is the
@@ -1138,7 +1141,17 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 
 		ecef, err := ephemeris.PropagateToECEF(omms[i], epoch)
 		if err != nil {
-			continue // skip satellites whose SGP4 propagation fails / goes out of range
+			// SGP4 propagation failed (OMM->TLE, propagation, or ECEF range). The satellite is
+			// dropped from propagatedStates; count + surface it (PropagationFailed) so it is not
+			// mistaken for a generic downstream EphemerisPayloadMissing. Log carries only the NORAD
+			// and the classified error, never the external ObjectName.
+			propagationFailures++
+			if len(failedNorads) < propagationFailedExamples {
+				failedNorads = append(failedNorads, omms[i].NoradCatID)
+			}
+			logf.FromContext(ctx).Info("skipping satellite: SGP4 propagation to ECEF failed",
+				"norad", omms[i].NoradCatID, "err", err.Error())
+			continue
 		}
 		// ObjectName comes from external GP data; bound it (rune-safe) so a malformed/huge
 		// name can't bloat the status object past the etcd size limit — shared with pass windows.
@@ -1154,7 +1167,46 @@ func (r *SatelliteEphemerisReconciler) propagateStates(
 	truncEvent := r.reportStatesTruncated(eph, len(omms), skippedByCap)
 	r.reportEphemerisEpochStale(eph, staleEpochs, len(omms))
 	r.reportSourceEpochRejected(eph, unparseableEpochs, futureEpochs, len(omms))
+	r.reportPropagationFailed(eph, propagationFailures, len(omms), failedNorads)
 	return truncEvent
+}
+
+// propagationFailedExamples bounds how many NORAD IDs the PropagationFailed condition message names.
+const propagationFailedExamples = 3
+
+// reportPropagationFailed sets the PropagationFailed condition + metric: True when one or more tracked
+// element sets passed the epoch checks but failed SGP4 propagation to ECEF and were dropped from
+// propagatedStates. The message carries only a bounded reason and up to propagationFailedExamples NORAD
+// IDs — never raw external fields. Condition-only (no event), like reportEphemerisEpochStale, so the
+// 3-minute re-propagation cadence does not make it noisy.
+func (r *SatelliteEphemerisReconciler) reportPropagationFailed(eph *ntnv1alpha1.SatelliteEphemeris, failed, total int, exampleNorads []int) {
+	c := metav1.Condition{
+		Type:               ntnv1alpha1.ConditionPropagationFailed,
+		Status:             metav1.ConditionFalse,
+		Reason:             "PropagationOK",
+		Message:            "All tracked element sets propagated to ECEF successfully",
+		ObservedGeneration: eph.Generation,
+	}
+	if failed > 0 {
+		c.Status = metav1.ConditionTrue
+		c.Reason = "PropagationFailed"
+		msg := fmt.Sprintf("%d of %d tracked element set(s) failed SGP4 propagation to ECEF (conversion, propagation, or ECEF range) and were dropped from propagatedStates",
+			failed, total)
+		if len(exampleNorads) > 0 {
+			parts := make([]string, len(exampleNorads))
+			for i, n := range exampleNorads {
+				parts[i] = fmt.Sprintf("%d", n)
+			}
+			suffix := ""
+			if failed > len(exampleNorads) {
+				suffix = ", ..."
+			}
+			msg += fmt.Sprintf("; e.g. NORAD %s%s", strings.Join(parts, ", "), suffix)
+		}
+		c.Message = msg
+	}
+	meta.SetStatusCondition(&eph.Status.Conditions, c)
+	ntnmetrics.EphemerisPropagationFailedCount.With(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name}).Set(float64(failed))
 }
 
 // reportSourceEpochRejected surfaces element sets the producer refused BEFORE SGP4 — an

--- a/internal/controller/satelliteephemeris_propfail_test.go
+++ b/internal/controller/satelliteephemeris_propfail_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+)
+
+// TestPropagateStates_SurfacesPropagationFailure pins the fix: a tracked element set that passes the
+// epoch checks but fails SGP4 propagation to ECEF is no longer silently dropped — it is counted and
+// surfaced via the PropagationFailed condition + metric, with a BOUNDED message (reason + NORAD, never
+// the raw external ObjectName), so it is not mistaken for a generic downstream PayloadMissing.
+func TestPropagateStates_SurfacesPropagationFailure(t *testing.T) {
+	ntnmetrics.EphemerisPropagationFailedCount.Reset()
+	r := &SatelliteEphemerisReconciler{}
+
+	bad := badOMMForTest() // eccentricity 1.5 → SGP4 propagation fails, but epoch is parseable+plausible
+	bad.NoradCatID = 54321
+	bad.ObjectName = "EVIL-SAT-SHOULD-NOT-APPEAR-IN-CONDITION"
+	good := issOMMForTest()
+	good.NoradCatID = 25544
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{}
+	r.propagateStates(context.Background(), eph, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{bad, good}}, time.Now().Add(2*time.Hour))
+
+	// The good satellite propagates; the bad one is dropped from status but SURFACED.
+	if len(eph.Status.PropagatedStates) != 1 || eph.Status.PropagatedStates[0].NoradID != 25544 {
+		t.Fatalf("expected only the good satellite (25544) propagated, got %+v", eph.Status.PropagatedStates)
+	}
+	cond := meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionPropagationFailed)
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != "PropagationFailed" {
+		t.Fatalf("PropagationFailed must be True/PropagationFailed, got %+v", cond)
+	}
+	if !strings.Contains(cond.Message, "1 of 2") || !strings.Contains(cond.Message, "54321") {
+		t.Fatalf("message must be bounded and name the failed NORAD, got %q", cond.Message)
+	}
+	if strings.Contains(cond.Message, bad.ObjectName) {
+		t.Fatalf("condition must NOT embed the raw external ObjectName; got %q", cond.Message)
+	}
+	if got := testutil.ToFloat64(ntnmetrics.EphemerisPropagationFailedCount.WithLabelValues("", "")); got != 1 {
+		t.Fatalf("propagation-failed metric = %v, want 1", got)
+	}
+
+	// All good: the condition clears to False when nothing fails.
+	eph2 := &ntnv1alpha1.SatelliteEphemeris{}
+	r.propagateStates(context.Background(), eph2, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{good}}, time.Now().Add(2*time.Hour))
+	if cond := meta.FindStatusCondition(eph2.Status.Conditions, ntnv1alpha1.ConditionPropagationFailed); cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("PropagationFailed must be False when all propagate, got %+v", cond)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -122,6 +122,18 @@ var (
 		[]string{"namespace", "ephemeris"},
 	)
 
+	// EphemerisPropagationFailedCount is the number of tracked element sets that failed SGP4
+	// propagation to ECEF in the latest reconcile (OMM->TLE conversion, propagation, or ECEF range
+	// validation). These satellites are dropped from propagatedStates, so without this signal a
+	// non-propagatable element set looks like a generic downstream PayloadMissing.
+	EphemerisPropagationFailedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ntn_operators_ephemeris_propagation_failed_count",
+			Help: "Number of tracked element sets that failed SGP4 propagation to ECEF in the latest reconcile.",
+		},
+		[]string{"namespace", "ephemeris"},
+	)
+
 	// GPFetchReady is 1 when the latest reconcile obtained usable GP data (a fresh
 	// fetch, a 304 Not Modified, or a served cache) and 0 when it could not (fetcher
 	// setup failed, the fetch errored with no cache to fall back on, or an insecure
@@ -247,6 +259,7 @@ func init() {
 		GPSatelliteCount,
 		GPDeepSpaceRejectedCount,
 		EphemerisEpochStaleCount,
+		EphemerisPropagationFailedCount,
 		GPFetchReady,
 		EphemerisPushErrorsTotal,
 		EphemerisPushReady,


### PR DESCRIPTION
## What

Surfaces SGP4 `PropagateToECEF` failures (previously a silent `continue`) via a `PropagationFailed` status condition + `ntn_operators_ephemeris_propagation_failed_count` gauge.

## Why

A tracked element set that passed the epoch checks but failed `PropagateToECEF` (OMM→TLE conversion, propagation, or ECEF range validation) was dropped from `propagatedStates` with no condition, metric, log, or count. A malformed/non-propagatable element set was therefore indistinguishable from a generic downstream `EphemerisPayloadMissing` — the exact gap the review flagged.

## How

`propagateStates` counts these failures and reports them via `reportPropagationFailed` (condition + gauge, mirroring `reportEphemerisEpochStale`). The condition is distinct from `SourceEpochRejected` (refused *before* propagation) and `UnsupportedOrbitRegime` (deep-space). The message carries only a **bounded** reason + up to three example NORAD IDs — never raw external fields (`ObjectName`); a per-satellite log records the NORAD + classified error. The gauge is deleted on CR deletion alongside the other per-CR ephemeris gauges (WO-20 hygiene).

## Testing

`TestPropagateStates_SurfacesPropagationFailure`: a bad element set (eccentricity 1.5) among a good one → only the good propagates, `PropagationFailed=True` names the failed NORAD, the metric reads 1, the raw `ObjectName` is **absent** from the condition, and the condition clears to `False` when all propagate. `make test` (controller 89.9%, metrics 100%) + `golangci-lint` (0 issues).