### PR TITLE
test(failover): lock both telemetry-gap streak resets independently

### DIFF
--- a/internal/controller/ntnslice_satread_test.go
+++ b/internal/controller/ntnslice_satread_test.go
@@ -122,6 +122,171 @@ func TestReconcile_TransientEphemerisReadError_HoldsSatellite(t *testing.T) {
 	}
 }
 
+// TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell is the symmetric partner of
+// TestReconcile_MetricsUnreliable_ResetsStreakAndTriggersReadyUnknown (three_state_test): a
+// telemetry gap on the OTHER axis — satellite availability UNKNOWN via a transient
+// SatelliteEphemeris read error — must also break the continuous confirmation/recovery streaks
+// (H2), so samples straddling the gap are not treated as consecutive, while the wall-clock
+// min-dwell is preserved. Metrics are FRESH here, so only the unknown-satellite branch (the
+// !satelliteKnown case, checked before qualityReliable) can drive the reset — isolating it from
+// the metrics-unreliable reset the sibling test covers.
+func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+
+	// Transient (non-NotFound) SatelliteEphemeris read → availability UNKNOWN (line-389 branch).
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*ntnv1alpha1.SatelliteEphemeris); ok {
+					return apierrors.NewInternalError(errors.New("simulated transient apiserver read error"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	// FRESH, healthy metrics → qualityReliable is true, so ONLY the unknown-satellite axis drives
+	// the reset.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -80, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       false,
+		LastFreshAt: fixedNow,
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	// Seed a confirmation + recovery streak AND a dwell clock from an earlier reliable window.
+	dwell := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
+		ConsecutiveDegraded: 2,
+		LastSwitchback:      dwell,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	st := r.loadFlapState(key, nsObj.UID)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("recovery clock must reset when satellite availability is unknown (H2), got %v", st.RecoveryObservedAt)
+	}
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("confirmation streak must reset when satellite availability is unknown (H2), got %d", st.ConsecutiveDegraded)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("the wall-clock min-dwell must be PRESERVED across the gap, got %v want %v", st.LastSwitchback, dwell)
+	}
+}
+
+// TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell isolates the OTHER
+// telemetry-gap reset branch — metrics UNRELIABLE while satellite availability is KNOWN (the
+// default/fail-static case). The sibling MetricsUnreliable test in three_state_test happens to
+// leave PassesPredicted unset, so its satellite is ALSO unknown and its reset comes from the
+// !satelliteKnown branch; this test sets PassesPredicted=True so !satelliteKnown is false and the
+// reset can ONLY come from the metrics-unreliable branch. The confirmation/recovery streaks must
+// reset (H2) and the wall-clock min-dwell must be preserved.
+func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	sch := makeScheme(t)
+
+	eph := &ntnv1alpha1.SatelliteEphemeris{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneweb-constellation", Namespace: "default"},
+	}
+	nsObj := &ntnv1alpha1.NTNSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: ntnv1alpha1.NTNSliceSpec{
+			Tenant:          "acme-corp",
+			TerrestrialPath: ntnv1alpha1.PathSpec{Provider: "chunghwa-telecom", APN: "internet", Priority: "primary"},
+			SatellitePath: ntnv1alpha1.SatellitePathSpec{
+				PathSpec:     ntnv1alpha1.PathSpec{Provider: "oneweb", Priority: "failover"},
+				EphemerisRef: "oneweb-constellation",
+			},
+			FailoverPolicy: ntnv1alpha1.FailoverPolicy{
+				Triggers:        []string{"rsrp < -100"},
+				SwitchbackDelay: metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		Status: ntnv1alpha1.NTNSliceStatus{ActivePathType: string(slice.PathSatellite)},
+	}
+	cli := fake.NewClientBuilder().WithScheme(sch).
+		WithObjects(nsObj, eph).WithStatusSubresource(nsObj, eph).Build()
+
+	// Satellite KNOWN: an active pass window AND PassesPredicted=True (so !satelliteKnown is false).
+	eph.Status.NextPassWindows = []ntnv1alpha1.PassWindow{{
+		Satellite: "ONEWEB-0012", GroundStation: "gs",
+		AOS: metav1.Time{Time: fixedNow.Add(-1 * time.Hour)},
+		LOS: metav1.Time{Time: fixedNow.Add(1 * time.Hour)},
+	}}
+	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
+		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue,
+		Reason: "Predicted", Message: "windows current",
+	})
+	if err := cli.Status().Update(context.Background(), eph); err != nil {
+		t.Fatalf("seed ephemeris pass window: %v", err)
+	}
+
+	// Metrics stale BEYOND the 90s bound → unreliable → the default (fail-static) branch runs.
+	fr := fakeReader{res: slicemetrics.Result{
+		Metrics:     slice.Metrics{RSRP: -90, LatencyMs: 10, PacketLossPercent: 0},
+		Stale:       true,
+		LastFreshAt: fixedNow.Add(-100 * time.Second),
+	}}
+	r := &NTNSliceReconciler{
+		Client: cli, Scheme: sch,
+		Now:            func() time.Time { return fixedNow },
+		ReaderProvider: fakeReaderProvider{reader: fr},
+	}
+
+	key := client.ObjectKeyFromObject(nsObj)
+	dwell := fixedNow.Add(-30 * time.Second)
+	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
+		ConsecutiveDegraded: 2,
+		LastSwitchback:      dwell,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	st := r.loadFlapState(key, nsObj.UID)
+	if !st.RecoveryObservedAt.IsZero() {
+		t.Errorf("recovery clock must reset on unreliable metrics with a known satellite (H2), got %v", st.RecoveryObservedAt)
+	}
+	if st.ConsecutiveDegraded != 0 {
+		t.Errorf("confirmation streak must reset on unreliable metrics with a known satellite (H2), got %d", st.ConsecutiveDegraded)
+	}
+	if !st.LastSwitchback.Equal(dwell) {
+		t.Errorf("the wall-clock min-dwell must be PRESERVED, got %v want %v", st.LastSwitchback, dwell)
+	}
+}
+
 // TestReconcile_InertTrigger_SurfacesTriggersReadyFalse pins I-10 end to end:
 // a trigger over a metric with no configured source (LatencyMissing) is inert;
 // the reconcile must surface TriggersReady=False/InertTriggers rather than let the


### PR DESCRIPTION
## What

Two controller tests that independently lock the anti-flap streak reset on **both** telemetry-gap axes (finding #4 coverage), salvaged from my superseded #287 after #288 landed the observation-identity fix without them.

## Why

`resetRecoveryStreak` (from #220) breaks the confirmation/recovery streak — keeping the wall-clock min-dwell — on two gap axes:
1. **satellite availability unknown** (`!satelliteKnown`, checked first), and
2. **metrics unreliable** (fail-static).

**Mutation testing revealed only axis 1 was tested.** The existing `TestReconcile_MetricsUnreliable_ResetsStreak…` leaves `PassesPredicted` unset, so its satellite is *also* unknown and it actually resets via the `!satelliteKnown` branch. Removing the **metrics-unreliable** reset left the whole suite green — that branch was uncovered.

## The two tests (both mutation-verified)

- `TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell` — fresh metrics + a transient `SatelliteEphemeris` read error (`interceptor`) → isolates the `!satelliteKnown` reset.
- `TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell` — `PassesPredicted=True` + stale-beyond-90s metrics → isolates the fail-static reset.

Each asserts the streak (`ConsecutiveDegraded`, `RecoveryObservedAt`) resets while the wall-clock `LastSwitchback` (min-dwell) is preserved. Verified to fail **only** when its own reset is removed; the other stays green.

**Test-only**, no behavior change — locks already-shipped #220 semantics. `internal/controller` green, `golangci-lint` 0 issues.