### PR TITLE
fix(failover): count confirmationSamples by distinct observation, not reconcile call

### DIFF
--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -299,7 +299,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// write persists (WO-20 / N-1), so a rolled-back Status().Update never announces
 	// (then re-announces on retry) a transition that did not become durable.
 	var pending []deferredEvent
-	metrics, qualityReliable := r.readPathQuality(ctx, ns, now, &pending)
+	metrics, observedAt, qualityReliable := r.readPathQuality(ctx, ns, now, &pending)
 
 	// Step 3: Check satellite availability via SatelliteEphemeris. satelliteKnown is
 	// false on a transient ephemeris read error — availability is unknown and the
@@ -422,6 +422,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			currentPath,
 			ns.Spec.FailoverPolicy.Triggers,
 			metrics,
+			observedAt,
 			satelliteAvailable,
 			ns.Spec.FailoverPolicy.SwitchbackDelay.Duration,
 			now,
@@ -644,7 +645,7 @@ func (r *NTNSliceReconciler) applyBillingStatus(ns *ntnv1alpha1.NTNSlice, active
 // the degraded conditions and returns qualityReliable=false so the caller fails
 // static (findings.md B-4/I-8). It mutates conditions on ns in memory; the caller
 // persists them once at the end of the reconcile.
-func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time, pending *[]deferredEvent) (slice.Metrics, bool) {
+func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha1.NTNSlice, now time.Time, pending *[]deferredEvent) (slice.Metrics, time.Time, bool) {
 	log := logf.FromContext(ctx)
 
 	reader, err := r.readerProvider().For(ns)
@@ -657,7 +658,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		}
 		log.Error(err, "failed to build metrics reader; failing static", "reason", reason)
 		r.setMetricsDegraded(ns, reason, err.Error())
-		return slice.Metrics{}, false
+		return slice.Metrics{}, time.Time{}, false
 	}
 	readResult, err := reader.Read(ctx, ns)
 	if err != nil {
@@ -667,7 +668,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		}
 		log.Info("metrics unavailable; failing static (holding current path)", "reason", reason, "err", err.Error())
 		r.setMetricsDegraded(ns, reason, err.Error())
-		return slice.Metrics{}, false
+		return slice.Metrics{}, time.Time{}, false
 	}
 
 	// Fresh read: record freshness. The stale Event is emitted only on the
@@ -686,7 +687,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 			ObservedGeneration: ns.Generation,
 		})
 		log.V(2).Info("metrics read", "rsrp", readResult.Metrics.RSRP, "latencyMs", readResult.Metrics.LatencyMs, "packetLossPercent", readResult.Metrics.PacketLossPercent, "stale", false)
-		return readResult.Metrics, true
+		return readResult.Metrics, readResult.ObservedAt, true
 	}
 
 	age := now.Sub(readResult.LastFreshAt)
@@ -705,7 +706,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 	if age <= metricsMaxStaleness {
 		// Stale but within the freshness bound — still usable for a decision.
 		log.V(2).Info("metrics read", "rsrp", readResult.Metrics.RSRP, "latencyMs", readResult.Metrics.LatencyMs, "packetLossPercent", readResult.Metrics.PacketLossPercent, "stale", true)
-		return readResult.Metrics, true
+		return readResult.Metrics, readResult.ObservedAt, true
 	}
 
 	// Too stale to drive a switch → fail static. Surface it like the other
@@ -720,7 +721,7 @@ func (r *NTNSliceReconciler) readPathQuality(ctx context.Context, ns *ntnv1alpha
 		Message:            fmt.Sprintf("Metrics stale beyond %s; quality-driven failover suspended (fail static)", metricsMaxStaleness),
 		ObservedGeneration: ns.Generation,
 	})
-	return slice.Metrics{}, false
+	return slice.Metrics{}, time.Time{}, false
 }
 
 // setMetricsDegraded records that path-quality metrics are unusable for a switch

--- a/pkg/slice/failover.go
+++ b/pkg/slice/failover.go
@@ -639,6 +639,13 @@ type AntiFlapState struct {
 	// available satellite (a quality-driven, ping-pong-prone hand-back — NOT a
 	// pass-ended forced switchback). Min-dwell is measured from here.
 	LastSwitchback time.Time
+	// LastCountedObservedAt is the source timestamp (Result.ObservedAt) of the most recent
+	// observation that advanced the anti-flap state. A degraded/recovered sample updates the
+	// counters only when its ObservedAt is newer than this, so a stale-cache replay or a
+	// stalled-scrape duplicate (same or older timestamp) HOLDS the state instead of falsely
+	// confirming it — making confirmationSamples count DISTINCT observations, not reconcile
+	// calls (#203-M3). Zero when no timestamped observation has been counted yet.
+	LastCountedObservedAt time.Time
 }
 
 // terrestrialDegraded reports whether any valid, live (non-inert) trigger fires
@@ -716,6 +723,7 @@ func EvaluateFailoverWithAntiFlap(
 	currentPath PathType,
 	triggers []string,
 	metrics Metrics,
+	observedAt time.Time,
 	satelliteAvailable bool,
 	switchbackDelay time.Duration,
 	now time.Time,
@@ -729,21 +737,30 @@ func EvaluateFailoverWithAntiFlap(
 	//    metric). The recovery clock advances ONLY while confirmed-recovered, so the
 	//    switchback delay measures continuous PAST-hysteresis recovery and never counts
 	//    dead-band or unknown-metric time as recovery (H3/C1).
-	switch {
-	case terrestrialDegraded(triggers, metrics):
-		st.ConsecutiveDegraded++
-		st.RecoveryObservedAt = time.Time{} // re-degraded → reset the switchback clock
-	case terrestrialConfirmedRecovered(triggers, metrics, hysteresisMargin):
-		st.ConsecutiveDegraded = 0
-		if st.RecoveryObservedAt.IsZero() {
-			st.RecoveryObservedAt = now // a fresh continuous past-hysteresis streak begins
+	// Only a genuinely NEW observation advances the confirmation/recovery clocks. A replayed
+	// stale-cache value or a stalled-scrape duplicate (same or older source timestamp) carries no
+	// new information, so it HOLDS the counters: otherwise confirmationSamples would count reconcile
+	// calls, not distinct observations, and a metrics-source outage could replay one degraded sample
+	// N times into a failover (#203-M3). A zero ObservedAt (a reader that cannot supply a source
+	// timestamp) falls back to counting every call, preserving the prior behavior.
+	if observedAt.IsZero() || observedAt.After(st.LastCountedObservedAt) {
+		switch {
+		case terrestrialDegraded(triggers, metrics):
+			st.ConsecutiveDegraded++
+			st.RecoveryObservedAt = time.Time{} // re-degraded → reset the switchback clock
+		case terrestrialConfirmedRecovered(triggers, metrics, hysteresisMargin):
+			st.ConsecutiveDegraded = 0
+			if st.RecoveryObservedAt.IsZero() {
+				st.RecoveryObservedAt = now // a fresh continuous past-hysteresis streak begins
+			}
+		default:
+			// Dead-band or unknown metric: neither degraded nor confirmed recovered. Break
+			// the recovery streak so a later confirmed recovery must re-accumulate the full
+			// switchback delay. (The evaluator independently holds on satellite here.)
+			st.ConsecutiveDegraded = 0
+			st.RecoveryObservedAt = time.Time{}
 		}
-	default:
-		// Dead-band or unknown metric: neither degraded nor confirmed recovered. Break
-		// the recovery streak so a later confirmed recovery must re-accumulate the full
-		// switchback delay. (The evaluator independently holds on satellite here.)
-		st.ConsecutiveDegraded = 0
-		st.RecoveryObservedAt = time.Time{}
+		st.LastCountedObservedAt = observedAt
 	}
 
 	// 2. Run the base engine, measuring the switchback delay from the recovery

--- a/pkg/slice/failover_antiflap_test.go
+++ b/pkg/slice/failover_antiflap_test.go
@@ -34,11 +34,52 @@ const afSwitchbackDelay = 60 * time.Second
 // immediately, exactly like the un-gated engine.
 func TestAntiFlap_OptInPreservesImmediateFailover(t *testing.T) {
 	res, _ := EvaluateFailoverWithAntiFlap(
-		context.Background(), PathTerrestrial, triggers, afDegraded, true,
+		context.Background(), PathTerrestrial, triggers, afDegraded, time.Time{}, true,
 		afSwitchbackDelay, now, 0, AntiFlapConfig{}, AntiFlapState{},
 	)
 	if res.Decision != DecisionFailover {
 		t.Fatalf("zero-config must fail over immediately, got %s (%s)", res.Decision, res.Reason)
+	}
+}
+
+// TestAntiFlap_ReplayedObservationDoesNotConfirm pins #203-M3: confirmationSamples must count
+// DISTINCT observations, not reconcile calls. A single degraded observation replayed by the stale
+// cache (same ObservedAt) during a metrics-source outage must NOT accumulate confirmations into a
+// failover; only genuinely new observations (advancing ObservedAt) count. Mutation: drop the
+// `observedAt.After(st.LastCountedObservedAt)` gate → the replays each increment the counter, reach
+// the threshold, and the "replay must hold" assertion fails.
+func TestAntiFlap_ReplayedObservationDoesNotConfirm(t *testing.T) {
+	cfg := AntiFlapConfig{ConfirmationSamples: 3}
+	var st AntiFlapState
+	eval := func(observedAt time.Time) FailoverResult {
+		var res FailoverResult
+		res, st = EvaluateFailoverWithAntiFlap(
+			context.Background(), PathTerrestrial, triggers, afDegraded, observedAt, true,
+			afSwitchbackDelay, now, 0, cfg, st,
+		)
+		return res
+	}
+
+	obs := now // the single degraded observation's source timestamp
+	// t=0: one fresh degraded observation → 1/3, hold terrestrial.
+	if res := eval(obs); res.Decision != DecisionStay || st.ConsecutiveDegraded != 1 {
+		t.Fatalf("first observation: want Stay 1/3, got %s count=%d", res.Decision, st.ConsecutiveDegraded)
+	}
+	// A metrics-source outage replays the SAME observation (same ObservedAt) every reconcile. It must
+	// HOLD at 1/3 and never fail over — the bug was that each replay incremented the counter (#203-M3).
+	for i := range 5 {
+		if res := eval(obs); res.Decision != DecisionStay || st.ConsecutiveDegraded != 1 {
+			t.Fatalf("replay %d must hold at 1/3 (a replay is not a new confirmation), got %s count=%d",
+				i, res.Decision, st.ConsecutiveDegraded)
+		}
+	}
+	// Two more DISTINCT observations (advancing ObservedAt) reach 3/3 → a real sustained degradation
+	// still fails over, so the gate only suppresses replays, not genuine confirmations.
+	if res := eval(obs.Add(1 * time.Second)); res.Decision != DecisionStay || st.ConsecutiveDegraded != 2 {
+		t.Fatalf("second distinct observation: want Stay 2/3, got %s count=%d", res.Decision, st.ConsecutiveDegraded)
+	}
+	if res := eval(obs.Add(2 * time.Second)); res.Decision != DecisionFailover {
+		t.Fatalf("third distinct observation must fail over (3/3), got %s count=%d", res.Decision, st.ConsecutiveDegraded)
 	}
 }
 
@@ -51,7 +92,7 @@ func TestAntiFlap_NConsecutiveConfirmation(t *testing.T) {
 	eval := func(m Metrics) FailoverResult {
 		var res FailoverResult
 		res, st = EvaluateFailoverWithAntiFlap(
-			context.Background(), PathTerrestrial, triggers, m, true,
+			context.Background(), PathTerrestrial, triggers, m, time.Time{}, true,
 			afSwitchbackDelay, now, 0, cfg, st,
 		)
 		return res
@@ -92,7 +133,7 @@ func TestAntiFlap_MinDwellBlocksRefailover(t *testing.T) {
 	eval := func(at time.Time) FailoverResult {
 		var res FailoverResult
 		res, st = EvaluateFailoverWithAntiFlap(
-			context.Background(), PathTerrestrial, triggers, afDegraded, true,
+			context.Background(), PathTerrestrial, triggers, afDegraded, time.Time{}, true,
 			afSwitchbackDelay, at, 0, cfg, st,
 		)
 		return res
@@ -117,7 +158,7 @@ func TestAntiFlap_SwitchbackTimerResetsOnRedegrade(t *testing.T) {
 	eval := func(m Metrics, at time.Time) FailoverResult {
 		var res FailoverResult
 		res, st = EvaluateFailoverWithAntiFlap(
-			context.Background(), PathSatellite, triggers, m, true,
+			context.Background(), PathSatellite, triggers, m, time.Time{}, true,
 			afSwitchbackDelay, at, 0, AntiFlapConfig{}, st,
 		)
 		return res

--- a/pkg/slice/failover_three_state_test.go
+++ b/pkg/slice/failover_three_state_test.go
@@ -93,7 +93,7 @@ func TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay(t *testing.T) {
 
 	// Sit in the dead-band longer than the switchback delay. The recovery clock must
 	// stay unset — the dead-band is not recovery.
-	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand,
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand, time.Time{},
 		true, 60*time.Second, now, margin, AntiFlapConfig{}, st)
 	if res.Decision != DecisionStay {
 		t.Fatalf("dead-band must stay on satellite, got %s: %s", res.Decision, res.Reason)
@@ -101,7 +101,7 @@ func TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay(t *testing.T) {
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Fatal("the recovery clock must NOT start in the dead-band (H3)")
 	}
-	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand,
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, deadBand, time.Time{},
 		true, 60*time.Second, now.Add(120*time.Second), margin, AntiFlapConfig{}, st)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Fatal("still in dead-band 120s later: the recovery clock must remain unset (H3)")
@@ -109,7 +109,7 @@ func TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay(t *testing.T) {
 
 	// Cross the margin. The clock starts NOW, so the 60s delay is not yet elapsed → hold.
 	tCross := now.Add(121 * time.Second)
-	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered,
+	res, st = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered, time.Time{},
 		true, 60*time.Second, tCross, margin, AntiFlapConfig{}, st)
 	if res.Decision != DecisionStay {
 		t.Fatalf("the switchback delay must be measured from the past-hysteresis recovery, not the "+
@@ -120,7 +120,7 @@ func TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay(t *testing.T) {
 	}
 
 	// After a full switchback delay of continuous past-hysteresis recovery → switchback.
-	res, _ = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered,
+	res, _ = EvaluateFailoverWithAntiFlap(context.Background(), PathSatellite, trg, recovered, time.Time{},
 		true, 60*time.Second, tCross.Add(60*time.Second), margin, AntiFlapConfig{}, st)
 	if res.Decision != DecisionSwitchback {
 		t.Fatalf("after switchbackDelay of continuous past-hysteresis recovery, expected Switchback, got %s: %s",
@@ -237,7 +237,7 @@ func TestAntiFlap_InitToTerrestrial_DoesNotStartDwell(t *testing.T) {
 	cfg := AntiFlapConfig{MinTerrestrialDwell: 90 * time.Second}
 	healthy := Metrics{RSRP: -90, LatencyMs: 20, PacketLossPercent: 0.1}
 
-	res, st := EvaluateFailoverWithAntiFlap(context.Background(), PathUnavailable, triggers, healthy,
+	res, st := EvaluateFailoverWithAntiFlap(context.Background(), PathUnavailable, triggers, healthy, time.Time{},
 		true, 60*time.Second, now, 0, cfg, AntiFlapState{})
 	if res.Decision != DecisionSwitchback {
 		t.Fatalf("init from unavailable → terrestrial expected Switchback, got %s: %s", res.Decision, res.Reason)
@@ -248,7 +248,7 @@ func TestAntiFlap_InitToTerrestrial_DoesNotStartDwell(t *testing.T) {
 
 	// A real degradation immediately after must be free to fail over, not dwell-blocked.
 	degraded := Metrics{RSRP: -130, LatencyMs: 20, PacketLossPercent: 0.1}
-	res2, _ := EvaluateFailoverWithAntiFlap(context.Background(), PathTerrestrial, triggers, degraded,
+	res2, _ := EvaluateFailoverWithAntiFlap(context.Background(), PathTerrestrial, triggers, degraded, time.Time{},
 		true, 60*time.Second, now.Add(time.Second), 0, cfg, st)
 	if res2.Decision != DecisionFailover {
 		t.Fatalf("a real degradation after init must fail over (not be dwell-blocked), got %s: %s",

--- a/pkg/slice/metrics/prometheus.go
+++ b/pkg/slice/metrics/prometheus.go
@@ -123,6 +123,7 @@ func (r *prometheusReader) Read(ctx context.Context, ns *ntnv1alpha1.NTNSlice) (
 		{r.queries.LatencyMs, func(v float64) { m.LatencyMs = v }, func() { m.LatencyMissing = false }},
 		{r.queries.PacketLossPercent, func(v float64) { m.PacketLossPercent = v }, func() { m.PacketLossMissing = false }},
 	}
+	var observedAt time.Time
 	for _, f := range fields {
 		if f.query == "" {
 			continue
@@ -131,15 +132,21 @@ func (r *prometheusReader) Read(ctx context.Context, ns *ntnv1alpha1.NTNSlice) (
 		// fetch, not the whole Read. A slow query burning the whole budget
 		// must not starve the other metrics.
 		qctx, cancel := context.WithTimeout(ctx, r.timeout)
-		v, err := r.fetch(qctx, f.query)
+		v, ts, err := r.fetch(qctx, f.query)
 		cancel()
 		if err != nil {
 			return Result{}, err
 		}
 		f.set(v)
 		f.present() // real value obtained → the field is present (I-10)
+		// The observation instant is the freshest per-metric sample time: it advances only
+		// when the source produced a new scrape for at least one queried metric, so a stalled
+		// scrape (same samples re-returned) leaves it unchanged.
+		if ts.After(observedAt) {
+			observedAt = ts
+		}
 	}
-	return Result{Metrics: m}, nil
+	return Result{Metrics: m, ObservedAt: observedAt}, nil
 }
 
 // fetch issues a single instant query, extracts a finite float64, and
@@ -148,7 +155,7 @@ func (r *prometheusReader) Read(ctx context.Context, ns *ntnv1alpha1.NTNSlice) (
 // on every non-success path. Empty vectors and non-finite values surface
 // as ErrNoMetrics so the caller sees a uniform "this metric is
 // unobservable" signal.
-func (r *prometheusReader) fetch(ctx context.Context, q string) (result float64, err error) {
+func (r *prometheusReader) fetch(ctx context.Context, q string) (result float64, observedAt time.Time, err error) {
 	start := time.Now()
 	var reason string
 	defer func() {
@@ -168,21 +175,23 @@ func (r *prometheusReader) fetch(ctx context.Context, q string) (result float64,
 	v, qerr := r.client.Query(ctx, q, r.now())
 	if qerr != nil {
 		reason = reasonQueryError
-		return 0, fmt.Errorf("prometheusReader: query %q: %w", q, qerr)
+		return 0, time.Time{}, fmt.Errorf("prometheusReader: query %q: %w", q, qerr)
 	}
 	switch value := v.(type) {
 	case *model.Scalar:
 		f := float64(value.Value)
 		if math.IsNaN(f) || math.IsInf(f, 0) {
 			reason = reasonNonFinite
-			return 0, fmt.Errorf("prometheusReader: query %q non-finite (%v): %w", q, f, ErrNoMetrics)
+			return 0, time.Time{}, fmt.Errorf("prometheusReader: query %q non-finite (%v): %w", q, f, ErrNoMetrics)
 		}
-		return f, nil
+		// value.Timestamp is the SOURCE sample time (the query evaluation instant for a
+		// scalar), returned so the anti-flap engine can tell a new observation from a replay.
+		return f, value.Timestamp.Time(), nil
 	case model.Vector:
 		switch len(value) {
 		case 0:
 			reason = reasonEmptyVector
-			return 0, fmt.Errorf("prometheusReader: query %q empty vector: %w", q, ErrNoMetrics)
+			return 0, time.Time{}, fmt.Errorf("prometheusReader: query %q empty vector: %w", q, ErrNoMetrics)
 		case 1:
 			// fall through to finite check below
 		default:
@@ -191,18 +200,20 @@ func (r *prometheusReader) fetch(ctx context.Context, q string) (result float64,
 			// user to reduce it with avg() / max() / a more specific
 			// selector is safer than picking value[0] nondeterministically.
 			reason = reasonAmbiguousVector
-			return 0, fmt.Errorf(
+			return 0, time.Time{}, fmt.Errorf(
 				"prometheusReader: query %q returned %d samples, expected exactly one: %w",
 				q, len(value), ErrNoMetrics)
 		}
 		f := float64(value[0].Value)
 		if math.IsNaN(f) || math.IsInf(f, 0) {
 			reason = reasonNonFinite
-			return 0, fmt.Errorf("prometheusReader: query %q non-finite (%v): %w", q, f, ErrNoMetrics)
+			return 0, time.Time{}, fmt.Errorf("prometheusReader: query %q non-finite (%v): %w", q, f, ErrNoMetrics)
 		}
-		return f, nil
+		// value[0].Timestamp is the source scrape time of the selected sample — the identity
+		// of THIS observation, which a stalled scrape or a stale-cache replay leaves unchanged.
+		return f, value[0].Timestamp.Time(), nil
 	default:
 		reason = reasonUnsupportedType
-		return 0, fmt.Errorf("prometheusReader: query %q unsupported result type %T: %w", q, v, ErrNoMetrics)
+		return 0, time.Time{}, fmt.Errorf("prometheusReader: query %q unsupported result type %T: %w", q, v, ErrNoMetrics)
 	}
 }

--- a/pkg/slice/metrics/prometheus_test.go
+++ b/pkg/slice/metrics/prometheus_test.go
@@ -88,6 +88,30 @@ func TestPrometheusReader_AllScalars_ReturnsParsedMetrics(t *testing.T) {
 	}
 }
 
+// TestPrometheusReader_ObservedAtFromSampleTimestamp pins #203-M3's plumbing: the reader must carry
+// the SOURCE sample timestamp (model.Sample.Timestamp) through Result.ObservedAt — it was previously
+// discarded — so the anti-flap engine can tell a new observation from a stalled-scrape duplicate.
+func TestPrometheusReader_ObservedAtFromSampleTimestamp(t *testing.T) {
+	obs := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	ts := model.TimeFromUnixNano(obs.UnixNano())
+	client := &fakeQueryClient{
+		responses: map[string]model.Value{
+			"rsrp_query":    model.Vector{&model.Sample{Value: -100, Timestamp: ts}},
+			"latency_query": model.Vector{&model.Sample{Value: 40, Timestamp: ts}},
+			"loss_query":    model.Vector{&model.Sample{Value: 0.5, Timestamp: ts}},
+		},
+	}
+	r := metrics.NewPrometheusReader(client, defaultConfig())
+	got, err := r.Read(context.Background(), sliceCR())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !got.ObservedAt.Equal(obs) {
+		t.Fatalf("ObservedAt must be the source sample timestamp %v, got %v (the reader must not discard "+
+			"model.Sample.Timestamp, #203-M3)", obs, got.ObservedAt)
+	}
+}
+
 func TestPrometheusReader_VectorWithOneSample_Parsed(t *testing.T) {
 	client := &fakeQueryClient{
 		responses: map[string]model.Value{

--- a/pkg/slice/metrics/reader.go
+++ b/pkg/slice/metrics/reader.go
@@ -43,10 +43,20 @@ var ErrNoMetrics = errors.New("metrics: no value available")
 // the current read; for a stale return it is the timestamp of the previous
 // successful read. A zero value means the reader does not track freshness
 // (e.g., annotationReader, which has no notion of "out of date").
+//
+// ObservedAt is the SOURCE timestamp of the underlying observation (for Prometheus,
+// model.Sample.Timestamp), NOT the read time — so a stale-cache replay carries the
+// original observation's timestamp, and a reachable source that keeps returning the
+// same (stalled-scrape) sample carries an unchanged timestamp. The anti-flap engine
+// counts a confirmation only when ObservedAt advances, so a replayed or duplicate
+// observation cannot falsely satisfy confirmationSamples (#203-M3). A zero value means
+// the reader cannot supply a source timestamp; the engine then falls back to counting
+// each call (the prior behavior).
 type Result struct {
 	Metrics     slice.Metrics
 	Stale       bool
 	LastFreshAt time.Time
+	ObservedAt  time.Time
 }
 
 // Reader produces path quality measurements for a single NTNSlice.

--- a/pkg/slice/metrics/stale.go
+++ b/pkg/slice/metrics/stale.go
@@ -43,8 +43,9 @@ type staleCache struct {
 }
 
 type staleEntry struct {
-	metrics slice.Metrics
-	freshAt time.Time
+	metrics    slice.Metrics
+	freshAt    time.Time
+	observedAt time.Time // source sample time; replayed unchanged so a replay is not a new observation
 }
 
 // NewStaleCache returns a Reader that remembers the last fresh observation
@@ -68,7 +69,7 @@ func (c *staleCache) Read(ctx context.Context, ns *ntnv1alpha1.NTNSlice) (Result
 	if err == nil {
 		freshAt := c.now()
 		c.mu.Lock()
-		c.cache[ns.UID] = staleEntry{metrics: res.Metrics, freshAt: freshAt}
+		c.cache[ns.UID] = staleEntry{metrics: res.Metrics, freshAt: freshAt, observedAt: res.ObservedAt}
 		c.mu.Unlock()
 		res.LastFreshAt = freshAt
 		return res, nil
@@ -97,5 +98,5 @@ func (c *staleCache) Read(ctx context.Context, ns *ntnv1alpha1.NTNSlice) (Result
 	ntnmetrics.ReaderStaleUsedTotal.With(prometheus.Labels{
 		"namespace": ns.Namespace, "name": ns.Name,
 	}).Inc()
-	return Result{Metrics: cached.metrics, Stale: true, LastFreshAt: cached.freshAt}, nil
+	return Result{Metrics: cached.metrics, Stale: true, LastFreshAt: cached.freshAt, ObservedAt: cached.observedAt}, nil
 }

--- a/pkg/slice/metrics/stale_test.go
+++ b/pkg/slice/metrics/stale_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -70,6 +71,33 @@ func TestStaleCache_FirstSuccess_Cached(t *testing.T) {
 	}
 	if got.Metrics.RSRP != -95 {
 		t.Errorf("got %v want -95", got.Metrics.RSRP)
+	}
+}
+
+// TestStaleCache_ReplayPreservesObservedAt pins #203-M3's plumbing: a stale-cache replay must carry
+// the ORIGINAL observation's source timestamp, not a new one, so the anti-flap engine sees the same
+// ObservedAt and does not count the replay as a fresh confirmation.
+func TestStaleCache_ReplayPreservesObservedAt(t *testing.T) {
+	obs := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	inner := &scriptedReader{script: []scriptStep{
+		{res: metrics.Result{Metrics: slice.Metrics{RSRP: -95}, ObservedAt: obs}},
+		{err: metrics.ErrNoMetrics},
+	}}
+	c := metrics.NewStaleCache(inner)
+	fresh, err := c.Read(context.Background(), nsWithUID("u1"))
+	if err != nil || !fresh.ObservedAt.Equal(obs) {
+		t.Fatalf("fresh read must carry the source ObservedAt %v, got %v (err=%v)", obs, fresh.ObservedAt, err)
+	}
+	stale, err := c.Read(context.Background(), nsWithUID("u1"))
+	if err != nil {
+		t.Fatalf("stale replay error: %v", err)
+	}
+	if !stale.Stale {
+		t.Fatal("replay must be marked stale")
+	}
+	if !stale.ObservedAt.Equal(obs) {
+		t.Fatalf("a stale replay must preserve the original ObservedAt %v, got %v — else the anti-flap "+
+			"would treat the replay as a new observation (#203-M3)", obs, stale.ObservedAt)
 	}
 }
 


### PR DESCRIPTION
## What

`confirmationSamples` promises that **N distinct** degraded observations are required before failing over, so a single blip is absorbed. But the anti-flap engine counted **reconcile calls**, not distinct observations. This gates the confirmation counter on the source observation's timestamp.

## The bug (#203-M3, deferred by #220/#231)

`EvaluateFailoverWithAntiFlap` incremented `ConsecutiveDegraded` on every reliable-degraded call, with no observation identity. Combined with the controller reconciling every 30s, stale metrics within 90s (`metricsMaxStaleness`) still treated as reliable, and the stale cache replaying the **same** cached value on a source failure, a metrics-source outage replays one degraded observation into a failover:

```
confirmationSamples=3
t=0   fresh degraded observation        -> count 1
t=30  source down, stale cache replays  -> count 2
t=60  same replay                       -> count 3 -> failover
```

So a single blip that `confirmationSamples` is meant to absorb, followed by a source outage, triggers the very failover it was configured to prevent. The Prometheus reader kept `model.Sample.Value` and discarded `model.Sample.Timestamp`, so there was no way to tell a new observation from a replay.

## Fix

Thread the source observation timestamp through the reader chain and gate the confirmation on it:
- `Result.ObservedAt` = `model.Sample.Timestamp` (the freshest of the queried samples).
- `staleCache` preserves `ObservedAt` on a replay, so a replay carries the original timestamp.
- `AntiFlapState.LastCountedObservedAt`; `EvaluateFailoverWithAntiFlap` advances the confirmation/recovery counters **only when `ObservedAt` is newer than the last counted one**. A same-or-older observation holds the current state instead of confirming.

This also covers the subtler case the `Stale` flag cannot see: a **reachable** Prometheus whose scrape target stalled returns the same sample repeatedly as "fresh" — the timestamp still does not advance, so it does not confirm.

A zero `ObservedAt` (a reader that cannot supply a source timestamp) falls back to counting every call, preserving prior behavior. `AntiFlapState` is in-memory, so there is no API/CRD change.

I deliberately did **not** take the finding's alternative of replacing `confirmationSamples` with a `degradedFor` time condition — that is a public CRD API redesign, and the sample-count semantics can be made correct without it.

## Tests

- `TestAntiFlap_ReplayedObservationDoesNotConfirm`: five replays of one observation hold at 1/3 and never fail over; two further distinct observations reach 3/3 and do fail over (a real sustained degradation still works). Mutation-verified by removing the gate (the replays then increment and the hold assertion fails).
- `TestPrometheusReader_ObservedAtFromSampleTimestamp` and `TestStaleCache_ReplayPreservesObservedAt`: the plumbing (reader extracts the timestamp; the cache preserves it on replay).

`golangci-lint` / `gofmt` / `go vet` clean; full controller envtest passes.
