### PR TITLE
perf(ci): build the chart-test image from the host Go cache

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -83,9 +83,30 @@ jobs:
       - name: Create Kind cluster
         run: kind create cluster
 
-      - name: Build and load image
+      # Build the manager on the host so the compile reuses setup-go's persistent build cache
+      # (~/.cache/go-build, keyed on go.sum and shared across jobs) — a warm cache turns the ~60s
+      # in-container recompile into a few seconds. Go 1.20+ ships no precompiled stdlib, so an
+      # in-container build (make docker-build) has a cold cache every run; the Dockerfile path is still
+      # exercised by the E2E job. CGO_ENABLED=0 keeps it static (runs in distroless); the arch is left
+      # native (= runner = Kind node); ./cmd/ is the package ko ships at release → a functionally
+      # identical binary.
+      - name: Build manager binary (host Go cache)
         run: |
-          make docker-build IMG=controller:latest
+          mkdir -p /tmp/img
+          CGO_ENABLED=0 GOOS=linux go build -o /tmp/img/manager ./cmd/
+
+      # Package the static binary into the same distroless runtime the Dockerfile ships (keep in sync
+      # with Dockerfile's final stage). A /tmp context sidesteps .dockerignore, which excludes bin/.
+      - name: Package + load image into Kind
+        run: |
+          cat > /tmp/img/Dockerfile <<'EOF'
+          FROM gcr.io/distroless/static:nonroot
+          WORKDIR /
+          COPY manager /manager
+          USER 65532:65532
+          ENTRYPOINT ["/manager"]
+          EOF
+          docker build -t controller:latest /tmp/img
           kind load docker-image controller:latest
 
       - name: Install Helm


### PR DESCRIPTION
## What

`test-chart.yml` (the ~13-min Helm + HA job) built the operator image with `make docker-build` — an in-container `go build` that starts from a **cold** Go build cache every run. Go 1.20+ ships no precompiled stdlib and the container cache never persists, so it recompiles the whole tree (~60s) on every PR push. This builds the binary on the host instead, where `setup-go`'s build cache is already warm.

## Why the in-container build is slow (measured, not assumed)

Benchmarked locally (`docker build --no-cache`): dropping `go build -a` changed the build by only ~2s (65.4s → 63.1s), which **disproves** the "`-a` recompiles stdlib" theory for Go 1.20+ and confirms the cost is the **cold compile**, not `-a`. The only lever is persisting the Go build cache, which the in-container build cannot do without a BuildKit cache-mount plus a third-party cache-dance action.

| build | time |
|---|---|
| in-container `go build` (every run) | ~63s |
| host `go build`, cold cache | 59s |
| host `go build`, **warm cache** | **0.4s** |

`setup-go cache: true` (already set in this job) persists `~/.cache/go-build` keyed on `go.sum` and shared across jobs, so on the common go.sum-unchanged PR the host compile is warm.

**Measured effect in CI: the Helm lint + deploy job dropped from ~13m to ~9m17s.**

## Change

Build `./cmd/` on the host (`CGO_ENABLED=0 GOOS=linux`, native arch = runner = Kind node; `./cmd/` is the package `ko` ships at release), then COPY the static binary into the same `distroless/static:nonroot` runtime via a `/tmp` build context (sidesteps `.dockerignore`, which excludes `bin/`).

## Why it is safe (no functionality or quality loss)

- The host- and in-container-built binaries are **functionally identical** — 76,274,467 vs 76,241,419 bytes, differing only in embedded build-path strings — and the packaged image size matches the Dockerfile build (~34.5M). The deployed image and the HA suite are unchanged.
- The in-container **Dockerfile build is still exercised by the E2E job** (`e2e_suite_test.go` runs `make docker-build`), so Dockerfile coverage is not lost.
- Releases build with **`ko`, not the Dockerfile**, so nothing here touches a shipped artifact.

Verified locally: host build + inline-Dockerfile image builds and runs (`/manager --help`); the run step's heredoc produces the correct Dockerfile after YAML dedent; the workflow parses.

## Deliberately NOT done (would risk correctness or add fragile deps)

- **golangci-lint analysis cache** — real staleness / false-green risk; not worth the speedup.
- **buildx + gha cache-dance** for the in-container compile — needs a third-party action; the host-build reuses the existing `setup-go` cache with none.
- **Caching the release build** — the signed/scanned release path is left cold for provenance clarity; it is a rare job, not a bottleneck.
- **Cutting the HA continuity ~5-min wait** — it is functional (observes continuity across a real leader failover beyond `propagationEpochLead`).
