### PR TITLE
fix(groundstation): skip the terminal status write on a no-op reconcile

### DIFF
--- a/internal/controller/groundstationlifecycle_controller.go
+++ b/internal/controller/groundstationlifecycle_controller.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,6 +116,9 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	previousPhase := gs.Status.Phase
+	// Snapshot status before the health/firmware evaluation mutates it, so the terminal write
+	// can be skipped when this reconcile changed nothing (see Step 7).
+	oldStatus := gs.Status.DeepCopy()
 	requeueAfter := r.healthCheckInterval(gs)
 
 	// Step 2: Find matching Node.
@@ -168,9 +172,15 @@ func (r *GroundStationLifecycleReconciler) Reconcile(ctx context.Context, req ct
 		}).Set(val)
 	}
 
-	// Step 7: Update status.
-	if err := r.Status().Update(ctx, gs); err != nil {
-		return ctrl.Result{}, err
+	// Step 7: Update status — only when something changed, or an event is queued. A steady-state
+	// reconcile re-derives identical Phase + conditions, so an unconditional Update would rewrite
+	// byte-identical status and churn every watcher each requeue cycle (#204-G3; matches the
+	// NTNCellConfig #271 guard). A pending event forces the write so WO-20 emit-after-persist still
+	// holds (Step 8 announces only what was durably recorded).
+	if !equality.Semantic.DeepEqual(oldStatus, &gs.Status) || len(pending) > 0 {
+		if err := r.Status().Update(ctx, gs); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Step 8: Emit queued events only after the status persisted (WO-20 / N-1): a

--- a/internal/controller/groundstationlifecycle_noop_test.go
+++ b/internal/controller/groundstationlifecycle_noop_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// TestGroundStationReconcile_NoOpStatusWrite_G3 pins the terminal status-write guard: a
+// steady-state reconcile (nothing changed, no event queued) must NOT re-issue Status().Update.
+// GroundStation requeues on a fixed interval, so an unconditional write would rewrite
+// byte-identical status every cycle and churn every watcher — the #204-G3 churn the NTNCellConfig
+// #271 guard removed, here propagated to the sibling controller. resourceVersion cannot catch
+// this: the API store short-circuits a byte-identical write so it never bumps. The
+// SubResourceUpdate interceptor therefore counts write REQUESTS instead.
+//
+// Mutation: drop the DeepEqual guard on the terminal write → the steady-state reconcile writes
+// again and the delta assertion fails.
+func TestGroundStationReconcile_NoOpStatusWrite_G3(t *testing.T) {
+	sch := runtime.NewScheme()
+	utilruntime.Must(ntnv1alpha1.AddToScheme(sch))
+	utilruntime.Must(corev1.AddToScheme(sch))
+
+	gs := &ntnv1alpha1.GroundStationLifecycle{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-noop", Namespace: "default", Generation: 1},
+	}
+
+	var statusUpdates int
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(gs).WithStatusSubresource(gs).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// c is the underlying client; calling it does not re-enter this interceptor.
+			SubResourceUpdate: func(ctx context.Context, c client.Client, sr string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				statusUpdates++
+				return c.SubResource(sr).Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := &GroundStationLifecycleReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(10)}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "gs-noop", Namespace: "default"}}
+
+	// Drive to steady state. With no matching Node the health eval is deterministic
+	// (Phase=Provisioning + NodeNotFound conditions), so status stabilizes after the first write.
+	for range 2 {
+		if _, err := r.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("reconcile to steady state: %v", err)
+		}
+	}
+	before := statusUpdates
+
+	// A steady-state reconcile re-derives identical status and queues no event → no write.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+	if statusUpdates != before {
+		t.Fatalf("a steady-state reconcile must not re-write status (#204-G3): "+
+			"Status().Update issued %d extra request(s)", statusUpdates-before)
+	}
+}


### PR DESCRIPTION
## What

The `GroundStationLifecycle` reconcile did an unconditional `Status().Update` at the end of every cycle. This guards it with `equality.Semantic.DeepEqual` so a no-op reconcile skips the write, matching the NTNCellConfig #271 guard.

## The churn

The reconcile requeues on a fixed interval (default 30s) and re-derives `Phase` plus the K8sNodeReady / AntennaReady / RFLinkHealthy conditions each cycle. In steady state those are byte-identical to what is already stored (`meta.SetStatusCondition` only bumps `LastTransitionTime` on a real change, and no per-reconcile timestamp lands in status), so every requeue rewrote identical status: a resourceVersion bump and a watch event for no change. It is the same #204-G3 churn the NTNCellConfig terminal write was guarded against in #271, just not propagated to this sibling controller.

## Fix

Snapshot `oldStatus` after the Get, and write only when `!DeepEqual(oldStatus, &gs.Status)` or an event is queued. The `len(pending) > 0` clause keeps the WO-20 emit-after-persist discipline intact: a queued phase/firmware event always has a durable status write behind it (Step 8 announces only what was recorded). Events are only queued on a real transition, so that clause is defensive rather than load-bearing today.

## Test

`TestGroundStationReconcile_NoOpStatusWrite_G3` counts `Status().Update` requests with a `SubResourceUpdate` interceptor and asserts a steady-state reconcile issues zero. resourceVersion cannot catch this: the API store short-circuits a byte-identical write so it never bumps (the same reason #271's test counts requests, not resourceVersion). Mutation-verified by disabling the guard. Full controller envtest suite passes; `golangci-lint` / `gofmt` / `go vet` clean.

## Scope

The sibling `NTNSlice` terminal status write (`ntnslice_controller.go:504`) has the same unguarded pattern, but it commits anti-flap state to shared memory after the write (a durability barrier), so a guard there needs its own analysis. Left as a follow-up rather than lumped in.
