### PR TITLE
fix(ntnslice): skip the terminal status write on a no-op reconcile

### DIFF
--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,6 +284,12 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	now := r.now()
 
+	// Snapshot status before the quality/availability/failover evaluation mutates it, so the
+	// terminal write can be skipped when this reconcile changed nothing (see Step 8). Only durable
+	// anti-flap state (LastSwitchbackTime) lives in status and so is captured here; the in-memory
+	// streak (storeFlapState) is committed regardless and does not gate the write.
+	oldStatus := ns.Status.DeepCopy()
+
 	// Step 2: Read path-quality metrics and determine whether they are reliable
 	// enough to drive a switch. Unreliable metrics fail static in Step 4 (the engine
 	// is replaced by EvaluateSafeHold, which holds the current path but still honors
@@ -500,8 +507,12 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	r.applySecurityStatus(ns)
 	r.applyBillingStatus(ns, activePath)
 
-	// Step 8: Update status.
-	if err := r.Status().Update(ctx, ns); err != nil {
+	// Step 8: Persist status, but only when it changed or an event is queued — a steady-state
+	// (DecisionStay, no switchback) reconcile re-derives identical status, so an unconditional
+	// Update would churn every watcher each requeue (#204-G3; matches #271 / GroundStation). The
+	// storeFlapState / FailoverTotal / event blocks below are unchanged: each fires only on a real
+	// transition (⟹ statusChanged) or a queued event, so the durable write always precedes them.
+	if err := r.persistStatusIfChanged(ctx, ns, oldStatus, pending); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -545,6 +556,19 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	return ctrl.Result{RequeueAfter: sliceRequeueInterval}, nil
+}
+
+// persistStatusIfChanged writes ns.Status only when it differs from oldStatus or an event is
+// queued, so a no-op reconcile does not churn the object (#204-G3). A queued event forces the
+// write so the WO-20 emit-after-persist discipline holds. Split out of Reconcile to keep that
+// function under the cyclomatic-complexity budget.
+func (r *NTNSliceReconciler) persistStatusIfChanged(
+	ctx context.Context, ns *ntnv1alpha1.NTNSlice, oldStatus *ntnv1alpha1.NTNSliceStatus, pending []deferredEvent,
+) error {
+	if equality.Semantic.DeepEqual(oldStatus, &ns.Status) && len(pending) == 0 {
+		return nil
+	}
+	return r.Status().Update(ctx, ns)
 }
 
 // applyQoSStatus sets the QoS-related status fields and conditions.

--- a/internal/controller/ntnslice_noop_test.go
+++ b/internal/controller/ntnslice_noop_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestReconcile_NoOpStatusWrite_G3 pins the terminal status-write guard: a steady-state reconcile
+// (DecisionStay, healthy metrics, no switchback) must NOT re-issue Status().Update. NTNSlice
+// requeues on a fixed interval, so an unconditional write would rewrite byte-identical status every
+// cycle and churn every watcher — the #204-G3 churn the NTNCellConfig #271 guard removed, here
+// propagated to NTNSlice. The in-memory anti-flap streak (storeFlapState) still commits every
+// reconcile; only the durable status write is skipped. resourceVersion cannot catch a byte-identical
+// write (the store short-circuits it so it never bumps), so the SubResourceUpdate interceptor counts
+// write REQUESTS.
+//
+// Mutation: drop the DeepEqual guard on the terminal write → the steady-state reconcile writes again
+// and the delta assertion fails.
+func TestReconcile_NoOpStatusWrite_G3(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{ObjectMeta: metav1.ObjectMeta{Name: "eph", Namespace: "default"}}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "cht", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "eph",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+	}
+
+	var statusUpdates int
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(nsObj, eph).
+		WithStatusSubresource(nsObj, eph).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, sr string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if _, ok := obj.(*ntnv1alpha1.NTNSlice); ok { // count NTNSlice status writes only
+					statusUpdates++
+				}
+				return c.SubResource(sr).Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	// Healthy, fresh metrics: RSRP -80 does not fire "rsrp < -100", so the slice stays on the
+	// primary terrestrial path every reconcile (DecisionStay).
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		LastFreshAt: fixedNow,
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	req := reconcile.Request{NamespacedName: key}
+	// Drive to steady state (the first reconcile establishes ActivePathType + conditions).
+	for range 3 {
+		if _, err := r.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("reconcile to steady state: %v", err)
+		}
+	}
+	before := statusUpdates
+
+	// A steady-state DecisionStay reconcile re-derives identical status and queues no event → no write.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("steady-state reconcile: %v", err)
+	}
+	if statusUpdates != before {
+		t.Fatalf("a steady-state (DecisionStay) reconcile must not re-write status (#204-G3): "+
+			"Status().Update issued %d extra request(s)", statusUpdates-before)
+	}
+}


### PR DESCRIPTION
## What

The `NTNSlice` reconcile did an unconditional `Status().Update` at the end of every cycle. This guards it with `equality.Semantic.DeepEqual` so a steady-state reconcile skips the write, completing the write-path churn audit alongside #271 (NTNCellConfig) and #280 (GroundStation).

## The churn

The reconcile requeues on a fixed interval and re-derives `ActivePathType`, the `PathActive` condition, and the QoS/Security/Billing status each cycle. In steady state (`DecisionStay`, healthy metrics, no switchback) those are byte-identical to what is stored, so every requeue rewrote identical status: a resourceVersion bump and a watch event for no change.

## The anti-flap subtlety (why this one needed care)

NTNSlice commits an anti-flap state via `storeFlapState` *after* the status write, gated on the write being durable. A naive guard could skip the write while still committing anti-flap state. It stays correct because:

- The in-memory streak (consecutive-degraded / recovery clock) is committed to a Go map, not the API. It is reseeded from status on restart, so it must advance every reconcile regardless of whether the durable write happened.
- The only *durable* anti-flap state is `LastSwitchbackTime`, which is a status field. Any change to it trips `DeepEqual` and forces the write, so a switchback is never committed to memory ahead of a durable write.
- `FailoverTotal` and the decision events fire only on a real transition (`FailoverCount++` / a path change, so `statusChanged`), and the quality events are covered by `|| len(pending) > 0`, so the write always precedes any post-write side effect.

I checked this against the full failover/anti-flap envtest suite, which passes unchanged.

## Fix

Snapshot `oldStatus` after the Get, and write only when `!DeepEqual(oldStatus, &ns.Status)` or an event is queued. Extracted into `persistStatusIfChanged` to keep `Reconcile` under the gocyclo budget.

## Test

`TestReconcile_NoOpStatusWrite_G3` counts `Status().Update` requests with a `SubResourceUpdate` interceptor and asserts a steady-state `DecisionStay` reconcile issues zero. resourceVersion cannot catch this: the store short-circuits a byte-identical write so it never bumps. Mutation-verified. Full controller envtest, `golangci-lint`, `gofmt`, `go vet` clean.

## Audit complete

This is the last unguarded write from the churn audit: `ApplyCellConfig` (#204-G3), `PushEphemerisUpdate` (#278), NTNCellConfig (#271), GroundStation (#280), NTNSlice (this). SatelliteEphemeris status writes are the #234 / ADR-0006 accepted churn and are intentionally left alone.
