### PR TITLE
fix(api): bound failoverPolicy durations at admission; ConfirmationSamples *int32

### DIFF
--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -194,9 +194,12 @@ type FailoverPolicy struct {
 	Triggers []string `json:"triggers"`
 
 	// switchbackDelay is how long to wait after terrestrial recovers
-	// before switching back (prevents flapping).
+	// before switching back (prevents flapping). A negative value is meaningless
+	// here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+	// above any LEO-pass-relative value).
 	// +kubebuilder:default="60s"
 	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s') && duration(self) <= duration('24h')",message="switchbackDelay must be a non-negative duration no greater than 24h"
 	SwitchbackDelay metav1.Duration `json:"switchbackDelay,omitempty"`
 
 	// sessionContinuity preserves active sessions during failover.
@@ -227,15 +230,18 @@ type FailoverPolicy struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=10
 	// +optional
-	ConfirmationSamples *int `json:"confirmationSamples,omitempty"`
+	ConfirmationSamples *int32 `json:"confirmationSamples,omitempty"`
 
 	// minTerrestrialDwell is the minimum time the terrestrial path must be held
 	// after a switchback before another failover to satellite may be taken. It
 	// bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
 	// — a genuinely failing terrestrial still fails over once the dwell elapses,
 	// so it never indefinitely blocks a real failover. 0 (the default) disables
-	// it; 30s–120s is a sane range relative to a LEO pass.
+	// it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+	// silently disable the dwell (elapsed < negative is never true), so admission
+	// bounds it to [0s, 24h].
 	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s') && duration(self) <= duration('24h')",message="minTerrestrialDwell must be a non-negative duration no greater than 24h"
 	// +optional
 	MinTerrestrialDwell metav1.Duration `json:"minTerrestrialDwell,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -168,7 +168,7 @@ func (in *FailoverPolicy) DeepCopyInto(out *FailoverPolicy) {
 	out.SwitchbackDelay = in.SwitchbackDelay
 	if in.ConfirmationSamples != nil {
 		in, out := &in.ConfirmationSamples, &out.ConfirmationSamples
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	out.MinTerrestrialDwell = in.MinTerrestrialDwell

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -98,6 +98,7 @@ spec:
                       resets on any healthy reliable sample; losing it on a controller restart or
                       leader-election handoff only re-requires confirmation (a DELAY), never causes
                       a spurious switch.
+                    format: int32
                     maximum: 10
                     minimum: 1
                     type: integer
@@ -119,9 +120,16 @@ spec:
                       bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
                       — a genuinely failing terrestrial still fails over once the dwell elapses,
                       so it never indefinitely blocks a real failover. 0 (the default) disables
-                      it; 30s–120s is a sane range relative to a LEO pass.
+                      it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+                      silently disable the dwell (elapsed < negative is never true), so admission
+                      bounds it to [0s, 24h].
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: minTerrestrialDwell must be a non-negative duration
+                        no greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   sessionContinuity:
                     default: true
                     description: sessionContinuity preserves active sessions during
@@ -131,9 +139,16 @@ spec:
                     default: 60s
                     description: |-
                       switchbackDelay is how long to wait after terrestrial recovers
-                      before switching back (prevents flapping).
+                      before switching back (prevents flapping). A negative value is meaningless
+                      here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+                      above any LEO-pass-relative value).
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: switchbackDelay must be a non-negative duration no
+                        greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   triggers:
                     description: |-
                       triggers defines conditions that initiate failover (OR logic).

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -98,6 +98,7 @@ spec:
                       resets on any healthy reliable sample; losing it on a controller restart or
                       leader-election handoff only re-requires confirmation (a DELAY), never causes
                       a spurious switch.
+                    format: int32
                     maximum: 10
                     minimum: 1
                     type: integer
@@ -119,9 +120,16 @@ spec:
                       bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
                       — a genuinely failing terrestrial still fails over once the dwell elapses,
                       so it never indefinitely blocks a real failover. 0 (the default) disables
-                      it; 30s–120s is a sane range relative to a LEO pass.
+                      it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+                      silently disable the dwell (elapsed < negative is never true), so admission
+                      bounds it to [0s, 24h].
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: minTerrestrialDwell must be a non-negative duration
+                        no greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   sessionContinuity:
                     default: true
                     description: sessionContinuity preserves active sessions during
@@ -131,9 +139,16 @@ spec:
                     default: 60s
                     description: |-
                       switchbackDelay is how long to wait after terrestrial recovers
-                      before switching back (prevents flapping).
+                      before switching back (prevents flapping). A negative value is meaningless
+                      here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+                      above any LEO-pass-relative value).
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: switchbackDelay must be a non-negative duration no
+                        greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   triggers:
                     description: |-
                       triggers defines conditions that initiate failover (OR logic).

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -101,6 +101,7 @@ spec:
                       resets on any healthy reliable sample; losing it on a controller restart or
                       leader-election handoff only re-requires confirmation (a DELAY), never causes
                       a spurious switch.
+                    format: int32
                     maximum: 10
                     minimum: 1
                     type: integer
@@ -122,9 +123,16 @@ spec:
                       bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
                       — a genuinely failing terrestrial still fails over once the dwell elapses,
                       so it never indefinitely blocks a real failover. 0 (the default) disables
-                      it; 30s–120s is a sane range relative to a LEO pass.
+                      it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+                      silently disable the dwell (elapsed < negative is never true), so admission
+                      bounds it to [0s, 24h].
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: minTerrestrialDwell must be a non-negative duration
+                        no greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   sessionContinuity:
                     default: true
                     description: sessionContinuity preserves active sessions during
@@ -134,9 +142,16 @@ spec:
                     default: 60s
                     description: |-
                       switchbackDelay is how long to wait after terrestrial recovers
-                      before switching back (prevents flapping).
+                      before switching back (prevents flapping). A negative value is meaningless
+                      here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+                      above any LEO-pass-relative value).
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: switchbackDelay must be a non-negative duration no
+                        greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   triggers:
                     description: |-
                       triggers defines conditions that initiate failover (OR logic).

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -410,7 +410,7 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			MinTerrestrialDwell: ns.Spec.FailoverPolicy.MinTerrestrialDwell.Duration,
 		}
 		if ns.Spec.FailoverPolicy.ConfirmationSamples != nil {
-			afCfg.ConfirmationSamples = *ns.Spec.FailoverPolicy.ConfirmationSamples
+			afCfg.ConfirmationSamples = int(*ns.Spec.FailoverPolicy.ConfirmationSamples)
 		}
 
 		flapKey := client.ObjectKeyFromObject(ns)

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -419,7 +419,7 @@ var _ = Describe("NTNSlice Controller", func() {
 		AfterEach(func() { deleteSlice() })
 
 		It("holds terrestrial until N consecutive degraded samples confirm", func() {
-			confirmN := 2
+			confirmN := int32(2)
 			spec := baseSpec()
 			spec.FailoverPolicy.ConfirmationSamples = &confirmN
 			ntnSlice := &ntnv1alpha1.NTNSlice{

--- a/internal/controller/ntnslice_dwell_admission_test.go
+++ b/internal/controller/ntnslice_dwell_admission_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// These run against the envtest API server, so they exercise the CRD's REAL CEL
+// x-kubernetes-validations for the failoverPolicy duration bounds — not a Go-side copy.
+// A negative minTerrestrialDwell would silently disable the dwell (elapsed < negative is
+// never true) and a negative switchbackDelay is equally meaningless; both are bounded to
+// [0s, 24h] at admission so the footgun cannot reach the runtime.
+var _ = Describe("NTNSlice failoverPolicy duration admission (CEL)", func() {
+	n := 0
+	// mkSlice builds an otherwise-valid slice (valid trigger, so the trigger CEL passes) with the
+	// given dwell and switchback durations, so a rejection can only come from the duration rules.
+	mkSlice := func(dwell, switchback metav1.Duration) *ntnv1alpha1.NTNSlice {
+		n++
+		return &ntnv1alpha1.NTNSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("adm-dwell-%d", n), Namespace: "default"},
+			Spec: ntnv1alpha1.NTNSliceSpec{
+				Tenant: "acme-corp",
+				TerrestrialPath: ntnv1alpha1.PathSpec{
+					Provider: "chunghwa-telecom", APN: "internet", Priority: "primary",
+				},
+				SatellitePath: ntnv1alpha1.SatellitePathSpec{
+					PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+					EphemerisRef: "oneweb-constellation",
+				},
+				FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+					Triggers:            []string{"rsrp < -120"},
+					SwitchbackDelay:     switchback,
+					MinTerrestrialDwell: dwell,
+				},
+			},
+		}
+	}
+
+	// assertAdmission creates s and checks it is accepted, or rejected by an Invalid admission error
+	// that names the offending field (so a reject cannot false-green on an unrelated validation error).
+	assertAdmission := func(s *ntnv1alpha1.NTNSlice, accepted bool, field string) {
+		err := k8sClient.Create(ctx, s)
+		if accepted {
+			Expect(err).NotTo(HaveOccurred(), "%s should be admitted", field)
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, s) })
+			return
+		}
+		Expect(err).To(HaveOccurred(), "%s must be rejected by CEL admission", field)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "want an Invalid admission error, got %v", err)
+		Expect(err.Error()).To(ContainSubstring(field), "the rejection must reference %s, got %v", field, err)
+	}
+
+	sec := func(d time.Duration) metav1.Duration { return metav1.Duration{Duration: d} }
+
+	DescribeTable("bounds minTerrestrialDwell to [0s, 24h] at admission",
+		func(dwell metav1.Duration, accepted bool) {
+			assertAdmission(mkSlice(dwell, sec(60*time.Second)), accepted, "minTerrestrialDwell")
+		},
+		Entry("zero disables the dwell", sec(0), true),
+		Entry("a normal 90s dwell", sec(90*time.Second), true),
+		Entry("the 24h ceiling itself", sec(24*time.Hour), true),
+		Entry("a negative dwell (would silently disable it)", sec(-90*time.Second), false),
+		Entry("above the 24h fat-finger ceiling", sec(48*time.Hour), false),
+	)
+
+	DescribeTable("bounds switchbackDelay to [0s, 24h] at admission",
+		func(switchback metav1.Duration, accepted bool) {
+			assertAdmission(mkSlice(sec(0), switchback), accepted, "switchbackDelay")
+		},
+		Entry("a normal 60s delay", sec(60*time.Second), true),
+		Entry("zero is allowed", sec(0), true),
+		Entry("a negative delay", sec(-5*time.Second), false),
+		Entry("above the 24h fat-finger ceiling", sec(48*time.Hour), false),
+	)
+})

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -98,6 +98,7 @@ spec:
                       resets on any healthy reliable sample; losing it on a controller restart or
                       leader-election handoff only re-requires confirmation (a DELAY), never causes
                       a spurious switch.
+                    format: int32
                     maximum: 10
                     minimum: 1
                     type: integer
@@ -119,9 +120,16 @@ spec:
                       bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
                       — a genuinely failing terrestrial still fails over once the dwell elapses,
                       so it never indefinitely blocks a real failover. 0 (the default) disables
-                      it; 30s–120s is a sane range relative to a LEO pass.
+                      it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+                      silently disable the dwell (elapsed < negative is never true), so admission
+                      bounds it to [0s, 24h].
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: minTerrestrialDwell must be a non-negative duration
+                        no greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   sessionContinuity:
                     default: true
                     description: sessionContinuity preserves active sessions during
@@ -131,9 +139,16 @@ spec:
                     default: 60s
                     description: |-
                       switchbackDelay is how long to wait after terrestrial recovers
-                      before switching back (prevents flapping).
+                      before switching back (prevents flapping). A negative value is meaningless
+                      here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+                      above any LEO-pass-relative value).
                     format: duration
                     type: string
+                    x-kubernetes-validations:
+                    - message: switchbackDelay must be a non-negative duration no
+                        greater than 24h
+                      rule: duration(self) >= duration('0s') && duration(self) <=
+                        duration('24h')
                   triggers:
                     description: |-
                       triggers defines conditions that initiate failover (OR logic).


### PR DESCRIPTION
## What

Two related `failoverPolicy` schema gaps the review raised: the duration fields had no value bound (a negative silently disables the feature), and `confirmationSamples` was `*int` rather than the Kubernetes `*int32` convention.

## Duration bounds (the correctness fix)

`minTerrestrialDwell` and `switchbackDelay` were typed only `Format=duration`, with no bound. `metav1.Duration` parses negatives, and a negative `minTerrestrialDwell` **silently disables** the dwell — the runtime guard `now.Sub(LastSwitchback) < dwell` is never true for a negative dwell, so a fat-fingered `-90s` turns off the anti-flap min-dwell with no error. A negative `switchbackDelay` is equally meaningless, and an absurd value (`1000h`) would pin terrestrial for weeks. The doc advertised "30s–120s is a sane range" but nothing enforced even non-negativity.

Add a CEL `x-kubernetes-validations` rule to both fields bounding them to `[0s, 24h]`:
- `0s` stays valid — it is the documented "disabled" value;
- negatives are rejected;
- `24h` is a fat-finger ceiling, far above any LEO-pass-relative value (a pass is ~10 min).

This mirrors how #231 tightened the `failoverPolicy` trigger admission — bound the value at the API, not only at runtime. Regenerated into all four CRD copies (`config/crd`, `dist/chart`, `bundle/manifests`, `nephio`).

## `confirmationSamples` `*int` → `*int32` (convention cleanup, #203-Low)

Deferred by #220. The value is bounded 1–10 so it never overflowed either width — this is a clarity/convention change, not a correctness one: `*int32` is the Kubernetes API idiom and is cross-arch-deterministic. Ripples: the controller derefs with an `int()` cast, deepcopy regenerated, the CRD schema gains `format: int32`.

## Test

`TestControllers` → "failoverPolicy duration admission (CEL)" runs against the **envtest API server with the real regenerated CRD**: a negative or `>24h` `minTerrestrialDwell`/`switchbackDelay` is rejected as `Invalid` with the field named, while `0s` / normal / `24h` are admitted. This is the **first duration CEL rule** in the API, so the envtest proves the apiserver actually enforces it — not just that controller-gen accepted the marker. The rejection entries can only pass if the apiserver rejects with the field-named message (the slice carries a valid trigger, ruling out an unrelated rejection), and `--fail-on-empty` confirms the specs ran.

`golangci-lint` / `gofmt` / `go vet` clean; full controller envtest + `pkg/slice` pass; `make generate manifests bundle nephio-sync` is idempotent (no uncommitted drift).

## Note

Independent of #289 (anti-flap generation reset) — they touch disjoint regions of the controller; `git merge-tree` reports a clean merge in either order.
