### PR TITLE
fix(ocudu): don't route the plaintext ws:// runtime push through HTTP_PROXY

### DIFF
--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -312,8 +312,14 @@ func pushNTNConfigUpdate(
 	// same-host redirect — so a gNB/proxy 302 from wss:// to http://same-host would
 	// resend the bearer over cleartext. ErrUseLastResponse stops the client at the
 	// 30x, before it re-sends anything, on both the wss and plaintext paths.
+	// A fresh Transport on BOTH schemes so neither inherits http.DefaultTransport's
+	// Proxy=ProxyFromEnvironment: the gNB endpoint is operator-authored, so routing the push through
+	// HTTP(S)_PROXY would be proxy-amplified SSRF — a CR could reach proxy-only networks the Pod cannot
+	// and make the NetworkPolicy-visible peer the proxy, not the gNB. A fresh Transport has Proxy=nil.
+	transport := &http.Transport{}
 	dialOpts := &websocket.DialOptions{
 		HTTPClient: &http.Client{
+			Transport: transport,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -321,7 +327,7 @@ func pushNTNConfigUpdate(
 	}
 	if target.TLSConfig != nil {
 		scheme = "wss://"
-		dialOpts.HTTPClient.Transport = &http.Transport{TLSClientConfig: target.TLSConfig}
+		transport.TLSClientConfig = target.TLSConfig
 		if target.AuthToken != "" {
 			dialOpts.HTTPHeader = http.Header{"Authorization": {"Bearer " + target.AuthToken}}
 		}

--- a/pkg/provider/ocudu/wsclient_proxy_test.go
+++ b/pkg/provider/ocudu/wsclient_proxy_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ocudu
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestPushNTNConfigUpdate_NeverRoutesThroughHTTPProxy pins that the runtime push never honors
+// HTTP(S)_PROXY on EITHER the plaintext ws:// or the wss:// path. The gNB endpoint is operator-authored,
+// so routing the push through an env proxy would let a CR reach proxy-only networks the Pod itself
+// cannot, and make the NetworkPolicy-visible peer the proxy rather than the gNB (proxy-amplified SSRF).
+// A capture listener stands in for the proxy; any connection to it is a failure. Mutation: leave the
+// plaintext path's HTTPClient.Transport nil (→ http.DefaultTransport → ProxyFromEnvironment) and the
+// ws:// case connects to the capture listener, so the count is non-zero.
+func TestPushNTNConfigUpdate_NeverRoutesThroughHTTPProxy(t *testing.T) {
+	var proxyHits atomic.Int32
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = lis.Close() }()
+	go func() {
+		for {
+			c, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			proxyHits.Add(1)
+			_ = c.Close()
+		}
+	}()
+	proxyURL := "http://" + lis.Addr().String()
+	t.Setenv("HTTP_PROXY", proxyURL)
+	t.Setenv("HTTPS_PROXY", proxyURL)
+	t.Setenv("NO_PROXY", "") // no host is exempt from the (would-be) proxy
+	t.Setenv("no_proxy", "")
+
+	env, err := buildNTNConfigUpdate(ecefRuntimeUpdate())
+	if err != nil {
+		t.Fatalf("build envelope: %v", err)
+	}
+
+	// A non-loopback, unresolvable endpoint: ProxyFromEnvironment WOULD proxy it (loopback is
+	// implicitly exempt, so a 127.0.0.1 target could not detect the leak). A direct dial fails at DNS
+	// and never touches the proxy; a proxied dial connects to the capture listener first.
+	targets := []struct {
+		name   string
+		target provider.ResolvedRemoteControl
+	}{
+		{"plaintext-ws", provider.ResolvedRemoteControl{Endpoint: "gnb-proxy-probe.invalid:8001"}},
+		{"tls-wss", provider.ResolvedRemoteControl{
+			Endpoint:  "gnb-proxy-probe.invalid:8001",
+			TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		}},
+	}
+	for _, tc := range targets {
+		// The dial is expected to FAIL (unresolvable host); only the proxy-usage matters here.
+		_ = pushNTNConfigUpdate(context.Background(), tc.target, env)
+	}
+	time.Sleep(100 * time.Millisecond) // let any wrong proxy Accept land on the listener goroutine
+	if got := proxyHits.Load(); got != 0 {
+		t.Fatalf("runtime push must never route through HTTP(S)_PROXY; capture proxy saw %d connection(s)", got)
+	}
+}


### PR DESCRIPTION
## What

`pushNTNConfigUpdate` set an explicit `http.Transport` **only on the wss:// (TLS) path**. The plaintext `ws://` path left `HTTPClient.Transport == nil`, so coder/websocket ran the handshake through `http.DefaultTransport` — whose `Proxy` is `ProxyFromEnvironment`. So the plaintext runtime push honored `HTTP_PROXY`/`HTTPS_PROXY`, **inconsistent with the TLS path** (a fresh `Transport`, `Proxy` nil) and with the "Proxy=nil to avoid proxy-amplified SSRF" posture from the earlier discussion.

## Why it matters

The gNB endpoint is operator-authored (an arbitrary `host:port`), so honoring an env proxy lets a CR author:
- reach networks the proxy can route to but the Pod itself cannot;
- make the **NetworkPolicy-visible destination the proxy, not the gNB**;
- amplify the existing arbitrary-`host:port` SSRF / port-probing surface.

No credential leak — the bearer is only ever set inside the TLS branch, so the plaintext path never carries it. Severity is Low–Medium: it's conditional on an outbound proxy being configured in the operator's env, and it amplifies an existing (by-design, NetworkPolicy-gated) surface rather than creating a new one.

## Fix

Allocate a fresh `http.Transport` (`Proxy` nil) **unconditionally**, on both schemes; the TLS branch just assigns `TLSClientConfig` to it. `CheckRedirect` (`ErrUseLastResponse`) was already applied to both paths and is unchanged. The wss:// path is behaviourally identical (it already used a fresh `&http.Transport{TLSClientConfig}`).

## Test

`TestPushNTNConfigUpdate_NeverRoutesThroughHTTPProxy` stands a capture listener in for the proxy, sets `HTTP(S)_PROXY`, and dials a non-loopback (proxied-if-honored) endpoint on **both** `ws://` and `wss://`; the capture must see zero connections. A loopback target could not detect the leak because `ProxyFromEnvironment` exempts loopback.

Verified it **FAILS on the pre-fix code** — the `ws://` case connected to the capture proxy (1 connection) — and passes after. All existing wss:// bearer / cert-verification / redirect-downgrade tests are unaffected. `gofmt` / `go vet` / `golangci-lint` clean.
