### PR TITLE
fix(failover): reset anti-flap confirmation streak on spec-generation change

### DIFF
--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -112,21 +112,30 @@ type NTNSliceReconciler struct {
 	flapState map[types.NamespacedName]flapStateEntry
 }
 
-// flapStateEntry pairs a slice's anti-flap state with the UID of the object it belongs to. A
-// same-name NTNSlice recreated with a NEW UID must not inherit the deleted object's counters or
-// min-dwell clock. The NotFound and finalizer cleanups usually drop the old entry first, but a
-// force-deletion (finalizer bypassed) whose DELETE the workqueue coalesces with the recreate's
-// CREATE is delivered as a single reconcile of the new object — the controller never observes the
-// intervening NotFound. Keying on UID as well as name closes that gap regardless of the cleanups.
+// flapStateEntry pairs a slice's anti-flap state with the object identity it was accumulated under:
+// the UID and the spec generation. UID guards a same-name recreate — a new UID must not inherit the
+// deleted object's counters or min-dwell clock; the NotFound and finalizer cleanups usually drop the
+// old entry first, but a force-deletion (finalizer bypassed) whose DELETE the workqueue coalesces
+// with the recreate's CREATE arrives as a single reconcile of the new object — the controller never
+// observes the intervening NotFound, so keying on UID closes that gap regardless of the cleanups.
+// generation guards a spec edit: confirmationSamples promises N CONSECUTIVE samples of the CURRENT
+// policy, so a streak accumulated under a prior generation (an old trigger/threshold/N, or a changed
+// metrics source or hysteresis) must not carry across a policy change — loadFlapState resets the
+// confirmation/recovery clocks on a generation change, keeping only the durable min-dwell clock (a
+// real past hand-back, not an evaluation streak).
 type flapStateEntry struct {
-	uid   types.UID
-	state slice.AntiFlapState
+	uid        types.UID
+	generation int64
+	state      slice.AntiFlapState
 }
 
-// loadFlapState returns the anti-flap state for the object identified by (key, uid), or the zero
-// value when no entry exists OR the stored entry belongs to a different object identity (a stale
-// entry left by a same-name predecessor, which is evicted here).
-func (r *NTNSliceReconciler) loadFlapState(key types.NamespacedName, uid types.UID) slice.AntiFlapState {
+// loadFlapState returns the anti-flap state for the object identified by (key, uid, generation), or
+// the zero value when no entry exists OR the stored entry belongs to a different object identity (a
+// stale entry left by a same-name predecessor, which is evicted here). When the entry matches by UID
+// but was accumulated under a different spec generation, the confirmation/recovery streak is reset
+// (it measured a now-superseded policy) while the durable min-dwell clock is kept; the refreshed
+// entry is written back so the reset holds even on a reconcile path that does not store.
+func (r *NTNSliceReconciler) loadFlapState(key types.NamespacedName, uid types.UID, generation int64) slice.AntiFlapState {
 	r.flapMu.Lock()
 	defer r.flapMu.Unlock()
 	entry, ok := r.flapState[key]
@@ -134,17 +143,29 @@ func (r *NTNSliceReconciler) loadFlapState(key types.NamespacedName, uid types.U
 		delete(r.flapState, key)
 		return slice.AntiFlapState{}
 	}
+	if entry.generation != generation {
+		// Spec edit → the streak measured a superseded policy. Clear the confirmation/recovery
+		// clocks (re-confirm under the new policy) and the observation cursor (a changed metrics
+		// source may carry lower timestamps and must not be gated by the old cursor); keep
+		// LastSwitchback — min-dwell describes a real past transition, not an evaluation streak.
+		entry.state.ConsecutiveDegraded = 0
+		entry.state.RecoveryObservedAt = time.Time{}
+		entry.state.LastCountedObservedAt = time.Time{}
+		entry.generation = generation
+		r.flapState[key] = entry
+	}
 	return entry.state
 }
 
-// storeFlapState persists the updated anti-flap state for the object identified by (key, uid).
-func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, uid types.UID, st slice.AntiFlapState) {
+// storeFlapState persists the updated anti-flap state for the object identified by (key, uid,
+// generation).
+func (r *NTNSliceReconciler) storeFlapState(key types.NamespacedName, uid types.UID, generation int64, st slice.AntiFlapState) {
 	r.flapMu.Lock()
 	defer r.flapMu.Unlock()
 	if r.flapState == nil {
 		r.flapState = make(map[types.NamespacedName]flapStateEntry)
 	}
-	r.flapState[key] = flapStateEntry{uid: uid, state: st}
+	r.flapState[key] = flapStateEntry{uid: uid, generation: generation, state: st}
 }
 
 // seedLastSwitchbackFromStatus does a monotonic merge of the durable min-dwell clock into the
@@ -370,6 +391,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	var pendingFlap *slice.AntiFlapState
 	var pendingFlapKey types.NamespacedName
 	var pendingFlapUID types.UID
+	var pendingFlapGeneration int64
 	switch {
 	case !satelliteKnown:
 		// I-13: satellite availability is unknown (transient ephemeris read error).
@@ -414,7 +436,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		flapKey := client.ObjectKeyFromObject(ns)
-		af := r.loadFlapState(flapKey, ns.UID)
+		af := r.loadFlapState(flapKey, ns.UID, ns.Generation)
 		r.seedLastSwitchbackFromStatus(&af, ns, now)
 		var newFlap slice.AntiFlapState
 		result, newFlap = slice.EvaluateFailoverWithAntiFlap(
@@ -431,6 +453,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			af,
 		)
 		pendingFlap, pendingFlapKey, pendingFlapUID = &newFlap, flapKey, ns.UID
+		pendingFlapGeneration = ns.Generation
 		r.persistLastSwitchbackToStatus(ns, newFlap.LastSwitchback, now)
 	default:
 		// Metrics unreliable but satellite availability known: fail static —
@@ -526,7 +549,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// never durably recorded. Under-counting a confirmation/recovery sample on a dropped write
 	// only DELAYS the next transition (fail-safe), matching the anti-flap design.
 	if pendingFlap != nil {
-		r.storeFlapState(pendingFlapKey, pendingFlapUID, *pendingFlap)
+		r.storeFlapState(pendingFlapKey, pendingFlapUID, pendingFlapGeneration, *pendingFlap)
 	}
 
 	// Emit the failover counter only after the status write persisted, so a

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -493,7 +493,7 @@ var _ = Describe("NTNSlice Controller", func() {
 			// (reset on re-degradation), not absolute time since failover. Seed the
 			// in-memory recovery clock so terrestrial has been recovered longer than
 			// the 60s delay — the precondition this test asserts.
-			reconciler.storeFlapState(typeNamespacedName, ntnSlice.UID, slice.AntiFlapState{
+			reconciler.storeFlapState(typeNamespacedName, ntnSlice.UID, ntnSlice.Generation, slice.AntiFlapState{
 				RecoveryObservedAt: time.Date(2026, 4, 17, 11, 55, 0, 0, time.UTC),
 			})
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{

--- a/internal/controller/ntnslice_generation_reset_test.go
+++ b/internal/controller/ntnslice_generation_reset_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/slice"
+	slicemetrics "github.com/thc1006/ntn-operators/pkg/slice/metrics"
+)
+
+// TestLoadFlapState_GenerationChange_ResetsStreakKeepsDwell pins the spec-generation finding
+// (#203-M2): confirmationSamples promises N CONSECUTIVE samples of the CURRENT policy, so a streak
+// accumulated under a prior spec generation (an old trigger/threshold/N, or a changed metrics source
+// or hysteresis) must NOT carry across an edit. loadFlapState resets the confirmation/recovery/
+// observation clocks when the generation differs, keeping only the durable min-dwell clock (a real
+// past hand-back, not an evaluation streak). Mutation: drop the `entry.generation != generation`
+// branch in loadFlapState → the streak survives the edit and the ConsecutiveDegraded assertion fails.
+func TestLoadFlapState_GenerationChange_ResetsStreakKeepsDwell(t *testing.T) {
+	r := &NTNSliceReconciler{}
+	key := types.NamespacedName{Name: "s", Namespace: "default"}
+	const uid = types.UID("slice-uid-1")
+	dwell := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	obs := dwell.Add(-30 * time.Second)
+
+	// A streak accumulated under generation 1: 2/3 confirmations, a recovery/observation cursor, and a
+	// real past hand-back (the durable dwell clock).
+	r.storeFlapState(key, uid, 1, slice.AntiFlapState{
+		ConsecutiveDegraded:   2,
+		RecoveryObservedAt:    obs,
+		LastCountedObservedAt: obs,
+		LastSwitchback:        dwell,
+	})
+
+	// Same generation → the streak is intact (a steady-state reconcile must not reset).
+	if st := r.loadFlapState(key, uid, 1); st.ConsecutiveDegraded != 2 {
+		t.Fatalf("same generation must preserve the streak, got ConsecutiveDegraded=%d", st.ConsecutiveDegraded)
+	}
+
+	// Generation 2 (a spec edit) → the confirmation/recovery/observation clocks reset, dwell preserved.
+	st := r.loadFlapState(key, uid, 2)
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("generation change must reset ConsecutiveDegraded, got %d", st.ConsecutiveDegraded)
+	}
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("generation change must reset RecoveryObservedAt, got %v", st.RecoveryObservedAt)
+	}
+	if !st.LastCountedObservedAt.IsZero() {
+		t.Errorf("generation change must reset the observation cursor, got %v", st.LastCountedObservedAt)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("generation change must KEEP the durable min-dwell clock, got %v want %v", st.LastSwitchback, dwell)
+	}
+
+	// The reset was written back (loadFlapState persists it), so the entry now records generation 2: a
+	// fresh streak accumulates from 0 without a spurious re-reset clobbering it.
+	r.storeFlapState(key, uid, 2, slice.AntiFlapState{ConsecutiveDegraded: 1, LastSwitchback: dwell})
+	if got := r.loadFlapState(key, uid, 2); got.ConsecutiveDegraded != 1 || !got.LastSwitchback.Equal(dwell) {
+		t.Errorf("post-edit generation must accumulate a fresh streak, got ConsecutiveDegraded=%d dwell=%v",
+			got.ConsecutiveDegraded, got.LastSwitchback)
+	}
+}
+
+// TestReconcile_StatusConflict_DoesNotAdvanceConfirmation pins the status-conflict gate: the
+// confirmation counter lives in shared memory and is committed (storeFlapState) only AFTER the status
+// write persists, so a conflicting/retried reconcile must not advance it — otherwise a metrics-source
+// blip during a status conflict could be counted more than once and reach the failover threshold on a
+// retry. Here a degraded sample would drive the seeded 1/2 streak to a failover, but the status write
+// is forced to CONFLICT; the in-memory streak must therefore remain exactly 1 (nothing committed).
+// Mutation: move storeFlapState before persistStatusIfChanged (the pre-fix order) → the failed write
+// still leaves an advanced/reset counter in memory and the "== 1" assertion fails.
+func TestReconcile_StatusConflict_DoesNotAdvanceConfirmation(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+		Status: ntnv1alpha1.SatelliteEphemerisStatus{
+			NextPassWindows: []ntnv1alpha1.PassWindow{{
+				Satellite: "ONEWEB-0012", GroundStation: "gs",
+				AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+				LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+			}},
+		},
+	}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue, Reason: "Predicted",
+	})
+	confirm := 2
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", UID: "slice-uid-1", Generation: 1},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:            []string{"rsrp < -120"},
+				SwitchbackDelay:     metav1.Duration{Duration: 60 * time.Second},
+				ConfirmationSamples: &confirm,
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathTerrestrial)},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, sub string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if _, ok := obj.(*ntnv1alpha1.NTNSlice); ok { // the failover's status write always conflicts
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "ntn.operators.dev", Resource: "ntnslices"},
+						obj.GetName(), fmt.Errorf("forced conflict"))
+				}
+				return c.SubResource(sub).Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }}
+	key := client.ObjectKeyFromObject(nsObj)
+	// Seed 1/2 confirmations under the object's identity (uid+generation), with the observation cursor
+	// clear so the fresh degraded sample below advances the streak.
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{ConsecutiveDegraded: 1})
+	// A reliable, degraded observation (rsrp -125 < -120) with a fresh source timestamp: the 2nd
+	// confirmation drives a failover, whose status write the interceptor conflicts.
+	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -125, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       false,
+		LastFreshAt: fixedNow,
+		ObservedAt:  fixedNow,
+	}}}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err == nil {
+		t.Fatal("expected the forced status conflict to surface as a reconcile error")
+	}
+
+	// The conflict aborted before storeFlapState, so the confirmation counter is unchanged: a retry
+	// re-evaluates from 1/2, it is NOT double-counted to 2/2 (or reset) by the dropped write.
+	if st := r.loadFlapState(key, nsObj.UID, nsObj.Generation); st.ConsecutiveDegraded != 1 {
+		t.Fatalf("a conflicted status write must not advance the in-memory confirmation counter, "+
+			"got ConsecutiveDegraded=%d, want 1", st.ConsecutiveDegraded)
+	}
+}

--- a/internal/controller/ntnslice_lastswitchback_persist_test.go
+++ b/internal/controller/ntnslice_lastswitchback_persist_test.go
@@ -96,7 +96,7 @@ func TestReconcile_FailedSwitchbackThenPassEnded_NoGhostDwell(t *testing.T) {
 	r := &NTNSliceReconciler{Client: cli, Scheme: sch, Now: func() time.Time { return fixedNow }}
 	key := client.ObjectKeyFromObject(nsObj)
 	// Terrestrial healthy long enough to switch back; satellite pass currently ACTIVE.
-	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", 0, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
 	}}}
@@ -212,7 +212,7 @@ func TestReconcile_Switchback_PersistsLastSwitchbackTime(t *testing.T) {
 	r, key := baseSliceForDwell(t, fixedNow, ntnv1alpha1.NTNSliceStatus{
 		ActivePathType: string(slice.PathSatellite),
 	})
-	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", 0, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	// Terrestrial HEALTHY (rsrp -80 does not fire), reliable; satellite available.
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
@@ -248,7 +248,7 @@ func TestReconcile_SelfHealsDurableLastSwitchback(t *testing.T) {
 		ActivePathType: string(slice.PathTerrestrial),
 	})
 	memClock := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, "", slice.AntiFlapState{LastSwitchback: memClock})
+	r.storeFlapState(key, "", 0, slice.AntiFlapState{LastSwitchback: memClock})
 	// Terrestrial DEGRADED (would fail over if dwell were satisfied), satellite available.
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
@@ -284,7 +284,7 @@ func TestReconcile_MonotonicSeed_KeepsNewerMemory(t *testing.T) {
 		ActivePathType:     string(slice.PathTerrestrial),
 		LastSwitchbackTime: &metav1.Time{Time: oldStatus},
 	})
-	r.storeFlapState(key, "", slice.AntiFlapState{LastSwitchback: memClock})
+	r.storeFlapState(key, "", 0, slice.AntiFlapState{LastSwitchback: memClock})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -110, LatencyMs: 10, PacketLossPercent: 0},
 		Stale:   false, LastFreshAt: fixedNow,
@@ -319,7 +319,7 @@ func TestReconcile_FutureDurableTimestampHealedBySwitchback(t *testing.T) {
 		ActivePathType:     string(slice.PathSatellite),
 		LastSwitchbackTime: &metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
 	})
-	r.storeFlapState(key, "", slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
+	r.storeFlapState(key, "", 0, slice.AntiFlapState{RecoveryObservedAt: fixedNow.Add(-90 * time.Second)})
 	r.ReaderProvider = fakeReaderProvider{reader: fakeReader{res: slicemetrics.Result{
 		Metrics: slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0}, Stale: false, LastFreshAt: fixedNow,
 	}}}
@@ -437,7 +437,7 @@ func TestReconcile_StaleFlapStateForDifferentUID_IsNotInherited(t *testing.T) {
 	// Leftover state stored under a DIFFERENT (deleted predecessor's) UID, with a recent switchback
 	// that would block failover (15s < 60s dwell) if it were wrongly inherited. The reconciled
 	// object built by baseSliceForDwell has a different UID (empty), so this must be evicted.
-	r.storeFlapState(key, "uid-of-deleted-predecessor", slice.AntiFlapState{
+	r.storeFlapState(key, "uid-of-deleted-predecessor", 0, slice.AntiFlapState{
 		LastSwitchback: fixedNow.Add(-15 * time.Second),
 	})
 

--- a/internal/controller/ntnslice_three_state_test.go
+++ b/internal/controller/ntnslice_three_state_test.go
@@ -88,7 +88,7 @@ func TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown(t *test
 	// Seed a recovery/confirmation streak AND a dwell clock from an earlier (reliable)
 	// window, to prove the unreliable reconcile clears the former but keeps the latter.
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -109,7 +109,7 @@ func TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown(t *test
 	}
 
 	// H2: recovery + confirmation cleared, dwell preserved.
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset on unreliable metrics (H2), got %v", st.RecoveryObservedAt)
 	}


### PR DESCRIPTION
## What

`confirmationSamples` promises **N consecutive** degraded samples of the **current** policy before failing over. But the in-memory `flapStateEntry` was keyed only on `(name, UID)`. A spec edit bumps `metadata.generation` without changing the UID, so `loadFlapState` kept serving the streak accumulated under the **previous** policy. This resets the confirmation/recovery streak when the generation changes.

## The bug (#203-M2, deferred by #220/#231)

A degradation that is mid-accumulation when the operator edits the spec mixes two policies into one "consecutive" count:

```
trigger rsrp<-120, ConsecutiveDegraded = 2/3
user edits spec -> trigger latency>500
next reconcile, latency degraded -> count 3/3 -> failover
```

Three "consecutive samples" that no single policy ever observed. The same crossing affects a changed threshold/operator, hysteresis margin, metrics source, `switchbackDelay`, or lowering `N` — any spec change. It is most reachable exactly when an operator is tuning thresholds or a GitOps push lands a policy change during a degradation. The consequence is a single premature failover to satellite; self-correcting via min-dwell/switchback, but it violates the feature's core contract and is silent (the failover looks legitimate — the counter reached `N`).

`#220`/`#231` explicitly listed "reset on generation change (#203-M2)" as deferred; no generation tracking existed until now.

## Fix

Add `generation` to `flapStateEntry`. `loadFlapState` resets the confirmation/recovery clocks and the observation cursor when the generation differs, and keeps **only** the durable min-dwell clock:

- `ConsecutiveDegraded`, `RecoveryObservedAt` → cleared (re-confirm/re-recover under the new policy);
- `LastCountedObservedAt` (from #288) → cleared, because a changed metrics source may carry lower timestamps and must not be gated by the old cursor;
- `LastSwitchback` → **kept**; min-dwell describes a real past hand-back, not an evaluation streak, and a policy edit does not un-happen it. It is also the durable axis (mirrored to `status.lastSwitchbackTime`).

The reset is written back so it holds even on a reconcile path that does not store. Resetting only **delays** the next switch (fail-safe), so over-resetting on an unrelated spec edit is harmless. `AntiFlapState` is in-memory, so there is **no API/CRD change**.

I chose `metadata.generation` over a policy fingerprint deliberately: generation bumps on any spec change (status writes do not bump it, so steady-state reconciles never reset), it needs no field enumeration, and a future failover-relevant field is covered automatically — a fingerprint would silently miss it, which is the exact bug class being fixed.

## Tests

- `TestLoadFlapState_GenerationChange_ResetsStreakKeepsDwell`: a generation change clears the streak/recovery/observation clocks and keeps the dwell clock; a fresh streak then accumulates from 0. Mutation-verified by dropping the generation-diff branch (the streak survives the edit and the assertion fails).
- `TestReconcile_StatusConflict_DoesNotAdvanceConfirmation`: pins the status-conflict gate — the counter is committed (`storeFlapState`) only **after** the status write persists, so a conflicted/retried reconcile does not advance or double-count it. Mutation-verified by committing memory before the write (the conflicted write then leaves an advanced counter).

`golangci-lint` / `gofmt` / `go vet` clean; full controller envtest + `pkg/slice` pass.

## Coverage note (anti-flap merge gates)

This closes the last two open gates in the anti-flap suite. For the record, the others are already covered: stale-replay/observation-token by #288 (`TestAntiFlap_ReplayedObservationDoesNotConfirm`), durable dwell across restart/handoff by #231/#259, dead-band-not-counted by H3 (`TestAntiFlap_DeadBandDoesNotConsumeSwitchbackDelay`), `PathUnavailable`→terrestrial-no-dwell by M1 (`TestAntiFlap_InitToTerrestrial_DoesNotStartDwell`), and same-name-different-UID by #273 (`TestReconcile_StaleFlapStateForDifferentUID_IsNotInherited`).
