### PR TITLE
fix(failover): count anti-flap confirmation by observation, not reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Anti-flap `confirmationSamples` now counts distinct observations, not reconciles.** The
+  N-consecutive failover confirmation advanced its counter on every reliable reconcile, but the
+  metrics chain re-serves the last-good value with an unchanged freshness stamp during a source
+  outage (`Result.Stale`), and a status-conflict retry re-reconciles the same read. A single
+  degraded observation re-served N times therefore tripped the gate — defeating the "absorb a
+  single-sample blip" contract exactly when the source flaked while terrestrial was degraded. The
+  evaluator now folds a sample into the streak only when its observation stamp (the reader chain's
+  `LastFreshAt`) differs from the last one counted; a repeated observation re-decides on the current
+  streak without advancing it. In-memory only, so its loss on restart re-requires confirmation (a
+  delay), consistent with the other flap clocks. Verified at the evaluator (stale replay ≠ N;
+  distinct observations do confirm) and end-to-end in the controller (a stuck stale source across
+  three reconciles no longer confirms a failover on one reading).
+
 ### Added
 
 - **Durable conditional-GET validators for the OMM cache (polite restart/failover refetch).** The

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -299,7 +299,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// write persists (WO-20 / N-1), so a rolled-back Status().Update never announces
 	// (then re-announces on retry) a transition that did not become durable.
 	var pending []deferredEvent
-	metrics, qualityReliable := r.readPathQuality(ctx, ns, now, &pending)
+	metrics, qualityReliable, observationAt := r.readPathQuality(ctx, ns, now, &pending)
 
 	// Step 3: Check satellite availability via SatelliteEphemeris. satelliteKnown is
 	// false on a transient ephemeris read error — availability is unknown and the
@@ -417,7 +417,10 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		af := r.loadFlapState(flapKey, ns.UID)
 		r.seedLastSwitchbackFromStatus(&af, ns, now)
 		var newFlap slice.AntiFlapState
-		result, newFlap = slice.EvaluateFailoverWithAntiFlap(
+		// Fold this sample into the streak keyed on its observation identity (observationAt), so a
+		// stale re-serve or a status-conflict re-reconcile of the SAME read cannot advance the
+		// N-consecutive counter (one degraded observation must not trip confirmation).
+		result, newFlap = slice.EvaluateFailoverWithAntiFlapAt(
 			ctx,
 			currentPath,
 			ns.Spec.FailoverPolicy.Triggers,
@@ -428,6 +431,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			hysteresisMargin,
 			afCfg,
 			af,
+			observationAt,
 		)
 		pendingFlap, pendingFlapKey, pendingFlapUID = &newFlap, flapKey, ns.UID
 		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback, now)
@@ -644,7 +648,12 @@ func (r *NTNSliceReconciler) applyBillingStatus(ns *ntnv1alpha1.NTNSlice, active
 // the degraded conditions and returns qualityReliable=false so the caller fails
 // static (findings.md B-4/I-8). It mutates conditions on ns in memory; the caller
 // persists them once at the end of the reconcile.
-func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time, pending *[]deferredEvent) (slice.Metrics, bool) {
+// readPathQuality returns the path-quality metrics, whether they are reliable enough to drive a
+// switch, and the observation's freshness stamp (the reader chain's LastFreshAt — stable while a
+// value is re-served stale, advancing only on a genuinely new read) so the caller can fold each
+// observation into the anti-flap streak exactly once. The stamp is the zero time when metrics are
+// unreliable (the streak does not advance on those cycles anyway).
+func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time, pending *[]deferredEvent) (slice.Metrics, bool, time.Time) {
 	log := logf.FromContext(ctx)
 
 	reader, err := r.readerProvider().For(ns)
@@ -657,7 +666,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		}
 		log.Error(err, "failed to build metrics reader; failing static", "reason", reason)
 		r.setMetricsDegraded(ns, reason, err.Error())
-		return slice.Metrics{}, false
+		return slice.Metrics{}, false, time.Time{}
 	}
 	readResult, err := reader.Read(ctx, ns)
 	if err != nil {
@@ -667,7 +676,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		}
 		log.Info("metrics unavailable; failing static (holding current path)", "reason", reason, "err", err.Error())
 		r.setMetricsDegraded(ns, reason, err.Error())
-		return slice.Metrics{}, false
+		return slice.Metrics{}, false, time.Time{}
 	}
 
 	// Fresh read: record freshness. The stale Event is emitted only on the
@@ -686,7 +695,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 			ObservedGeneration: ns.Generation,
 		})
 		log.V(2).Info("metrics read", "rsrp", readResult.Metrics.RSRP, "latencyMs", readResult.Metrics.LatencyMs, "packetLossPercent", readResult.Metrics.PacketLossPercent, "stale", false)
-		return readResult.Metrics, true
+		return readResult.Metrics, true, readResult.LastFreshAt
 	}
 
 	age := now.Sub(readResult.LastFreshAt)
@@ -705,7 +714,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 	if age <= metricsMaxStaleness {
 		// Stale but within the freshness bound — still usable for a decision.
 		log.V(2).Info("metrics read", "rsrp", readResult.Metrics.RSRP, "latencyMs", readResult.Metrics.LatencyMs, "packetLossPercent", readResult.Metrics.PacketLossPercent, "stale", true)
-		return readResult.Metrics, true
+		return readResult.Metrics, true, readResult.LastFreshAt
 	}
 
 	// Too stale to drive a switch → fail static. Surface it like the other
@@ -720,7 +729,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		Message:            fmt.Sprintf("Metrics stale beyond %s; quality-driven failover suspended (fail static)", metricsMaxStaleness),
 		ObservedGeneration: ns.Generation,
 	})
-	return slice.Metrics{}, false
+	return slice.Metrics{}, false, time.Time{}
 }
 
 // setMetricsDegraded records that path-quality metrics are unusable for a switch

--- a/internal/controller/ntnslice_observation_identity_test.go
+++ b/internal/controller/ntnslice_observation_identity_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestReconcile_StaleReplayObservation_DoesNotConfirmFailover is the controller-level proof of the
+// observation-identity wiring: a metrics source STUCK re-serving ONE degraded observation (Stale,
+// with a fixed LastFreshAt inside the 90s staleness bound — the source-outage-during-degradation
+// case) must not let successive reconciles climb the N-consecutive counter. Before the fix each
+// reconcile advanced it, so the third reconcile spuriously confirmed a failover on a SINGLE
+// reading; now readPathQuality carries the observation stamp and the streak folds it in once.
+func TestReconcile_StaleReplayObservation_DoesNotConfirmFailover(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+	n3 := 3
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:            []string{"rsrp < -100"},
+				SwitchbackDelay:     metav1.Duration{Duration: 60 * time.Second},
+				ConfirmationSamples: &n3,
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathTerrestrial)},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+
+	// A failover TARGET exists: an active pass window, and PassesPredicted=True so the consumer
+	// trusts it (checkSatelliteAvailability returns known+available only then).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue,
+		Reason: "Predicted", Message: "windows current",
+	})
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+
+	// ONE degraded observation, re-served stale on every read (fixed LastFreshAt, age 30s < 90s).
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -125, LatencyMs: 10, PacketLossPercent: 0}, // rsrp < -100 fires
+		Stale:       true,
+		LastFreshAt: fixedNow.Add(-30 * time.Second),
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+	key := client.ObjectKeyFromObject(nsObj)
+
+	for i := 1; i <= 3; i++ {
+		if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+	}
+
+	// The counter reflects the ONE observation, and the slice never confirmed a failover.
+	st := r.loadFlapState(key, nsObj.UID)
+	if st.ConsecutiveDegraded != 1 {
+		t.Fatalf("one re-served observation across 3 reconciles must count once, got %d", st.ConsecutiveDegraded)
+	}
+	updated := &ntnv1alpha1.NTNSlice{}
+	if err := cli.Get(context.Background(), key, updated); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if updated.Status.ActivePathType == string(slice.PathSatellite) {
+		t.Fatal("a single degraded observation re-served stale must NOT confirm N=3 and fail over to satellite")
+	}
+}

--- a/internal/controller/ntnslice_satread_test.go
+++ b/internal/controller/ntnslice_satread_test.go
@@ -122,6 +122,171 @@ func TestReconcile_TransientEphemerisReadError_HoldsSatellite(t *testing.T) {
 	}
 }
 
+// TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell is the symmetric partner of
+// TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown (three_state_test): a
+// telemetry gap on the OTHER axis — satellite availability UNKNOWN via a transient
+// SatelliteEphemeris read error — must also break the continuous confirmation/recovery streaks
+// (H2), so samples straddling the gap are not treated as consecutive, while the wall-clock
+// min-dwell is preserved. Metrics are FRESH here, so only the unknown-satellite branch (the
+// !satelliteKnown case, checked before qualityReliable) can drive the reset — isolating it from
+// the metrics-unreliable reset the sibling test covers.
+func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+
+	// Transient (non-NotFound) SatelliteEphemeris read → availability UNKNOWN (line-389 branch).
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*ntnv1alpha1.SatelliteEphemeris); ok {
+					return apierrors.NewInternalError(errors.New("simulated transient apiserver read error"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	// FRESH, healthy metrics → qualityReliable is true, so ONLY the unknown-satellite axis drives
+	// the reset.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       false,
+		LastFreshAt: fixedNow,
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	// Seed a confirmation + recovery streak AND a dwell clock from an earlier reliable window.
+	dwell := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
+		ConsecutiveDegraded: 2,
+		LastSwitchback:      dwell,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	st := r.loadFlapState(key, nsObj.UID)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("recovery clock must reset when satellite availability is unknown (H2), got %v", st.RecoveryObservedAt)
+	}
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("confirmation streak must reset when satellite availability is unknown (H2), got %d", st.ConsecutiveDegraded)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("the wall-clock min-dwell must be PRESERVED across the gap, got %v want %v", st.LastSwitchback, dwell)
+	}
+}
+
+// TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell isolates the OTHER
+// telemetry-gap reset branch — metrics UNRELIABLE while satellite availability is KNOWN (the
+// default/fail-static case). The sibling MetricsUnreliable test in three_state_test happens to
+// leave PassesPredicted unset, so its satellite is ALSO unknown and its reset comes from the
+// !satelliteKnown branch; this test sets PassesPredicted=True so !satelliteKnown is false and the
+// reset can ONLY come from the metrics-unreliable branch. The confirmation/recovery streaks must
+// reset (H2) and the wall-clock min-dwell must be preserved.
+func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+
+	// Satellite KNOWN: an active pass window AND PassesPredicted=True (so !satelliteKnown is false).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue,
+		Reason: "Predicted", Message: "windows current",
+	})
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+
+	// Metrics stale BEYOND the 90s bound → unreliable → the default (fail-static) branch runs.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -90, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       true,
+		LastFreshAt: fixedNow.Add(-100 * time.Second),
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	dwell := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
+		ConsecutiveDegraded: 2,
+		LastSwitchback:      dwell,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	st := r.loadFlapState(key, nsObj.UID)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("recovery clock must reset on unreliable metrics with a known satellite (H2), got %v", st.RecoveryObservedAt)
+	}
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("confirmation streak must reset on unreliable metrics with a known satellite (H2), got %d", st.ConsecutiveDegraded)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("the wall-clock min-dwell must be PRESERVED, got %v want %v", st.LastSwitchback, dwell)
+	}
+}
+
 // TestReconcile_InertTrigger_SurfacesTriggersReadyFalse pins I-10 end to end:
 // a trigger over a metric with no configured source (LatencyMissing) is inert;
 // the reconcile must surface TriggersReady=False/InertTriggers rather than let the

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -639,6 +639,15 @@ type AntiFlapState struct {
 	// available satellite (a quality-driven, ping-pong-prone hand-back — NOT a
 	// pass-ended forced switchback). Min-dwell is measured from here.
 	LastSwitchback time.Time
+	// LastObservationAt is the identity of the last observation whose degraded/recovered
+	// verdict was folded into the streak. The confirmation counter must advance on distinct
+	// OBSERVATIONS, not on reconciles: the metrics chain re-serves the SAME last-good value
+	// with an unchanged freshness stamp during a source outage (Result.Stale), and a status
+	// conflict can re-reconcile the same read — counting either as a fresh sample would let one
+	// degraded observation trip N-consecutive. EvaluateFailoverWithAntiFlapAt therefore folds a
+	// sample into the streak only when its observationAt differs from this. In-memory only; its
+	// loss on restart re-requires confirmation (a DELAY), consistent with the other two clocks.
+	LastObservationAt time.Time
 }
 
 // terrestrialDegraded reports whether any valid, live (non-inert) trigger fires
@@ -711,6 +720,11 @@ func terrestrialConfirmedRecovered(triggers []string, m Metrics, margin float64)
 // It returns the decision and the updated state; the caller owns (and may drop)
 // the state. Gating only ever downgrades a Failover to Stay on the current path;
 // it never fabricates a switch.
+//
+// It treats every call as a distinct observation. Callers that re-evaluate the SAME
+// observation across reconciles (a stale metrics re-serve, a status-conflict retry) must use
+// EvaluateFailoverWithAntiFlapAt with the observation's freshness stamp, so one observation is
+// not counted as N confirmation samples.
 func EvaluateFailoverWithAntiFlap(
 	ctx context.Context,
 	currentPath PathType,
@@ -723,27 +737,55 @@ func EvaluateFailoverWithAntiFlap(
 	cfg AntiFlapConfig,
 	st AntiFlapState,
 ) (FailoverResult, AntiFlapState) {
-	// 1. Update the confirmation + recovery clocks from this sample. Three states:
-	//    degraded (a raw trigger fires) / confirmed-recovered (all known triggers past
-	//    the hysteresis margin, none unknown) / neither (dead-band or an unknown
-	//    metric). The recovery clock advances ONLY while confirmed-recovered, so the
-	//    switchback delay measures continuous PAST-hysteresis recovery and never counts
-	//    dead-band or unknown-metric time as recovery (H3/C1).
-	switch {
-	case terrestrialDegraded(triggers, metrics):
-		st.ConsecutiveDegraded++
-		st.RecoveryObservedAt = time.Time{} // re-degraded → reset the switchback clock
-	case terrestrialConfirmedRecovered(triggers, metrics, hysteresisMargin):
-		st.ConsecutiveDegraded = 0
-		if st.RecoveryObservedAt.IsZero() {
-			st.RecoveryObservedAt = now // a fresh continuous past-hysteresis streak begins
+	return EvaluateFailoverWithAntiFlapAt(ctx, currentPath, triggers, metrics, satelliteAvailable,
+		switchbackDelay, now, hysteresisMargin, cfg, st, time.Time{})
+}
+
+// EvaluateFailoverWithAntiFlapAt is EvaluateFailoverWithAntiFlap with an explicit observation
+// identity. observationAt uniquely stamps the metrics sample (the reader chain's LastFreshAt): the
+// degraded/recovered verdict is folded into the streak ONLY when observationAt differs from the
+// last one already counted (st.LastObservationAt). A repeated observation — the metrics chain
+// re-serving its last-good value during a source outage (Result.Stale), or a status-conflict
+// re-reconcile of the same read — re-decides on the current streak WITHOUT advancing it, so a
+// single degraded observation cannot climb to N-consecutive. A zero observationAt disables the
+// gate (every call is a fresh sample), preserving the plain EvaluateFailoverWithAntiFlap contract.
+func EvaluateFailoverWithAntiFlapAt(
+	ctx context.Context,
+	currentPath PathType,
+	triggers []string,
+	metrics Metrics,
+	satelliteAvailable bool,
+	switchbackDelay time.Duration,
+	now time.Time,
+	hysteresisMargin float64,
+	cfg AntiFlapConfig,
+	st AntiFlapState,
+	observationAt time.Time,
+) (FailoverResult, AntiFlapState) {
+	// 1. Update the confirmation + recovery clocks from this sample — but ONLY when it is a new
+	//    observation, so a stale re-serve or a retried read cannot inflate the streak. Three
+	//    states: degraded (a raw trigger fires) / confirmed-recovered (all known triggers past the
+	//    hysteresis margin, none unknown) / neither (dead-band or an unknown metric). The recovery
+	//    clock advances ONLY while confirmed-recovered, so the switchback delay measures continuous
+	//    PAST-hysteresis recovery and never counts dead-band or unknown-metric time (H3/C1).
+	if observationAt.IsZero() || !observationAt.Equal(st.LastObservationAt) {
+		st.LastObservationAt = observationAt
+		switch {
+		case terrestrialDegraded(triggers, metrics):
+			st.ConsecutiveDegraded++
+			st.RecoveryObservedAt = time.Time{} // re-degraded → reset the switchback clock
+		case terrestrialConfirmedRecovered(triggers, metrics, hysteresisMargin):
+			st.ConsecutiveDegraded = 0
+			if st.RecoveryObservedAt.IsZero() {
+				st.RecoveryObservedAt = now // a fresh continuous past-hysteresis streak begins
+			}
+		default:
+			// Dead-band or unknown metric: neither degraded nor confirmed recovered. Break
+			// the recovery streak so a later confirmed recovery must re-accumulate the full
+			// switchback delay. (The evaluator independently holds on satellite here.)
+			st.ConsecutiveDegraded = 0
+			st.RecoveryObservedAt = time.Time{}
 		}
-	default:
-		// Dead-band or unknown metric: neither degraded nor confirmed recovered. Break
-		// the recovery streak so a later confirmed recovery must re-accumulate the full
-		// switchback delay. (The evaluator independently holds on satellite here.)
-		st.ConsecutiveDegraded = 0
-		st.RecoveryObservedAt = time.Time{}
 	}
 
 	// 2. Run the base engine, measuring the switchback delay from the recovery

--- a/pkg/slice/failover_observation_identity_test.go
+++ b/pkg/slice/failover_observation_identity_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slice
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestAntiFlapAt_StaleReplayDoesNotConfirm: one degraded observation re-served N times under the
+// SAME observation identity (a metrics-source outage re-serving its last-good value, or a
+// status-conflict re-reconcile of the same read) must NOT satisfy N-consecutive confirmation.
+// Before the identity gate, each call advanced the counter, so one degraded observation replayed
+// three times tripped N=3 — defeating the "absorb a single-sample blip" contract.
+func TestAntiFlapAt_StaleReplayDoesNotConfirm(t *testing.T) {
+	cfg := AntiFlapConfig{ConfirmationSamples: 3}
+	obs := now // ONE observation identity, re-served below
+	var st AntiFlapState
+	for i := 1; i <= 3; i++ {
+		var res FailoverResult
+		res, st = EvaluateFailoverWithAntiFlapAt(context.Background(), PathTerrestrial, triggers,
+			afDegraded, true, afSwitchbackDelay, now, 0, cfg, st, obs)
+		if res.Decision != DecisionStay {
+			t.Fatalf("re-serve %d of the SAME degraded observation must not fail over, got %s (%s)", i, res.Decision, res.Reason)
+		}
+	}
+	if st.ConsecutiveDegraded != 1 {
+		t.Fatalf("one observation re-served 3x must count as 1 confirmation, got %d", st.ConsecutiveDegraded)
+	}
+}
+
+// TestAntiFlapAt_CountsDistinctObservationsOnly walks the whole identity contract in one streak: a
+// new observation advances the counter, re-serving it holds, and three DISTINCT degraded
+// observations are required to confirm the failover.
+func TestAntiFlapAt_CountsDistinctObservationsOnly(t *testing.T) {
+	cfg := AntiFlapConfig{ConfirmationSamples: 3}
+	var st AntiFlapState
+	step := func(obs time.Time) FailoverResult {
+		var res FailoverResult
+		res, st = EvaluateFailoverWithAntiFlapAt(context.Background(), PathTerrestrial, triggers,
+			afDegraded, true, afSwitchbackDelay, now, 0, cfg, st, obs)
+		return res
+	}
+
+	o1 := now
+	step(o1) // new observation → 1/3
+	if st.ConsecutiveDegraded != 1 {
+		t.Fatalf("first observation: want 1, got %d", st.ConsecutiveDegraded)
+	}
+	step(o1)
+	step(o1) // same observation re-read twice → still 1/3
+	if st.ConsecutiveDegraded != 1 {
+		t.Fatalf("re-reading the same observation must not increment; got %d", st.ConsecutiveDegraded)
+	}
+	step(now.Add(time.Second)) // a new observation → 2/3
+	if st.ConsecutiveDegraded != 2 {
+		t.Fatalf("a new observation must increment; got %d", st.ConsecutiveDegraded)
+	}
+	res := step(now.Add(2 * time.Second)) // a third distinct observation → 3/3 → failover
+	if st.ConsecutiveDegraded != 3 || res.Decision != DecisionFailover {
+		t.Fatalf("third distinct degraded observation must confirm; count=%d decision=%s",
+			st.ConsecutiveDegraded, res.Decision)
+	}
+}
+
+// TestAntiFlapAt_ZeroObservationCountsEveryCall pins the back-compat contract: a zero observationAt
+// (the plain EvaluateFailoverWithAntiFlap path the pure-evaluator unit tests use) disables the
+// identity gate, so every call is a fresh sample — the pre-existing semantics are unchanged.
+func TestAntiFlapAt_ZeroObservationCountsEveryCall(t *testing.T) {
+	cfg := AntiFlapConfig{ConfirmationSamples: 3}
+	var st AntiFlapState
+	var res FailoverResult
+	for range 3 {
+		res, st = EvaluateFailoverWithAntiFlapAt(context.Background(), PathTerrestrial, triggers,
+			afDegraded, true, afSwitchbackDelay, now, 0, cfg, st, time.Time{})
+	}
+	if st.ConsecutiveDegraded != 3 || res.Decision != DecisionFailover {
+		t.Fatalf("zero observationAt must count every call; count=%d decision=%s", st.ConsecutiveDegraded, res.Decision)
+	}
+}


### PR DESCRIPTION
## The bug

The anti-flap **`confirmationSamples`** gate (require N *consecutive* degraded samples before failing over to satellite, to absorb a single blip) advanced its counter on **every reliable reconcile**. But a reconcile is not an observation:

- during a metrics-**source outage** the reader chain re-serves the last-good value with an **unchanged** freshness stamp (`Result.Stale=true`, same `LastFreshAt`), and `readPathQuality` treats a stale-within-bound value as reliable;
- a **status-conflict retry** re-reconciles the same read.

So a **single** degraded observation, re-served N times, climbed the counter to N and confirmed a failover — defeating the "absorb a single-sample blip" contract precisely in the outage-while-degraded case it exists for.

## The fix

`LastFreshAt` (the reader chain's observation stamp — stable while a value is re-served, advancing only on a genuinely new read, monotonic) is the observation identity. `readPathQuality` now returns it, and the new `EvaluateFailoverWithAntiFlapAt` folds a sample into the streak **only when the stamp differs from the last one counted** (`AntiFlapState.LastObservationAt`); a repeated observation re-decides on the current streak **without advancing it**. In-memory only — losing it on restart re-requires confirmation (a delay), consistent with the other two flap clocks. The plain `EvaluateFailoverWithAntiFlap` is kept as a zero-stamp wrapper (every call is a fresh sample), so the existing evaluator unit tests are unchanged.

This also covers the **status-conflict retry** case: the retry either re-reads the same stamp (held) or, since `storeFlapState` already commits only after a successful status write, discards the failed attempt's increment.

## Tests (mutation-verified)

- **Evaluator** (`pkg/slice`): one observation replayed 3× ≠ N=3; three *distinct* degraded observations do confirm; a zero stamp counts every call (back-compat).
- **Controller** (`internal/controller`): a metrics source stuck re-serving one degraded observation across three reconciles does **not** confirm a failover to satellite (`ConsecutiveDegraded` stays 1, path stays terrestrial). Removing the gate fails both for the right reason.

`golangci-lint` 0 issues; `pkg/slice` + `internal/controller` green.

## Scope notes (the rest of the review finding)

The finding also raised several items I verified as **already handled** or **declined with reasoning**:

- **Already covered by existing tests:** dead-band not counting toward recovery (`TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay`), `PathUnavailable → PathTerrestrial` not starting the dwell (`TestAntiFlap_InitToTerrestrial_DoesNotStartDwell`), durable min-dwell across restart/handoff (`ntnslice_lastswitchback_persist_test.go`), same-name-different-UID not inheriting state (`TestReconcile_StaleFlapStateForDifferentUID_IsNotInherited`).
- **`confirmationSamples *int → *int32`: declined.** The whole NTN API uses `int` (`Terrestrial5QI`, `FailoverCount`, `SessionCount`); the value is admission-bounded 1–10 (no functional or cross-arch difference); changing one field breaks internal consistency for zero benefit.
- **`minTerrestrialDwell` bounds: declined.** A non-positive value is already safe (the `>0` gate disables it), and "no upper bound" matches every other duration in the codebase (`switchbackDelay`, `maxLatencyBudget`, `queryTimeout` are all `Format`-only). The dwell is a soft bound that elapses. Not worth a one-off CEL rule + 5-file CRD churn.
- **Generation-reset on spec edit: declined.** The counter tracks real degraded observations; counting a mix of old- and new-policy degraded readings toward N is defensible (terrestrial was genuinely degraded in all of them), the streak self-corrects within ≤N reconciles under the new policy, and it is already fail-safe (delay, never spurious). Not worth reworking the shared durable-dwell test seeding.

---

### Also: independent locks for the telemetry-gap streak resets (finding #4)

Finding #4 (a telemetry gap must break the confirmation/recovery streak) is already fixed by #220 — no code change needed. But **mutation testing found a coverage gap**: `resetRecoveryStreak` is called on two axes (satellite-unknown `!satelliteKnown`, and metrics-unreliable fail-static), and the existing `MetricsUnreliable` test actually resets via the **satellite-unknown** branch (its eph leaves `PassesPredicted` unset). Removing the **metrics-unreliable** reset left the whole suite green — that branch was untested.

Added two tests that isolate each branch (both mutation-verified to fail only when their own reset is removed): `TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell` and `TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell`. Test-only; locks already-shipped #220 semantics.