### PR TITLE
fix(security): unify remoteControl.tls failure reason — close Secret existence oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cause is still logged for the operator (who can read Secrets); genuinely transient errors still
   recover fast via the ~3 min ephemeris heartbeat. A table-driven regression pins that all seven
   failure modes (missing, unreadable, unlabelled, service-account token, bootstrap token, malformed CA,
-  malformed client cert) yield an identical public reason, message, and requeue interval.
+  malformed client cert) yield an identical public reason, message, and requeue interval. The sibling
+  endpoint allow-list (`--remote-control-allowed-endpoint-hosts`) keeps its own distinct reason
+  `RemoteControlEndpointNotAllowed`: it fires before the Secret read and reflects admin egress policy,
+  not Secret state, so folding it into the uniform credential reason would be inaccurate and needless.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Closed a residual Secret existence/type oracle in the `remoteControl.tls` credential path.** #219
+  unified the CR-facing *message* for a `remoteControl.tls` resolution failure but not the *reason*: a
+  missing/unreadable Secret classified as `ProviderPushFailed` (1 min requeue) while a present-but-bad
+  one (wrong type / missing opt-in label / malformed cert) classified as `RemoteControlConfigInvalid`
+  (5 min requeue). Since the controller writes that reason verbatim into
+  `status.conditions[].reason` — and stamps it on the per-failure `EphemerisPushErrorsTotal` metric — a
+  principal who can write an `NTNCellConfig` but has no `secrets/get` could still distinguish "my
+  guessed Secret exists but isn't a valid credential" from "it is missing/unreadable", defeating #219's
+  "No Secret existence/type oracle" claim. Every `remoteControl.tls` failure now surfaces the single
+  uniform reason `RemoteControlCredentialUnavailable` with the uniform message **and** the same 5 min
+  self-heal cadence, so neither the condition, the metric label, nor the metric's per-failure increment
+  *rate* (a channel the message/reason split alone left open) can tell the cases apart. The specific
+  cause is still logged for the operator (who can read Secrets); genuinely transient errors still
+  recover fast via the ~3 min ephemeris heartbeat. A table-driven regression pins that all seven
+  failure modes (missing, unreadable, unlabelled, service-account token, bootstrap token, malformed CA,
+  malformed client cert) yield an identical public reason, message, and requeue interval.
+
 ### Added
 
 - **Durable conditional-GET validators for the OMM cache (polite restart/failover refetch).** The

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -87,6 +87,12 @@ const (
 	// EphemerisPushErrorsTotal would leak via its increment rate) would let a principal who can
 	// write the NTNCellConfig but not read Secrets probe Secret existence and type (an oracle).
 	ephemerisReasonRemoteControlCredential = "RemoteControlCredentialUnavailable"
+	// ephemerisReasonRemoteControlEndpointNotAllowed is the reason when a credentialed push is refused
+	// because its endpoint is outside the admin --remote-control-allowed-endpoint-hosts list (#300,
+	// ADR-0009). It is DISTINCT from the credential reason on purpose: the check runs before the Secret
+	// read and concerns admin egress policy, not Secret state, so it leaks nothing about a Secret and
+	// need not fold into the oracle-closing uniform credential reason.
+	ephemerisReasonRemoteControlEndpointNotAllowed = "RemoteControlEndpointNotAllowed"
 	// ephemerisReasonSelectionAmbiguous fails a push CLOSED when spec.ephemerisNoradID is unset but
 	// the referenced SatelliteEphemeris exposes more than one satellite: the controller refuses to
 	// guess which one to serve (silently pushing the first would switch satellites whenever the
@@ -182,7 +188,10 @@ const remoteControlConfigRequeue = 5 * time.Minute
 // self-heals slowly (its Secret fix is unwatched, so this is a poll, not a hammer); every other
 // requeuing reason is a transient failure that retries tightly.
 func ephemerisPushRequeueInterval(reason string) time.Duration {
-	if reason == ephemerisReasonRemoteControlCredential {
+	// Both remoteControl config errors self-heal slowly: the credential fix is an unwatched Secret
+	// edit, and the endpoint fix is an admin allowlist change (operator flag). A low-frequency poll
+	// beats a tight per-minute retry for either.
+	if reason == ephemerisReasonRemoteControlCredential || reason == ephemerisReasonRemoteControlEndpointNotAllowed {
 		return remoteControlConfigRequeue
 	}
 	return time.Minute
@@ -805,7 +814,7 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		if err := r.RemoteControlAllowedHosts.Check("https://" + rc.Endpoint); err != nil {
 			logf.FromContext(ctx).Error(err, "refusing to send a remoteControl.tls credential to an "+
 				"endpoint outside --remote-control-allowed-endpoint-hosts", "cell", cc.Name, "endpoint", rc.Endpoint)
-			return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlConfig, errRemoteControlEndpointNotAllowed)
+			return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlEndpointNotAllowed, errRemoteControlEndpointNotAllowed)
 		}
 	}
 	// Resolve opt-in transport security (wss:// + shared secret / mTLS) from the

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -80,7 +80,13 @@ const (
 	ephemerisReasonProviderPushFailed   = "ProviderPushFailed"
 	ephemerisReasonProviderPushRejected = "ProviderPushRejected"
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
-	ephemerisReasonRemoteControlConfig  = "RemoteControlConfigInvalid"
+	// ephemerisReasonRemoteControlCredential is the UNIFORM CR-facing reason for EVERY
+	// remoteControl.tls resolution failure — Secret missing, unreadable, wrong type, unlabelled,
+	// or malformed cert. It deliberately does NOT distinguish "missing/unreadable" from
+	// "present-but-invalid": a split reason (or a split retry cadence, which the per-failure
+	// EphemerisPushErrorsTotal would leak via its increment rate) would let a principal who can
+	// write the NTNCellConfig but not read Secrets probe Secret existence and type (an oracle).
+	ephemerisReasonRemoteControlCredential = "RemoteControlCredentialUnavailable"
 	// ephemerisReasonSelectionAmbiguous fails a push CLOSED when spec.ephemerisNoradID is unset but
 	// the referenced SatelliteEphemeris exposes more than one satellite: the controller refuses to
 	// guess which one to serve (silently pushing the first would switch satellites whenever the
@@ -146,7 +152,7 @@ func ephemerisPushConditionReason(err error) string {
 // versus recovering on its own via a watched change. The reasons below clear only on a spec edit
 // (generation bump) or a SatelliteEphemeris refresh (new marker) — both watched — so a self-requeue
 // would just hammer a still-failing push. Everything else requeues: a transient failure (API GET
-// error, gNB unreachable), AND RemoteControlConfigInvalid, whose fix (a Secret edit) is NOT watched
+// error, gNB unreachable), AND RemoteControlCredentialUnavailable, whose fix (a Secret edit) is NOT watched
 // — the controller watches only NTNCellConfig + SatelliteEphemeris and secrets are get-only by
 // design, so without a self-requeue such a cell recovers only on the next ephemeris heartbeat, and
 // never if the producer stalls. ephemerisPushRequeueInterval sets the cadence.
@@ -163,16 +169,20 @@ func ephemerisPushShouldRequeue(reason string) bool {
 	}
 }
 
-// remoteControlConfigRequeue is the low-frequency self-heal poll for a RemoteControlConfigInvalid
-// failure. Its fix is a Secret edit, which the controller does not watch, so the cell must poll to
-// recover rather than rely on the (possibly absent) SatelliteEphemeris heartbeat fan-out.
+// remoteControlConfigRequeue is the low-frequency self-heal poll for any
+// RemoteControlCredentialUnavailable failure. Its fix is a Secret edit (create / label / repair),
+// which the controller does not watch, so the cell must poll to recover rather than rely on the
+// (possibly absent) SatelliteEphemeris heartbeat fan-out. It is applied UNIFORMLY to every
+// credential failure — including a transient/absent-Secret read error — so the retry cadence
+// carries no signal that distinguishes a missing Secret from a present-but-invalid one; the
+// ~3-minute ephemeris heartbeat remains the fast-recovery path for a genuinely transient error.
 const remoteControlConfigRequeue = 5 * time.Minute
 
-// ephemerisPushRequeueInterval is the backoff for a requeuing push failure: a credential/config
-// error self-heals slowly (its Secret fix is unwatched, so this is a poll, not a hammer); every
-// other requeuing reason is a transient failure that retries tightly.
+// ephemerisPushRequeueInterval is the backoff for a requeuing push failure: a credential error
+// self-heals slowly (its Secret fix is unwatched, so this is a poll, not a hammer); every other
+// requeuing reason is a transient failure that retries tightly.
 func ephemerisPushRequeueInterval(reason string) time.Duration {
-	if reason == ephemerisReasonRemoteControlConfig {
+	if reason == ephemerisReasonRemoteControlCredential {
 		return remoteControlConfigRequeue
 	}
 	return time.Minute
@@ -808,17 +818,14 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		// SatelliteEphemeris, and secrets are get-only), so a Secret fix does not re-trigger
 		// reconcile. It therefore gets a low-frequency bounded self-heal requeue
 		// (ephemerisPushRequeueInterval) — not a tight per-minute retry, and not no requeue,
-		// which would strand the cell until the next ephemeris heartbeat, if any. A transient
-		// Secret read error stays tight-requeuing.
-		reason := ephemerisReasonProviderPushFailed
-		if errors.Is(tlsErr, errRemoteControlCredentialInvalid) {
-			reason = ephemerisReasonRemoteControlConfig
-		}
-		// Log the specific cause for the operator; surface only a uniform message on the
-		// CR (see errRemoteControlCredentialUnavailable — avoids a Secret existence/type
-		// oracle for a principal that can write the CR but not read Secrets).
+		// which would strand the cell until the next ephemeris heartbeat, if any. EVERY
+		// remoteControl.tls failure — a missing/unreadable Secret and a present-but-invalid one
+		// alike — takes the SAME reason and the SAME cadence, so neither the CR condition nor the
+		// per-failure error metric's increment rate can distinguish them (a Secret existence/type
+		// oracle). The specific cause is logged for the operator (who can read Secrets); the CR
+		// sees only the uniform reason + message.
 		logf.FromContext(ctx).Error(tlsErr, "remoteControl.tls credential could not be resolved", "cell", cc.Name)
-		return false, marker, newEphemerisPushError(reason, errRemoteControlCredentialUnavailable)
+		return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlCredential, errRemoteControlCredentialUnavailable)
 	}
 	target := provider.ResolvedRemoteControl{
 		Endpoint:  spec.Provider.RemoteControl.Endpoint,
@@ -864,13 +871,6 @@ const (
 	// constant); like a service-account token it is a cluster credential, not a gNB one.
 	secretTypeBootstrapToken = "bootstrap.kubernetes.io/token"
 )
-
-// errRemoteControlCredentialInvalid tags a DETERMINISTIC remoteControl.tls config
-// failure (wrong Secret type, missing opt-in label, malformed cert material). The caller
-// does not tight-requeue it like a transient failure; instead it gets a low-frequency
-// self-heal poll (remoteControlConfigRequeue), because its fix is a Secret edit, and the
-// controller does NOT watch Secrets (get-only), so a Secret fix does not re-trigger reconcile.
-var errRemoteControlCredentialInvalid = errors.New("not a usable remote-control credential")
 
 // errRemoteControlCredentialUnavailable is the UNIFORM, CR-facing message for any
 // remoteControl.tls resolution failure. The specific cause (Secret missing / wrong
@@ -927,10 +927,10 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	// Opaque Secret from holding some other bearer token.
 	switch secret.Type {
 	case corev1.SecretTypeServiceAccountToken, secretTypeBootstrapToken:
-		return nil, "", fmt.Errorf("remoteControl.tls secret %q has type %q — a Kubernetes API credential must not be used as a gNB remote-control secret: %w", t.SecretName, secret.Type, errRemoteControlCredentialInvalid)
+		return nil, "", fmt.Errorf("remoteControl.tls secret %q has type %q — a Kubernetes API credential must not be used as a gNB remote-control secret", t.SecretName, secret.Type)
 	}
 	if secret.Labels[remoteControlCredentialLabel] != "true" {
-		return nil, "", fmt.Errorf("remoteControl.tls secret %q must be labelled %s=true by its owner to be usable as a remote-control credential: %w", t.SecretName, remoteControlCredentialLabel, errRemoteControlCredentialInvalid)
+		return nil, "", fmt.Errorf("remoteControl.tls secret %q must be labelled %s=true by its owner to be usable as a remote-control credential", t.SecretName, remoteControlCredentialLabel)
 	}
 
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
@@ -945,7 +945,7 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if ca := secret.Data["ca.crt"]; len(ca) > 0 {
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(ca) {
-			return nil, "", fmt.Errorf("remoteControl.tls secret %q: ca.crt is not valid PEM: %w", t.SecretName, errRemoteControlCredentialInvalid)
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: ca.crt is not valid PEM", t.SecretName)
 		}
 		cfg.RootCAs = pool
 	}
@@ -953,11 +953,11 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if t.Mode == "mtls" {
 		crt, key := secret.Data["tls.crt"], secret.Data["tls.key"]
 		if len(crt) == 0 || len(key) == 0 {
-			return nil, "", fmt.Errorf("remoteControl.tls mode=mtls requires tls.crt and tls.key in secret %q: %w", t.SecretName, errRemoteControlCredentialInvalid)
+			return nil, "", fmt.Errorf("remoteControl.tls mode=mtls requires tls.crt and tls.key in secret %q", t.SecretName)
 		}
 		pair, err := tls.X509KeyPair(crt, key)
 		if err != nil {
-			return nil, "", fmt.Errorf("remoteControl.tls secret %q: invalid client certificate/key (%v): %w", t.SecretName, err, errRemoteControlCredentialInvalid)
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: invalid client certificate/key (%v)", t.SecretName, err)
 		}
 		cfg.Certificates = []tls.Certificate{pair}
 	}

--- a/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
+++ b/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
@@ -82,8 +82,8 @@ func TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist(t *testing.T
 		if err == nil || !errors.Is(err, errRemoteControlEndpointNotAllowed) {
 			t.Fatalf("want errRemoteControlEndpointNotAllowed (endpoint checked before the Secret read), got %v", err)
 		}
-		if reason := ephemerisPushConditionReason(err); reason != ephemerisReasonRemoteControlConfig {
-			t.Fatalf("must classify as %q, got %q", ephemerisReasonRemoteControlConfig, reason)
+		if reason := ephemerisPushConditionReason(err); reason != ephemerisReasonRemoteControlEndpointNotAllowed {
+			t.Fatalf("must classify as %q, got %q", ephemerisReasonRemoteControlEndpointNotAllowed, reason)
 		}
 		if pushed {
 			t.Fatal("the credential must NOT be sent to a non-allowlisted endpoint (the provider was called)")

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -33,7 +32,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/provider"
@@ -199,9 +200,6 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 		if tok != "" {
 			t.Fatalf("no token may be returned on rejection, got %q", tok)
 		}
-		if !errors.Is(err, errRemoteControlCredentialInvalid) {
-			t.Errorf("a credential-config rejection must be classified permanent (wrap errRemoteControlCredentialInvalid) so it does not tight-requeue; got %v", err)
-		}
 	})
 
 	t.Run("service-account-token Secret → rejected even if labelled", func(t *testing.T) {
@@ -223,9 +221,6 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 		if tok != "" {
 			t.Fatalf("the apiserver token must never be returned, got %q", tok)
 		}
-		if !errors.Is(err, errRemoteControlCredentialInvalid) {
-			t.Errorf("a rejected Secret type must be classified permanent (wrap errRemoteControlCredentialInvalid); got %v", err)
-		}
 	})
 
 	t.Run("bootstrap-token Secret → rejected even if labelled", func(t *testing.T) {
@@ -244,25 +239,24 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 		if err == nil || tok != "" {
 			t.Fatal("a bootstrap-token Secret must never be usable as a remote-control credential")
 		}
-		if !errors.Is(err, errRemoteControlCredentialInvalid) {
-			t.Errorf("must be classified permanent; got %v", err)
-		}
 	})
 }
 
-// TestEphemerisPushRequeue_RemoteControlConfigSelfHeals pins that a deterministic
+// TestEphemerisPushRequeue_RemoteControlCredentialSelfHeals pins that a
 // remoteControl.tls credential error requeues on a low-frequency SELF-HEAL poll — not a tight
 // per-minute retry, and not never. Its fix is a Secret edit, which the controller does NOT watch
 // (only NTNCellConfig + SatelliteEphemeris are watched; secrets are get-only), so without a
 // self-requeue the cell recovers only on the next SatelliteEphemeris heartbeat fan-out, and never
 // if the producer stalls. A transient ProviderPushFailed still tight-requeues (control).
-func TestEphemerisPushRequeue_RemoteControlConfigSelfHeals(t *testing.T) {
-	if !ephemerisPushShouldRequeue(ephemerisReasonRemoteControlConfig) {
-		t.Error("RemoteControlConfigInvalid must self-requeue: its Secret fix is not watched, so no requeue would strand the cell")
+func TestEphemerisPushRequeue_RemoteControlCredentialSelfHeals(t *testing.T) {
+	if !ephemerisPushShouldRequeue(ephemerisReasonRemoteControlCredential) {
+		t.Error("RemoteControlCredentialUnavailable must self-requeue: its Secret fix is not watched, so no requeue would strand the cell")
 	}
-	if got := ephemerisPushRequeueInterval(ephemerisReasonRemoteControlConfig); got != remoteControlConfigRequeue {
-		t.Errorf("credential-config requeue = %v, want %v (a slow self-heal poll, not a tight retry)", got, remoteControlConfigRequeue)
+	if got := ephemerisPushRequeueInterval(ephemerisReasonRemoteControlCredential); got != remoteControlConfigRequeue {
+		t.Errorf("credential requeue = %v, want %v (a slow self-heal poll, not a tight retry)", got, remoteControlConfigRequeue)
 	}
+	// A generic ProviderPushFailed (an actual gNB push failure, NOT a credential failure) still
+	// tight-requeues — control that the 5m interval is credential-specific, not a blanket slowdown.
 	if !ephemerisPushShouldRequeue(ephemerisReasonProviderPushFailed) {
 		t.Error("a transient ProviderPushFailed must still requeue (control)")
 	}
@@ -271,12 +265,13 @@ func TestEphemerisPushRequeue_RemoteControlConfigSelfHeals(t *testing.T) {
 	}
 }
 
-// TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlConfig proves the input to
-// the self-heal requeue: an un-opted-in (unlabelled) remoteControl.tls Secret makes the runtime
-// push fail with the RemoteControlConfigInvalid reason. Combined with the classification above,
-// this is the end-to-end guarantee — a bad Secret schedules a bounded self-heal retry rather than
-// stranding the cell, since a Secret edit does not re-trigger reconcile.
-func TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlConfig(t *testing.T) {
+// TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlCredential proves the input
+// to the self-heal requeue: an un-opted-in (unlabelled) remoteControl.tls Secret makes the runtime
+// push fail with the uniform RemoteControlCredentialUnavailable reason. Combined with the
+// requeue-classification above, this is the end-to-end guarantee — a bad Secret schedules a
+// bounded self-heal retry rather than stranding the cell, since a Secret edit does not re-trigger
+// reconcile.
+func TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlCredential(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -302,8 +297,8 @@ func TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlConfig(
 		t.Fatal("an un-opted-in remoteControl.tls Secret must fail the push")
 	}
 	reason := ephemerisPushConditionReason(err)
-	if reason != ephemerisReasonRemoteControlConfig {
-		t.Fatalf("a bad credential must classify as %q, got %q", ephemerisReasonRemoteControlConfig, reason)
+	if reason != ephemerisReasonRemoteControlCredential {
+		t.Fatalf("a bad credential must classify as %q, got %q", ephemerisReasonRemoteControlCredential, reason)
 	}
 	// And that reason self-heal-requeues (the Secret fix is unwatched), so the cell is not stranded.
 	if !ephemerisPushShouldRequeue(reason) || ephemerisPushRequeueInterval(reason) != remoteControlConfigRequeue {
@@ -340,8 +335,8 @@ func TestPushEphemerisUpdateIfNeeded_SecretFixRecovers(t *testing.T) {
 
 	// Push 1: the un-opted-in Secret fails the push as a credential-config error.
 	if _, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, &provider.MockProvider{}); err == nil ||
-		ephemerisPushConditionReason(err) != ephemerisReasonRemoteControlConfig {
-		t.Fatalf("push 1: want a RemoteControlConfigInvalid failure, got %v", err)
+		ephemerisPushConditionReason(err) != ephemerisReasonRemoteControlCredential {
+		t.Fatalf("push 1: want a RemoteControlCredentialUnavailable failure, got %v", err)
 	}
 
 	// Patch ONLY the Secret — add the opt-in label. No spec edit, no ephemeris change.
@@ -356,5 +351,99 @@ func TestPushEphemerisUpdateIfNeeded_SecretFixRecovers(t *testing.T) {
 	if err != nil || !pushed || mock.RuntimeCalls != 1 {
 		t.Fatalf("push 2 (post-Secret-fix) must recover with a successful push; got pushed=%v err=%v calls=%d",
 			pushed, err, mock.RuntimeCalls)
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_CredentialFailuresUniform is the security regression the review
+// asked for: EVERY remoteControl.tls resolution failure — a missing/unreadable Secret and a
+// present-but-invalid one alike — must surface the IDENTICAL public reason, message, AND requeue
+// cadence on the CR, so a principal who can write the NTNCellConfig but not read Secrets cannot
+// distinguish a missing Secret from a present-but-bad one (a Secret existence/type oracle; #219).
+// The uniform cadence matters because EphemerisPushErrorsTotal counts per-failure, so a split
+// interval would leak the same distinction via the metric's increment rate.
+func TestPushEphemerisUpdateIfNeeded_CredentialFailuresUniform(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	certPEM, _ := selfSignedPEM(t)
+
+	const secretName = "cred"
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	ns := eph.Namespace // resolveRemoteControlTLS looks the Secret up in the ephemeris namespace
+	labelled := map[string]string{remoteControlCredentialLabel: "true"}
+	mkSecret := func(labels map[string]string, typ corev1.SecretType, data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns, Labels: labels},
+			Type:       typ,
+			Data:       data,
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mode    string
+		secret  *corev1.Secret // nil ⇒ Secret ABSENT (missing)
+		readErr bool           // inject a Secret GET failure (unreadable / forbidden)
+	}{
+		{name: "missing", mode: "tls", secret: nil},
+		{name: "read-failure", mode: "tls", readErr: true,
+			secret: mkSecret(labelled, "", map[string][]byte{"ca.crt": certPEM})},
+		{name: "unlabelled", mode: "tls",
+			secret: mkSecret(nil, "", map[string][]byte{"ca.crt": certPEM})},
+		{name: "service-account-token", mode: "tls",
+			secret: mkSecret(labelled, corev1.SecretTypeServiceAccountToken, map[string][]byte{"token": []byte("apiserver"), "ca.crt": certPEM})},
+		{name: "bootstrap-token", mode: "tls",
+			secret: mkSecret(labelled, secretTypeBootstrapToken, map[string][]byte{"token": []byte("bootstrap"), "ca.crt": certPEM})},
+		{name: "malformed-ca", mode: "tls",
+			secret: mkSecret(labelled, "", map[string][]byte{"ca.crt": []byte("not-pem")})},
+		{name: "malformed-client-cert", mode: "mtls",
+			secret: mkSecret(labelled, "", map[string][]byte{"ca.crt": certPEM, "tls.crt": []byte("bad"), "tls.key": []byte("bad")})},
+	}
+
+	wantMsg := errRemoteControlCredentialUnavailable.Error()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{eph.DeepCopy()}
+			if tc.secret != nil {
+				objs = append(objs, tc.secret)
+			}
+			b := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...)
+			if tc.readErr {
+				b = b.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return context.DeadlineExceeded // a transient/unreadable Secret GET
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+			c := b.Build()
+			r := &NTNCellConfigReconciler{Client: c, APIReader: c}
+			cc := ccWithRemoteControl()
+			cc.Spec.Provider.RemoteControl.TLS = &ntnv1alpha1.RemoteControlTLS{Mode: tc.mode, SecretName: secretName}
+
+			_, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, &provider.MockProvider{})
+			if err == nil {
+				t.Fatalf("%s: expected a credential failure", tc.name)
+			}
+			// UNIFORM public reason — no Secret existence/type oracle.
+			if got := ephemerisPushConditionReason(err); got != ephemerisReasonRemoteControlCredential {
+				t.Errorf("%s: public reason = %q, want the uniform %q", tc.name, got, ephemerisReasonRemoteControlCredential)
+			}
+			// UNIFORM public message.
+			if got := err.Error(); got != wantMsg {
+				t.Errorf("%s: public message = %q, want the uniform %q", tc.name, got, wantMsg)
+			}
+			// UNIFORM self-heal cadence — so the per-failure error metric's increment rate cannot
+			// distinguish the cases either.
+			if iv := ephemerisPushRequeueInterval(ephemerisPushConditionReason(err)); iv != remoteControlConfigRequeue {
+				t.Errorf("%s: requeue interval = %v, want the uniform %v", tc.name, iv, remoteControlConfigRequeue)
+			}
+		})
 	}
 }

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -308,7 +308,7 @@ func TestPushEphemerisUpdateIfNeeded_BadCredentialClassifiesRemoteControlCredent
 }
 
 // TestPushEphemerisUpdateIfNeeded_SecretFixRecovers is the end-to-end coverage the review asked for
-// on the RemoteControlConfigInvalid self-heal (#282): patch ONLY the Secret and observe recovery. A
+// on the RemoteControlCredentialUnavailable self-heal (#282): patch ONLY the Secret and observe recovery. A
 // remoteControl.tls Secret missing the opt-in label fails the push as a credential-config error;
 // adding the label (no spec edit, no ephemeris change) makes the very next push — which is exactly
 // what the 5m self-heal requeue re-runs — succeed. That is what lets the cell recover even when the
@@ -323,7 +323,7 @@ func TestPushEphemerisUpdateIfNeeded_SecretFixRecovers(t *testing.T) {
 	}
 	certPEM, _ := selfSignedPEM(t)
 	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
-	// Valid cert material, but NOT opted in (no owner label) → RemoteControlConfigInvalid.
+	// Valid cert material, but NOT opted in (no owner label) → RemoteControlCredentialUnavailable.
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "cred", Namespace: eph.Namespace},
 		Data:       map[string][]byte{"ca.crt": certPEM},

--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -337,9 +337,9 @@ func pushNTNConfigUpdate(
 		// A definitive HTTP handshake response (a refused redirect, an auth rejection,
 		// or any non-101 in the 3xx/4xx range) is a PERMANENT config/credential problem,
 		// not transient unreachability — classify it non-retryable so the reconciler does
-		// not tight-requeue it every minute (mirroring RemoteControlConfigInvalid). A nil
-		// response is a connection-level failure (dial/TLS/timeout, or a 5xx server error)
-		// and stays retryable. coder/websocket owns resp.Body, so we only read the status.
+		// not tight-requeue it every minute. A nil response is a connection-level failure
+		// (dial/TLS/timeout, or a 5xx server error) and stays retryable. coder/websocket
+		// owns resp.Body, so we only read the status.
 		if resp != nil && resp.StatusCode >= 300 && resp.StatusCode < 500 {
 			return &wsError{wsHandshakeRejected, fmt.Sprintf("handshake to %s rejected: HTTP %d", endpoint, resp.StatusCode)}
 		}


### PR DESCRIPTION
## The finding (verified against current code, `d83de6e`)

#219 claimed "No Secret existence/type oracle" for the `remoteControl.tls` credential path, but it only unified the CR-facing **message** — not the **reason** or the **retry cadence**:

| Secret state | `resolveRemoteControlTLS` returns | reason written to `status.conditions[].reason` | requeue |
|---|---|---|---|
| missing / unreadable (`Get` fails) | plain error (no tag) | `ProviderPushFailed` | **1 min** |
| present but wrong-type / unlabelled / bad-PEM / bad-cert | wraps `errRemoteControlCredentialInvalid` | `RemoteControlConfigInvalid` | **5 min** |

The reason is written verbatim into the condition **and** stamped on the per-failure `EphemerisPushErrorsTotal` metric label. So a principal who can write an `NTNCellConfig` but has **no `secrets/get`** can point it at a guessed Secret name and read back:
- `RemoteControlConfigInvalid` ⇒ the Secret **exists** but isn't a valid credential (positive existence/type confirmation), vs
- `ProviderPushFailed` ⇒ missing/unreadable.

That's the oracle #219 said it prevented. **Adopted — it's real and reproducible.**

## The fix (and where I improved on the proposed one)

Both credential paths now use one uniform public reason **`RemoteControlCredentialUnavailable`** + the existing uniform message.

The review proposed keeping the 1m/5m cadence internal. I went further and **unified the cadence too (5m for all)**, because `EphemerisPushErrorsTotal` counts **per-failure** — so a split interval would leak the same distinction via the metric's **increment rate**, even behind a unified label (a channel the reason/message split alone leaves open). Unifying the cadence is also *simpler*: it removes the now-purposeless `errRemoteControlCredentialInvalid` classification tag entirely rather than adding an internal-field indirection. Behaviorally sound — every credential fix is an unwatched Secret edit, so a 5 min self-heal poll fits all of them, and the ~3 min ephemeris heartbeat remains the fast-recovery path for a genuinely transient read error. The specific cause is still **logged** for the operator (who *can* read Secrets).

## Regression test (the review's table)

`TestPushEphemerisUpdateIfNeeded_CredentialFailuresUniform` drives the runtime-push path through **all seven** failure modes and asserts an **identical** public reason, message, and requeue interval:

`missing` · `read-failure` (injected `Get` error) · `unlabelled` · `service-account-token` · `bootstrap-token` · `malformed-ca` · `malformed-client-cert`

## Adversarial review

- **Mutation-verified**: re-introducing the split (missing/unreadable → `ProviderPushFailed`) fails **only** the `missing` + `read-failure` subcases — the test locks the closure.
- **Only one caller** of `resolveRemoteControlTLS` (no second surfacing path).
- Condition reason/message, metric label, metric increment-rate, and the (episode-gated) event are all uniform; `lastTransitionTime` is identical across cases. The one remaining distinguishable outcome — *success* — reveals only an already-opted-in RC Secret (namespace-usable by design); sensitive non-opted-in Secrets stay indistinguishable from missing.

`internal/controller` green; `golangci-lint` (v2.12.2) 0 issues.