### PR TITLE
fix(ntncellconfig): self-heal-requeue a RemoteControlConfigInvalid push failure

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -126,24 +126,40 @@ func ephemerisPushConditionReason(err error) string {
 	return ephemerisReasonPushFailed
 }
 
+// ephemerisPushShouldRequeue reports whether a failed push needs a self-requeue to recover,
+// versus recovering on its own via a watched change. The reasons below clear only on a spec edit
+// (generation bump) or a SatelliteEphemeris refresh (new marker) — both watched — so a self-requeue
+// would just hammer a still-failing push. Everything else requeues: a transient failure (API GET
+// error, gNB unreachable), AND RemoteControlConfigInvalid, whose fix (a Secret edit) is NOT watched
+// — the controller watches only NTNCellConfig + SatelliteEphemeris and secrets are get-only by
+// design, so without a self-requeue such a cell recovers only on the next ephemeris heartbeat, and
+// never if the producer stalls. ephemerisPushRequeueInterval sets the cadence.
 func ephemerisPushShouldRequeue(reason string) bool {
 	switch reason {
 	case ephemerisReasonRefNotFound,
 		ephemerisReasonPayloadMissing,
 		ephemerisReasonEphemerisStale,
 		ephemerisReasonInputsStale,
-		ephemerisReasonRemoteControlConfig,
 		ephemerisReasonProviderPushRejected:
-		// These clear only on an external change — a spec edit (generation bump)
-		// or a SatelliteEphemeris refresh (new marker) — both of which re-trigger
-		// reconcile via generation/watch. A tight requeue would just hammer a
-		// permanently-failing push (e.g. the gNB rejecting a bad config, or a
-		// stale/missing propagated state) until that external change happens.
 		return false
 	default:
-		// Transient failures (API GET error, gNB unreachable) — retry.
 		return true
 	}
+}
+
+// remoteControlConfigRequeue is the low-frequency self-heal poll for a RemoteControlConfigInvalid
+// failure. Its fix is a Secret edit, which the controller does not watch, so the cell must poll to
+// recover rather than rely on the (possibly absent) SatelliteEphemeris heartbeat fan-out.
+const remoteControlConfigRequeue = 5 * time.Minute
+
+// ephemerisPushRequeueInterval is the backoff for a requeuing push failure: a credential/config
+// error self-heals slowly (its Secret fix is unwatched, so this is a poll, not a hammer); every
+// other requeuing reason is a transient failure that retries tightly.
+func ephemerisPushRequeueInterval(reason string) time.Duration {
+	if reason == ephemerisReasonRemoteControlConfig {
+		return remoteControlConfigRequeue
+	}
+	return time.Minute
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -393,7 +409,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if !ephemerisPushShouldRequeue(reason) {
 				return ctrl.Result{}, nil
 			}
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
+			return ctrl.Result{RequeueAfter: ephemerisPushRequeueInterval(reason)}, nil
 		}
 		if pushed {
 			meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
@@ -706,10 +722,14 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
 	tlsConfig, authToken, tlsErr := r.resolveRemoteControlTLS(ctx, eph.Namespace, spec.Provider.RemoteControl)
 	if tlsErr != nil {
-		// A deterministic credential/config error (wrong Secret type, missing opt-in
-		// label, malformed cert) is PERMANENT — it clears only on a Secret/spec edit,
-		// which re-triggers reconcile, so classify it non-requeuing instead of hammering
-		// the apiserver every minute. A transient Secret read error stays requeuing.
+		// A deterministic credential/config error (wrong Secret type, missing opt-in label,
+		// malformed cert) does not clear on retry — only on a Secret or spec edit. The spec is
+		// watched, but the Secret is NOT (the controller watches only NTNCellConfig +
+		// SatelliteEphemeris, and secrets are get-only), so a Secret fix does not re-trigger
+		// reconcile. It therefore gets a low-frequency bounded self-heal requeue
+		// (ephemerisPushRequeueInterval) — not a tight per-minute retry, and not no requeue,
+		// which would strand the cell until the next ephemeris heartbeat, if any. A transient
+		// Secret read error stays tight-requeuing.
 		reason := ephemerisReasonProviderPushFailed
 		if errors.Is(tlsErr, errRemoteControlCredentialInvalid) {
 			reason = ephemerisReasonRemoteControlConfig
@@ -748,10 +768,10 @@ const (
 )
 
 // errRemoteControlCredentialInvalid tags a DETERMINISTIC remoteControl.tls config
-// failure (wrong Secret type, missing opt-in label, malformed cert material). The
-// caller classifies it as permanent — it clears only on a Secret/spec edit (which
-// re-triggers reconcile via generation or the ephemeris fan-out), so it must not
-// tight-requeue like a transient failure would.
+// failure (wrong Secret type, missing opt-in label, malformed cert material). The caller
+// does not tight-requeue it like a transient failure; instead it gets a low-frequency
+// self-heal poll (remoteControlConfigRequeue), because its fix is a Secret edit, and the
+// controller does NOT watch Secrets (get-only), so a Secret fix does not re-trigger reconcile.
 var errRemoteControlCredentialInvalid = errors.New("not a usable remote-control credential")
 
 // errRemoteControlCredentialUnavailable is the UNIFORM, CR-facing message for any

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
 // selfSignedPEM returns a fresh self-signed cert + key PEM, usable as both a CA
@@ -249,15 +250,64 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 	})
 }
 
-// TestEphemerisPushShouldRequeue_RemoteControlConfigIsPermanent pins that a
-// deterministic remoteControl.tls credential error does NOT tight-requeue: it clears
-// only on a Secret/spec edit (which re-triggers reconcile), so hammering the apiserver
-// every minute would be pointless — unlike a transient ProviderPushFailed.
-func TestEphemerisPushShouldRequeue_RemoteControlConfigIsPermanent(t *testing.T) {
-	if ephemerisPushShouldRequeue(ephemerisReasonRemoteControlConfig) {
-		t.Error("RemoteControlConfigInvalid is a permanent config error and must NOT requeue")
+// TestEphemerisPushRequeue_RemoteControlConfigSelfHeals pins that a deterministic
+// remoteControl.tls credential error requeues on a low-frequency SELF-HEAL poll — not a tight
+// per-minute retry, and not never. Its fix is a Secret edit, which the controller does NOT watch
+// (only NTNCellConfig + SatelliteEphemeris are watched; secrets are get-only), so without a
+// self-requeue the cell recovers only on the next SatelliteEphemeris heartbeat fan-out, and never
+// if the producer stalls. A transient ProviderPushFailed still tight-requeues (control).
+func TestEphemerisPushRequeue_RemoteControlConfigSelfHeals(t *testing.T) {
+	if !ephemerisPushShouldRequeue(ephemerisReasonRemoteControlConfig) {
+		t.Error("RemoteControlConfigInvalid must self-requeue: its Secret fix is not watched, so no requeue would strand the cell")
+	}
+	if got := ephemerisPushRequeueInterval(ephemerisReasonRemoteControlConfig); got != remoteControlConfigRequeue {
+		t.Errorf("credential-config requeue = %v, want %v (a slow self-heal poll, not a tight retry)", got, remoteControlConfigRequeue)
 	}
 	if !ephemerisPushShouldRequeue(ephemerisReasonProviderPushFailed) {
 		t.Error("a transient ProviderPushFailed must still requeue (control)")
+	}
+	if got := ephemerisPushRequeueInterval(ephemerisReasonProviderPushFailed); got != time.Minute {
+		t.Errorf("transient requeue = %v, want 1m (control)", got)
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlConfig proves the input to
+// the self-heal requeue: an un-opted-in (unlabelled) remoteControl.tls Secret makes the runtime
+// push fail with the RemoteControlConfigInvalid reason. Combined with the classification above,
+// this is the end-to-end guarantee — a bad Secret schedules a bounded self-heal retry rather than
+// stranding the cell, since a Secret edit does not re-trigger reconcile.
+func TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	// An un-opted-in Secret (no owner label) is a deterministic credential-invalid error; it lives
+	// in the ephemeris namespace, where resolveRemoteControlTLS looks it up.
+	badSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cred", Namespace: eph.Namespace},
+		Data:       map[string][]byte{"ca.crt": []byte("x")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph, badSecret).Build()
+	r := &NTNCellConfigReconciler{Client: c, APIReader: c}
+
+	cc := ccWithRemoteControl()
+	cc.Spec.Provider.RemoteControl.TLS = &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "cred"}
+
+	_, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, &provider.MockProvider{})
+	if err == nil {
+		t.Fatal("an un-opted-in remoteControl.tls Secret must fail the push")
+	}
+	reason := ephemerisPushConditionReason(err)
+	if reason != ephemerisReasonRemoteControlConfig {
+		t.Fatalf("a bad credential must classify as %q, got %q", ephemerisReasonRemoteControlConfig, reason)
+	}
+	// And that reason self-heal-requeues (the Secret fix is unwatched), so the cell is not stranded.
+	if !ephemerisPushShouldRequeue(reason) || ephemerisPushRequeueInterval(reason) != remoteControlConfigRequeue {
+		t.Fatalf("a bad credential must schedule a %v self-heal requeue, got requeue=%v interval=%v",
+			remoteControlConfigRequeue, ephemerisPushShouldRequeue(reason), ephemerisPushRequeueInterval(reason))
 	}
 }


### PR DESCRIPTION
## What

A `remoteControl.tls` credential error (`RemoteControlConfigInvalid`) was classified permanent and returned an empty `Result` — no requeue. This gives it a low-frequency bounded self-heal requeue (5m), because the code's assumption that "a Secret edit re-triggers reconcile" is false.

## The bug

`pushEphemerisUpdateIfNeeded` resolves the gNB remote-control TLS from a referenced Secret. A deterministic credential error (wrong Secret type, missing opt-in label, malformed cert) was classified permanent (`ephemerisPushShouldRequeue` returned `false`), and both the prod and test comments justified it as clearing "only on a Secret/spec edit, which re-triggers reconcile."

That is wrong. The controller watches only `NTNCellConfig` + `SatelliteEphemeris`, and RBAC is `secrets/get` (no list/watch, deliberately, to avoid a Secret informer). So a **Secret edit does not re-trigger reconcile**. After the operator fixes the Secret, the cell recovers only on the next `SatelliteEphemeris` heartbeat fan-out, and never if the producer stalls (it still exists, so no `RefNotFound`, but stops updating status, so no fan-out). The cell can sit **permanently** in `RemoteControlConfigInvalid` with a fixed Secret, needing manual intervention.

## Fix

Move `RemoteControlConfigInvalid` from the no-requeue set to a low-frequency (5m) bounded self-heal poll:

- It re-checks within 5m of the fix, independent of the heartbeat.
- It is cheap: the TLS resolve fails *before* the 5s push dial, so a still-broken credential never even dials the gNB.
- No Secret informer is added — the get-only RBAC and the non-tight cadence are preserved.

The two false "a Secret edit re-triggers reconcile" comments are corrected.

## Tests

- The classification test now asserts the self-heal requeue + 5m interval (it previously asserted *no* requeue). Mutation-verified by restoring the stranding bug.
- A new push-level test drives an un-opted-in (unlabelled) Secret through `pushEphemerisUpdateIfNeeded` and asserts it classifies as `RemoteControlConfigInvalid` and schedules the 5m self-heal requeue — the "patch a bad Secret, observe the scheduled retry" coverage the classification-only test lacked.

`golangci-lint` / `gofmt` / `go vet` clean; full controller envtest passes.

## Rejected alternative

The review's heavier option — a `secretName → NTNCellConfig` index plus a Secret watch — would reintroduce the Secret informer cache (metadata + data) that the get-only RBAC deliberately avoids, for a failure mode a cheap 5m poll already covers. Not worth the memory or the widened Secret access.

## Not in this PR (the review's second finding)

The second finding — serialized runtime-push fan-out under `maxConcurrentReconciles=1` (a 5s-timeout push × N cells can exceed the ~3-min cadence, with head-of-line blocking) — is real but scale-dependent: it bites at ~37+ cells with several slow/unreachable gNBs, and the workqueue dedups same-key items so it is delayed reasserts, not unbounded backlog. The proposed remedies (per-controller concurrency, per-endpoint semaphore, circuit breaker, load test) are a deliberate, ADR-worthy effort and are intentionally not bundled here.
