### PR TITLE
fix(ntncellconfig): send sat_switch_with_resync only on intent change, not every heartbeat

### DIFF
--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -702,6 +702,13 @@ type NTNCellConfigStatus struct {
 	// +optional
 	ConfigMapRef string `json:"configMapRef,omitempty"`
 
+	// lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+	// to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+	// changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+	// ephemeris heartbeat (issue #207). Empty when no switch has been sent.
+	// +optional
+	LastPushedSatSwitchDigest string `json:"lastPushedSatSwitchDigest,omitempty"`
+
 	// conditions represent the current state of the resource.
 	// +listType=map
 	// +listMapKey=type

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -1036,6 +1036,13 @@ spec:
                 description: configMapRef is the name of the ConfigMap containing
                   the generated config.
                 type: string
+              lastPushedSatSwitchDigest:
+                description: |-
+                  lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+                  to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+                  changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+                  ephemeris heartbeat (issue #207). Empty when no switch has been sent.
+                type: string
             type: object
         required:
         - spec

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -1036,6 +1036,13 @@ spec:
                 description: configMapRef is the name of the ConfigMap containing
                   the generated config.
                 type: string
+              lastPushedSatSwitchDigest:
+                description: |-
+                  lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+                  to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+                  changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+                  ephemeris heartbeat (issue #207). Empty when no switch has been sent.
+                type: string
             type: object
         required:
         - spec

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -1039,6 +1039,13 @@ spec:
                 description: configMapRef is the name of the ConfigMap containing
                   the generated config.
                 type: string
+              lastPushedSatSwitchDigest:
+                description: |-
+                  lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+                  to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+                  changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+                  ephemeris heartbeat (issue #207). Empty when no switch has been sent.
+                type: string
             type: object
         required:
         - spec

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -745,12 +746,20 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		UlSyncValidityDur: ulSync,
 		Ephemeris:         provider.EphemerisUpdate{ECEF: &ecef},
 	}
-	// Attach a pending satellite switch (issue #52 / #49 mechanism): it rides in
-	// the same per-cell frame as the serving ephemeris. This is the only surface
-	// that carries k_mac. The switch only reaches the gNB when a fresh serving
-	// ephemeris push happens (OCUDU requires the cell's ephemeris_info anyway).
+	// Attach a pending satellite switch (issue #52 / #49 mechanism): it rides in the same per-cell
+	// frame as the serving ephemeris (the only surface that carries k_mac; OCUDU requires the cell's
+	// ephemeris_info anyway). But attach it ONLY when its intent changed since the last successful
+	// send: the serving ephemeris is set-state and safe to re-push on every ~3-min epoch heartbeat,
+	// whereas sat_switch_with_resync may carry MAC/RRC-resync command semantics whose idempotency is
+	// unproven upstream (issue #207) — re-sending it on every heartbeat (~40x more often since #204's
+	// epoch cadence) could re-trigger the switch. A new/changed switch still delivers promptly: the
+	// spec edit bumps the generation, so isEphemerisPushUpToDate re-pushes on this reconcile.
+	switchDigest := ""
 	if spec.NTN.SatSwitchWithResync != nil {
-		update.SatSwitch = spec.NTN.SatSwitchWithResync
+		switchDigest = satSwitchIntentDigest(spec.NTN.SatSwitchWithResync)
+		if switchDigest != cc.Status.LastPushedSatSwitchDigest {
+			update.SatSwitch = spec.NTN.SatSwitchWithResync
+		}
 	}
 	// Resolve opt-in transport security (wss:// + shared secret / mTLS) from the
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
@@ -788,7 +797,25 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		}
 		return false, marker, newEphemerisPushError(reason, fmt.Errorf("provider PushRuntimeUpdate: %w", err))
 	}
+	// Record the delivered switch intent so an identical switch is not re-attached on the next
+	// ephemeris heartbeat. "" when no switch is configured, so removing then re-adding a switch
+	// re-sends it (each transition bumps the generation, forcing this push path via re-push).
+	cc.Status.LastPushedSatSwitchDigest = switchDigest
 	return true, marker, nil
+}
+
+// satSwitchIntentDigest is a canonical content digest of a pending satellite switch, used to
+// re-send it only when its intent changes (pushRuntimeEphemeris). SatSwitchWithResync has no map
+// fields, so json.Marshal is deterministic.
+func satSwitchIntentDigest(sw *ntnv1alpha1.SatSwitchWithResync) string {
+	b, err := json.Marshal(sw)
+	if err != nil {
+		// A struct with no unmarshalable fields cannot fail to marshal; treat a theoretical error
+		// as "always changed" — safe (re-sends) rather than silently dropping the switch.
+		return "marshal-error"
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 const (

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -201,6 +201,69 @@ func TestPushEphemerisUpdateIfNeeded_SatSwitchAttached(t *testing.T) {
 	}
 }
 
+// TestPushEphemerisUpdateIfNeeded_SatSwitchGatedOnIntent pins that a pending switch is delivered
+// ONCE per intent, not re-sent on every ephemeris heartbeat (issue #207). The serving ephemeris is
+// set-state and re-pushes on every ~3-min epoch (since #204), but sat_switch_with_resync may carry
+// MAC/RRC-resync command semantics whose idempotency is unproven, so an unchanged switch must not
+// ride every heartbeat; a CHANGED intent must re-send. Mutation: drop the
+// `switchDigest != cc.Status.LastPushedSatSwitchDigest` gate → push 2 re-attaches the identical
+// switch and the "must NOT re-send" assertion fails.
+func TestPushEphemerisUpdateIfNeeded_SatSwitchGatedOnIntent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{}
+
+	kmac := 200
+	cc := ccWithRemoteControl()
+	cc.Spec.NTN.SatSwitchWithResync = &ntnv1alpha1.SatSwitchWithResync{
+		NTNConfig: ntnv1alpha1.SatSwitchNTNConfig{
+			EphemerisECEF: &ntnv1alpha1.EphemerisECEF{PosX: 6000000, PosY: 1, PosZ: 1},
+			KMac:          &kmac,
+		},
+	}
+
+	// Push 1: a new switch intent (empty stored digest) → attached + recorded in status.
+	if _, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock); err != nil {
+		t.Fatalf("push 1: %v", err)
+	}
+	if mock.LastRuntime.SatSwitch == nil {
+		t.Fatal("push 1: a new switch intent must be attached")
+	}
+	if cc.Status.LastPushedSatSwitchDigest == "" {
+		t.Fatal("push 1: the delivered switch intent must be recorded in status")
+	}
+
+	// Push 2: same intent → the serving ephemeris still pushes (set-state), but the switch must NOT
+	// re-attach on the heartbeat.
+	mock.LastRuntime = nil
+	if _, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock); err != nil {
+		t.Fatalf("push 2: %v", err)
+	}
+	if mock.LastRuntime == nil {
+		t.Fatal("push 2: the serving ephemeris must still be pushed")
+	}
+	if mock.LastRuntime.SatSwitch != nil {
+		t.Fatal("push 2: an unchanged switch intent must NOT be re-attached on the ephemeris heartbeat (#207)")
+	}
+
+	// Push 3: the switch intent changes (different k_mac) → re-attached.
+	newK := 201
+	cc.Spec.NTN.SatSwitchWithResync.NTNConfig.KMac = &newK
+	mock.LastRuntime = nil
+	if _, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock); err != nil {
+		t.Fatalf("push 3: %v", err)
+	}
+	if mock.LastRuntime.SatSwitch == nil || mock.LastRuntime.SatSwitch.NTNConfig.KMac == nil ||
+		*mock.LastRuntime.SatSwitch.NTNConfig.KMac != 201 {
+		t.Fatal("push 3: a changed switch intent must be re-attached")
+	}
+}
+
 // Without a pending switch, the runtime push must not carry a sat-switch block.
 func TestPushEphemerisUpdateIfNeeded_NoSatSwitchByDefault(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -661,7 +724,12 @@ func TestPushEphemerisUpdateIfNeeded_CrashBeforeStatus_PendingSatSwitch_IsIdempo
 	}
 	sw1 := *mock.LastRuntime.SatSwitch
 
-	// CRASH before status persists → the new leader re-pushes the same unchanged state.
+	// CRASH before status persists → the new leader re-pushes the same unchanged state. The crash
+	// means the status write — which carries lastPushedSatSwitchDigest — never persisted, so the new
+	// leader reads it empty and MUST re-carry the switch. The crash-idempotency contract (#230 item 6)
+	// therefore still holds: an un-recorded switch is re-sent (only a DURABLY recorded intent is gated
+	// off the heartbeat, #207).
+	cc.Status.LastPushedSatSwitchDigest = ""
 	pushed2, marker2, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
 	if err != nil || !pushed2 || mock.RuntimeCalls != 2 {
 		t.Fatalf("re-push #2: pushed=%v err=%v calls=%d", pushed2, err, mock.RuntimeCalls)

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -1036,6 +1036,13 @@ spec:
                 description: configMapRef is the name of the ConfigMap containing
                   the generated config.
                 type: string
+              lastPushedSatSwitchDigest:
+                description: |-
+                  lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+                  to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+                  changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+                  ephemeris heartbeat (issue #207). Empty when no switch has been sent.
+                type: string
             type: object
         required:
         - spec


### PR DESCRIPTION
Addresses a two-part review of the runtime-push path. **Finding 2 needed no work** (already fixed by #273); **Finding 1** is fixed here.

## Finding 1 — SatSwitchWithResync re-send may not be idempotent (issue #207)

The pending `SatSwitchWithResync` was re-attached to **every** runtime push. Since #204 the propagated epoch advances ~every 3 minutes (was ~2h), so a persistent switch re-sent ~**40x** more often. The serving-cell ephemeris is set-state and safe to re-push, but `sat_switch_with_resync` plausibly carries **MAC/RRC-resync command semantics** whose idempotency is **unproven** upstream — a mock only proves the same JSON is re-sent, not that OCUDU won't re-execute the switch. Re-triggering a resync every 3 minutes could disrupt UEs.

### Fix

Gate the attach on a canonical content digest of the switch, tracked in a new `status.lastPushedSatSwitchDigest`. The switch is attached **only when its intent differs** from the last delivered one, so an unchanged switch no longer rides the heartbeat.

- **Prompt delivery preserved**: a new or changed switch is a spec edit → bumps `metadata.generation` → `isEphemerisPushUpToDate` (which gates on `ObservedGeneration`) re-pushes on that reconcile. No extra push-trigger needed.
- **Crash-idempotency preserved and strengthened** (#230 item 6): a crash before status persists means the digest never persisted, so the new leader reads it empty and re-sends. Only a *durably recorded* intent is gated off the heartbeat. The existing crash test now resets the un-persisted digest to model that accurately.
- The `SatSwitchWithResync` type has no map fields, so `json.Marshal` + sha256 is a deterministic digest.
- New status field regenerated into **all 4 CRD copies** (`config/crd`, `dist/chart`, `bundle/manifests`, `nephio`); `make bundle-verify-sync` clean.

### Tests

`TestPushEphemerisUpdateIfNeeded_SatSwitchGatedOnIntent`: attach once → **not** re-attached on an identical heartbeat → re-attached when the intent changes. Mutation-verified by removing the gate. Full controller envtest, `golangci-lint`, `gofmt`, `go vet` clean.

## Finding 2 — runtime marker lacks UID / payload identity: already fixed by #273, no change

The review was based on pre-#273 code. On current main, `runtimeEphemerisPushMarker` is a sha256 digest that already includes `eph.UID`, `PropagatedStatesInputHash`, `SourceEpochUnixMs`, and the **full ECEF** (`PosX…VelZ`) — the review's "add CR UID + canonical payload digest" recommendation. The comment even notes "the ECEF closes the same-epoch gap" (the delete/recreate + same-epoch collision). The wall-clock-rollback concern is covered by the existing staleness gate (a past/near epoch is skipped as `EphemerisStale`). The only leftover — structured status fields vs the Condition-message string — is an observability nicety, not correctness; this PR's `lastPushedSatSwitchDigest` is one such structured field.
