### PR TITLE
fix(test): int32 confirmationSamples in generation-reset test (merge skew #289/#291)

### DIFF
--- a/internal/controller/ntnslice_generation_reset_test.go
+++ b/internal/controller/ntnslice_generation_reset_test.go
@@ -107,7 +107,7 @@ func TestReconcile_StatusConflict_DoesNotAdvanceConfirmation(t *testing.T) {
 	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type: ntnv1alpha1.ConditionPassesPredicted, Status: metav1.ConditionTrue, Reason: "Predicted",
 	})
-	confirm := 2
+	confirm := int32(2)
 	nsObj := &ntnv1alpha1.NTNSlice{
 		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", UID: "slice-uid-1", Generation: 1},
 		Spec: ntnv1alpha1.NTNSliceSpec{


### PR DESCRIPTION
Merge-skew hotfix. #289 (generation-reset) seeded `ConfirmationSamples` with `confirm := 2` (`*int`); #291 changed the field to `*int32`. Each PR was green against its own base, but neither base had the other change, so **merged main does not compile**:

```
ntnslice_generation_reset_test.go:123: cannot use &confirm (*int) as *int32
```

A textual merge cannot catch this — the two edits are in different files with no overlap. Caught by building the actual merged HEAD after both merged (the merged-main verification step). `int32(2)` restores compilation; the test is otherwise unchanged.

Verified on merged main: build / vet / full controller envtest / gofmt / golangci-lint all green.