### PR TITLE
fix(ocudu): a refused push handshake self-heals instead of stranding the cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   references and its `EnsureOwnership` back-fill used `SetControllerReference` in a single `Update`,
   so a genuine leftover has either our controller reference or none. A ConfigMap owned by a different controller, an unlabeled foreign object, and a
   labeled-but-empty impostor are still left untouched, and the skip is now logged. Mutation-tested.
+- **A refused runtime-push handshake no longer strands the cell until an unrelated heartbeat.** Every
+  non-101 HTTP response to the gNB `remote_control` WebSocket handshake in the 3xx/4xx band was
+  classified `ProviderPushRejected`, which is in the never-requeue set — a set whose contract is "the
+  fix is a WATCHED change" (a spec edit bumps the generation; an ephemeris refresh brings a new
+  marker). Nothing about a refused handshake meets that contract: a 401/403 after a credential
+  rotation, a 429 from a proxy, a redirect from a misconfigured ingress and a 404 from a restarting
+  gNB are all fixed by state the operator does not watch, so such a cell only ever recovered if the
+  referenced SatelliteEphemeris happened to fan out its ~3-minute heartbeat — and never once that
+  producer stalled. These now report a new `RemoteEndpointRejected` reason and self-heal on the same
+  bounded 5-minute poll the local-credential path already uses (`RemoteControlCredentialUnavailable`, #282).
+  `408 Request Timeout` and `425 Too Early` are additionally re-classified as transient, since both
+  explicitly invite the client to repeat the same request (RFC 9110 §15.5.9, RFC 8470 §5.2). Redirects
+  are still never followed — the bearer-downgrade guard is unchanged — they are merely retried later
+  instead of being written off. A post-handshake gNB `{"error":...}` stays permanent: there the fix
+  really is a spec edit.
 
 - **SGP4 propagation failures are now surfaced, not silently dropped.** A tracked element set that
   passed the epoch checks but failed `PropagateToECEF` (OMM→TLE conversion, propagation, or ECEF range

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -111,6 +111,7 @@ sum by (namespace, config, reason) (increase(ntn_operators_ephemeris_push_errors
 |---|---|---|
 | `ProviderPushFailed` | dial/write/read to the gNB failed | transient (operator requeues) |
 | `ProviderPushRejected` | gNB replied `{"error":...}` — bad config | permanent, clears on spec/ephemeris change |
+| `RemoteEndpointRejected` | the WebSocket handshake was refused (redirect, 401/403, 429, 4xx) | self-heals on a 5m poll — the fix is outside the cluster |
 | `EphemerisRefNotFound` / `EphemerisGetFailed` | the referenced SatelliteEphemeris is missing/unreadable | fix the ref, not the gNB |
 | `EphemerisPayloadMissing` | no propagated state to push yet | upstream ephemeris problem |
 | `EphemerisStale` | the propagated state is stale/expired | see **NTNEphemerisEpochStale** |
@@ -193,6 +194,12 @@ kubectl debug -n "$OPERATOR_NS" -it "$POD" --profile=restricted \
   is the exact failure the I-27 egress config prevents).
 - `ProviderPushRejected` — read the gNB log for the rejection; correct the
   NTNCellConfig spec (commonly `siWindowPosition`, or an ephemeris field).
+- `RemoteEndpointRejected` — the endpoint answered the handshake with a non-101.
+  Read the HTTP status in the condition message: 401/403 means the
+  `remoteControl.tls` credential no longer matches the gNB (rotate the Secret —
+  the operator picks it up on the next poll, no CR edit needed); 429 means a
+  proxy is rate-limiting; a redirect or 404/405 means a proxy in front of the gNB
+  is not passing `Upgrade` through. The cell retries every 5m on its own.
 - `EphemerisRefNotFound` / `PayloadMissing` — fix `spec.cellID` and the
   referenced SatelliteEphemeris; then wait for a refresh to re-trigger.
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -95,6 +95,12 @@ const (
 	// read and concerns admin egress policy, not Secret state, so it leaks nothing about a Secret and
 	// need not fold into the oracle-closing uniform credential reason.
 	ephemerisReasonRemoteControlEndpointNotAllowed = "RemoteControlEndpointNotAllowed"
+	// ephemerisReasonRemoteEndpointRejected marks a runtime push whose WebSocket handshake the
+	// remote endpoint REFUSED (a refused redirect, 401/403, 429, or another 4xx from the gNB or
+	// a proxy). Distinct from ProviderPushRejected, which is the gNB rejecting the payload after
+	// a successful handshake: there the fix is a spec edit (watched), here it is external state
+	// (a credential, a proxy rule, the gNB) that nothing watches — so it self-heals on a poll.
+	ephemerisReasonRemoteEndpointRejected = "RemoteEndpointRejected"
 	// ephemerisReasonSelectionAmbiguous fails a push CLOSED when spec.ephemerisNoradID is unset but
 	// the referenced SatelliteEphemeris exposes more than one satellite: the controller refuses to
 	// guess which one to serve (silently pushing the first would switch satellites whenever the
@@ -160,10 +166,12 @@ func ephemerisPushConditionReason(err error) string {
 // versus recovering on its own via a watched change. The reasons below clear only on a spec edit
 // (generation bump) or a SatelliteEphemeris refresh (new marker) — both watched — so a self-requeue
 // would just hammer a still-failing push. Everything else requeues: a transient failure (API GET
-// error, gNB unreachable), AND RemoteControlCredentialUnavailable, whose fix (a Secret edit) is NOT watched
-// — the controller watches only NTNCellConfig + SatelliteEphemeris and secrets are get-only by
-// design, so without a self-requeue such a cell recovers only on the next ephemeris heartbeat, and
-// never if the producer stalls. ephemerisPushRequeueInterval sets the cadence.
+// error, gNB unreachable), AND the unwatched-fix reasons — RemoteControlCredentialUnavailable (a
+// Secret edit), RemoteControlEndpointNotAllowed (an admin allowlist edit), and RemoteEndpointRejected
+// (a credential, proxy or gNB change behind the endpoint) — whose fixes the controller does not watch
+// (it watches only NTNCellConfig + SatelliteEphemeris and secrets are get-only), so without a
+// self-requeue such a cell recovers only on the next ephemeris heartbeat, and never if the producer
+// stalls. ephemerisPushRequeueInterval sets the cadence.
 func ephemerisPushShouldRequeue(reason string) bool {
 	switch reason {
 	case ephemerisReasonRefNotFound,
@@ -177,26 +185,26 @@ func ephemerisPushShouldRequeue(reason string) bool {
 	}
 }
 
-// remoteControlConfigRequeue is the low-frequency self-heal poll for any
-// RemoteControlCredentialUnavailable failure. Its fix is a Secret edit (create / label / repair),
-// which the controller does not watch, so the cell must poll to recover rather than rely on the
-// (possibly absent) SatelliteEphemeris heartbeat fan-out. It is applied UNIFORMLY to every
-// credential failure — including a transient/absent-Secret read error — so the retry cadence
-// carries no signal that distinguishes a missing Secret from a present-but-invalid one; the
-// ~3-minute ephemeris heartbeat remains the fast-recovery path for a genuinely transient error.
+// remoteControlConfigRequeue is the low-frequency self-heal poll for a failure whose fix the
+// controller cannot observe: a Secret edit (RemoteControlCredentialUnavailable), an admin allowlist
+// edit (RemoteControlEndpointNotAllowed), or external state behind the remote endpoint
+// (RemoteEndpointRejected). None is watched, so the cell must poll to recover rather than rely on
+// the (possibly absent) SatelliteEphemeris heartbeat fan-out. The credential poll is applied
+// UNIFORMLY to every credential failure so its cadence carries no missing-vs-present-Secret signal.
 const remoteControlConfigRequeue = 5 * time.Minute
 
-// ephemerisPushRequeueInterval is the backoff for a requeuing push failure: a credential error
-// self-heals slowly (its Secret fix is unwatched, so this is a poll, not a hammer); every other
-// requeuing reason is a transient failure that retries tightly.
+// ephemerisPushRequeueInterval is the backoff for a requeuing push failure: an unwatched-fix error
+// self-heals slowly (a poll, not a hammer); every other requeuing reason is a transient failure
+// that retries tightly.
 func ephemerisPushRequeueInterval(reason string) time.Duration {
-	// Both remoteControl config errors self-heal slowly: the credential fix is an unwatched Secret
-	// edit, and the endpoint fix is an admin allowlist change (operator flag). A low-frequency poll
-	// beats a tight per-minute retry for either.
-	if reason == ephemerisReasonRemoteControlCredential || reason == ephemerisReasonRemoteControlEndpointNotAllowed {
+	switch reason {
+	case ephemerisReasonRemoteControlCredential,
+		ephemerisReasonRemoteControlEndpointNotAllowed,
+		ephemerisReasonRemoteEndpointRejected:
 		return remoteControlConfigRequeue
+	default:
+		return time.Minute
 	}
-	return time.Minute
 }
 
 // +kubebuilder:rbac:groups=ntn.operators.dev,resources=ntncellconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -869,11 +877,16 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 		AuthToken: authToken,
 	}
 	if err := prov.PushRuntimeUpdate(ctx, target, update); err != nil {
-		// A permanent rejection (bad config / malformed frame) must not tight-loop;
-		// only a transient failure (gNB unreachable) is worth retrying.
+		// Three cadences, not two. A permanent rejection (bad config / malformed frame)
+		// must not requeue at all — its fix bumps the generation, which re-triggers us. A
+		// refused handshake must not tight-loop either, but its fix (credential, proxy,
+		// gNB) is unwatched, so it polls. Everything else is transient and retries tightly.
 		reason := ephemerisReasonProviderPushFailed
-		if errors.Is(err, provider.ErrRuntimePushRejected) {
+		switch {
+		case errors.Is(err, provider.ErrRuntimePushRejected):
 			reason = ephemerisReasonProviderPushRejected
+		case errors.Is(err, provider.ErrRuntimePushRetryLater):
+			reason = ephemerisReasonRemoteEndpointRejected
 		}
 		return false, marker, newEphemerisPushError(reason, fmt.Errorf("provider PushRuntimeUpdate: %w", err))
 	}

--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -602,10 +602,45 @@ func TestEphemerisPushShouldRequeue(t *testing.T) {
 	}
 	for _, reason := range []string{
 		ephemerisReasonGetFailed, ephemerisReasonProviderPushFailed, ephemerisReasonPushFailed,
+		ephemerisReasonRemoteControlCredential, ephemerisReasonRemoteControlEndpointNotAllowed,
+		ephemerisReasonRemoteEndpointRejected,
 	} {
 		if !ephemerisPushShouldRequeue(reason) {
-			t.Errorf("%s SHOULD requeue (transient)", reason)
+			t.Errorf("%s SHOULD requeue (its fix is either transient or unwatched)", reason)
 		}
+	}
+}
+
+// A refused handshake (401/403/429/redirect/4xx) must self-heal on the slow poll, not join the
+// never-requeue set. The endpoint said no, so a per-minute retry is wrong — but the fix is a
+// credential, a proxy rule or the gNB itself, none of which this controller watches, so "never
+// retry" would leave the cell dependent on an unrelated SatelliteEphemeris heartbeat fan-out and
+// permanently stranded if the producer stalls. Mirrors RemoteControlCredentialUnavailable (#282).
+func TestPushEphemerisUpdateIfNeeded_RefusedHandshakeSelfHeals(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{Client: c}
+	mock := &provider.MockProvider{
+		RuntimeErr: fmt.Errorf("%w: handshake rejected: HTTP 401", provider.ErrRuntimePushRetryLater),
+	}
+	cc := ccWithRemoteControl()
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if pushed {
+		t.Fatal("expected pushed=false on a refused handshake")
+	}
+	if got := ephemerisPushConditionReason(err); got != ephemerisReasonRemoteEndpointRejected {
+		t.Fatalf("expected RemoteEndpointRejected reason, got %q", got)
+	}
+	if !ephemerisPushShouldRequeue(ephemerisReasonRemoteEndpointRejected) {
+		t.Error("a refused handshake must self-requeue: its fix is unwatched, so no requeue strands the cell")
+	}
+	if got := ephemerisPushRequeueInterval(ephemerisReasonRemoteEndpointRejected); got != remoteControlConfigRequeue {
+		t.Errorf("refused-handshake requeue = %v, want %v (a slow self-heal poll, not a tight retry)", got, remoteControlConfigRequeue)
 	}
 }
 

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -94,6 +94,14 @@ var ErrRuntimeUnsupported = errors.New("runtime NTN config push is not supported
 // (unlike a transient unreachable-endpoint error). Test with errors.Is.
 var ErrRuntimePushRejected = errors.New("runtime NTN config push permanently rejected")
 
+// ErrRuntimePushRetryLater wraps a runtime-push failure that a tight retry cannot fix
+// but that is NOT permanent: the remote endpoint refused the handshake (a refused
+// redirect, 401/403, 429, a 4xx from the gNB or a proxy in front of it). The fix is
+// external state — a rotated credential, a corrected proxy rule, a restarted gNB —
+// which no controller watch observes, so the caller must poll at a low rate instead of
+// waiting for an event that will never arrive. Test with errors.Is.
+var ErrRuntimePushRetryLater = errors.New("runtime NTN config push refused by the remote endpoint")
+
 // ErrConfigMapNotOwned is returned by ApplyCellConfig when a ConfigMap with the
 // provider's deterministic name already exists but is NOT controller-owned by the
 // applying CR (a name collision with a foreign/user-created object, or a leftover

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -429,11 +429,18 @@ func (p *Provider) PushRuntimeUpdate(
 		return fmt.Errorf("%w: %v", provider.ErrRuntimePushRejected, err)
 	}
 	err = pushNTNConfigUpdate(ctx, target, env)
-	// Classify: gNB rejection / oversized / marshal are permanent (no tight
-	// requeue); an unreachable endpoint is transient and returned as-is.
+	// Classify: gNB rejection / oversized / marshal are permanent (their fix is a
+	// watched spec change); a refused handshake needs a slow poll (its fix is
+	// unwatched external state); an unreachable endpoint is transient, returned as-is.
 	var we *wsError
-	if errors.As(err, &we) && !we.retryable() {
-		return fmt.Errorf("%w: %v", provider.ErrRuntimePushRejected, we)
+	if errors.As(err, &we) {
+		switch we.retryPolicy() {
+		case wsRetrySlow:
+			return fmt.Errorf("%w: %v", provider.ErrRuntimePushRetryLater, we)
+		case wsRetryNever:
+			return fmt.Errorf("%w: %v", provider.ErrRuntimePushRejected, we)
+		case wsRetryTight:
+		}
 	}
 	return err
 }

--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -252,7 +252,9 @@ func buildNTNConfigUpdate(u provider.RuntimeUpdate) (ntnConfigUpdateEnvelope, er
 type wsErrorKind int
 
 const (
-	// wsUnreachable: dial/write/read failed — transient, worth a requeue.
+	// wsUnreachable: dial/write/read failed — transient, worth a requeue. Also covers a
+	// handshake the endpoint answered with a repeat-me status (408/425): the dial did fail,
+	// and the correct response is the same tight retry.
 	wsUnreachable wsErrorKind = iota
 	// wsPayloadTooLarge: frame exceeds OCUDU's 16 KB cap — permanent.
 	wsPayloadTooLarge
@@ -262,7 +264,8 @@ const (
 	wsRejected
 	// wsHandshakeRejected: the handshake got a definitive HTTP response (a refused
 	// redirect, an auth rejection, or another non-101 in the 3xx/4xx range) rather
-	// than an Upgrade — permanent (config/credential), must not tight-requeue.
+	// than an Upgrade — the endpoint is reachable and said no, so a tight retry is
+	// pointless, but the fix is unwatched external state, so it must still be polled.
 	wsHandshakeRejected
 )
 
@@ -274,9 +277,37 @@ type wsError struct {
 
 func (e *wsError) Error() string { return e.msg }
 
-// retryable reports whether the failure is worth requeuing (transient) vs a
-// permanent config/protocol error the operator should not hammer.
-func (e *wsError) retryable() bool { return e.kind == wsUnreachable }
+// wsRetryPolicy is how the reconciler should schedule the next attempt. Deliberately
+// three-valued, not a retryable/permanent bool: "must not tight-requeue" and "must
+// never retry" are different claims, and only the second one is safe when the fix is
+// something no controller watch can observe.
+type wsRetryPolicy int
+
+const (
+	// wsRetryTight: transient — retry on the normal per-minute cadence.
+	wsRetryTight wsRetryPolicy = iota
+	// wsRetrySlow: the endpoint refused us and the fix lives outside the cluster (a
+	// credential, a proxy rule, the gNB itself). Unwatched, so poll for it slowly.
+	wsRetrySlow
+	// wsRetryNever: the fix is a WATCHED change — a spec edit bumps the generation, an
+	// ephemeris refresh brings a new marker — which re-triggers reconcile on its own.
+	wsRetryNever
+)
+
+// retryPolicy maps a failure kind to its requeue cadence.
+func (e *wsError) retryPolicy() wsRetryPolicy {
+	switch e.kind {
+	case wsUnreachable:
+		return wsRetryTight
+	case wsHandshakeRejected:
+		return wsRetrySlow
+	case wsPayloadTooLarge, wsMarshal, wsRejected:
+		return wsRetryNever
+	}
+	// Unreachable for the kinds above; a future kind defaults to the safe cadence
+	// (poll slowly) rather than silently stranding the cell forever.
+	return wsRetrySlow
+}
 
 // pushNTNConfigUpdate dials the gNB remote_control WebSocket, sends a single
 // ntn_config_update text frame, reads the one-line reply, and returns nil on
@@ -334,13 +365,25 @@ func pushNTNConfigUpdate(
 	}
 	conn, resp, err := websocket.Dial(dialCtx, scheme+endpoint, dialOpts)
 	if err != nil {
-		// A definitive HTTP handshake response (a refused redirect, an auth rejection,
-		// or any non-101 in the 3xx/4xx range) is a PERMANENT config/credential problem,
-		// not transient unreachability — classify it non-retryable so the reconciler does
-		// not tight-requeue it every minute. A nil response is a connection-level failure
-		// (dial/TLS/timeout, or a 5xx server error) and stays retryable. coder/websocket
-		// owns resp.Body, so we only read the status.
+		// A definitive HTTP handshake response (a refused redirect, an auth rejection, or
+		// any other non-101 in the 3xx/4xx range) means the endpoint is reachable and said
+		// no — a tight per-minute retry cannot fix it. But it is NOT permanent either: the
+		// gNB, the proxy in front of it and the credential we present are all external
+		// state this controller does not watch, so "never retry" would strand the cell
+		// until some unrelated ephemeris heartbeat happens to fan out — and forever if the
+		// producer stalls. It gets the slow self-heal poll instead, exactly as the local
+		// credential path does (RemoteControlCredentialUnavailable, #282). A nil response is a
+		// connection-level failure (dial/TLS/timeout, or a 5xx) and keeps the tight
+		// cadence. coder/websocket owns resp.Body, so we only read the status.
 		if resp != nil && resp.StatusCode >= 300 && resp.StatusCode < 500 {
+			// 408 and 425 ask for the SAME request again (RFC 9110 §15.5.9, RFC 8470 §5.2),
+			// so they are the handshake's own transient failures, not a rejection.
+			if resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooEarly {
+				return &wsError{
+					wsUnreachable,
+					fmt.Sprintf("handshake to %s did not complete: HTTP %d", endpoint, resp.StatusCode),
+				}
+			}
 			return &wsError{wsHandshakeRejected, fmt.Sprintf("handshake to %s rejected: HTTP %d", endpoint, resp.StatusCode)}
 		}
 		return &wsError{wsUnreachable, fmt.Sprintf("dial %s: %v", endpoint, err)}

--- a/pkg/provider/ocudu/wsclient_test.go
+++ b/pkg/provider/ocudu/wsclient_test.go
@@ -380,17 +380,91 @@ func TestPushNTNConfigUpdate_WSS_RefusesRedirectDowngrade(t *testing.T) {
 	if err == nil {
 		t.Fatal("a handshake that 302-redirects must fail, not be followed")
 	}
-	// And it must be classified PERMANENT (a refused redirect is a config/attack, not a
-	// transient blip) so the reconciler does not tight-requeue it every minute.
+	// And it must be classified as a slow self-heal (a refused redirect is a proxy/config
+	// problem, not a transient blip) so the reconciler polls for the fix instead of either
+	// tight-requeuing every minute or giving up on the cell forever.
 	var we *wsError
-	if !errors.As(err, &we) || we.retryable() {
-		t.Fatalf("a refused-redirect handshake must be non-retryable (permanent), got %v", err)
+	if !errors.As(err, &we) || we.retryPolicy() != wsRetrySlow {
+		t.Fatalf("a refused-redirect handshake must poll slowly (wsRetrySlow), got %v", err)
 	}
 	mu.Lock()
 	leaked := plaintextSawAuth
 	mu.Unlock()
 	if leaked {
 		t.Fatal("SECURITY: the bearer Authorization header was sent to the plaintext redirect target")
+	}
+}
+
+// A non-101 handshake response must be classified by what actually fixes it, not by the
+// 3xx/4xx band alone. 408/425 ask for the same request again (RFC 9110 §15.5.9, RFC 8470
+// §5.2) and stay on the tight cadence; every other refusal — a redirect, 401/403 after a
+// credential rotation, 429 from a proxy, a plain 4xx — is fixed by external state that no
+// controller watch observes, so it polls. NOTHING in this range may be "never retry":
+// that is reserved for failures whose fix bumps the generation and re-triggers reconcile.
+func TestPushNTNConfigUpdate_HandshakeStatusRetryPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		status int
+		want   wsRetryPolicy
+		why    string
+	}{
+		{http.StatusMovedPermanently, wsRetrySlow, "301: never followed, but the proxy rule behind it can be fixed"},
+		{http.StatusFound, wsRetrySlow, "302: same as 301"},
+		{http.StatusTemporaryRedirect, wsRetrySlow, "307: same as 301"},
+		{http.StatusPermanentRedirect, wsRetrySlow, "308: same as 301"},
+		{http.StatusBadRequest, wsRetrySlow, "400: the gNB/proxy is external state, not a watched spec field"},
+		{http.StatusUnauthorized, wsRetrySlow, "401: a rotated credential must be picked up without a spec edit"},
+		{http.StatusForbidden, wsRetrySlow, "403: an auth policy change must be picked up without a spec edit"},
+		{http.StatusNotFound, wsRetrySlow, "404: the remote_control route can come back when the gNB restarts"},
+		{http.StatusMethodNotAllowed, wsRetrySlow, "405: a proxy that strips Upgrade can be reconfigured"},
+		{http.StatusRequestTimeout, wsRetryTight, "408: RFC 9110 §15.5.9 — the client MAY repeat the request"},
+		{http.StatusTooEarly, wsRetryTight, "425: RFC 8470 §5.2 — retry once the early-data replay risk is gone"},
+		{http.StatusTooManyRequests, wsRetrySlow, "429: transient, but hammering at 1/min is exactly what it forbids"},
+		{http.StatusInternalServerError, wsRetryTight, "500: a server-side blip is the transient case"},
+		{http.StatusServiceUnavailable, wsRetryTight, "503: same as 500"},
+	} {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			t.Cleanup(srv.Close)
+
+			target := provider.ResolvedRemoteControl{Endpoint: strings.TrimPrefix(srv.URL, "http://")}
+			env, _ := buildNTNConfigUpdate(ecefRuntimeUpdate())
+			err := pushNTNConfigUpdate(context.Background(), target, env)
+			if err == nil {
+				t.Fatalf("HTTP %d is not a WebSocket upgrade; the dial must fail", tc.status)
+			}
+			var we *wsError
+			if !errors.As(err, &we) {
+				t.Fatalf("want a *wsError, got %T: %v", err, err)
+			}
+			if got := we.retryPolicy(); got != tc.want {
+				t.Errorf("HTTP %d retryPolicy = %d, want %d — %s", tc.status, got, tc.want, tc.why)
+			}
+			if we.retryPolicy() == wsRetryNever {
+				t.Errorf("HTTP %d must never be classified wsRetryNever: no spec edit can fix external state", tc.status)
+			}
+		})
+	}
+}
+
+// The policy must survive the provider boundary: PushRuntimeUpdate collapses a *wsError into
+// a sentinel, and a refused handshake has to arrive as ErrRuntimePushRetryLater — NOT as
+// ErrRuntimePushRejected, which the reconciler treats as "no requeue, ever".
+func TestPushRuntimeUpdate_RefusedHandshakeIsRetryLater(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &Provider{}
+	target := provider.ResolvedRemoteControl{Endpoint: strings.TrimPrefix(srv.URL, "http://")}
+	err := p.PushRuntimeUpdate(context.Background(), target, ecefRuntimeUpdate())
+	if !errors.Is(err, provider.ErrRuntimePushRetryLater) {
+		t.Fatalf("a 401 handshake must surface ErrRuntimePushRetryLater, got %v", err)
+	}
+	if errors.Is(err, provider.ErrRuntimePushRejected) {
+		t.Fatal("a 401 handshake must NOT be permanent: no spec edit rotates the credential, so the cell would never retry")
 	}
 }
 
@@ -402,8 +476,11 @@ func TestPushNTNConfigUpdate_Rejected(t *testing.T) {
 	if !errors.As(err, &we) || we.kind != wsRejected {
 		t.Fatalf("expected wsRejected, got %v", err)
 	}
-	if we.retryable() {
-		t.Error("a gNB rejection must not be retryable")
+	// A post-handshake {"error":...} is the one rejection that IS permanent: the gNB read the
+	// payload and refused its content, and the fix is a spec edit whose generation bump
+	// re-triggers reconcile on its own.
+	if we.retryPolicy() != wsRetryNever {
+		t.Error("a gNB payload rejection must not requeue: its fix is a watched spec change")
 	}
 }
 
@@ -417,8 +494,8 @@ func TestPushNTNConfigUpdate_UnparseableReply(t *testing.T) {
 	if !errors.As(err, &we) {
 		t.Fatalf("expected a *wsError for an unparseable reply, got %v", err)
 	}
-	if !we.retryable() {
-		t.Error("an unparseable reply should be retryable, not a silent success")
+	if we.retryPolicy() != wsRetryTight {
+		t.Error("an unparseable reply should retry tightly, not be a silent success")
 	}
 }
 
@@ -430,8 +507,8 @@ func TestPushNTNConfigUpdate_Unreachable(t *testing.T) {
 	if !errors.As(err, &we) || we.kind != wsUnreachable {
 		t.Fatalf("expected wsUnreachable, got %v", err)
 	}
-	if !we.retryable() {
-		t.Error("an unreachable gNB should be retryable")
+	if we.retryPolicy() != wsRetryTight {
+		t.Error("an unreachable gNB should retry tightly")
 	}
 }
 
@@ -448,8 +525,8 @@ func TestPushNTNConfigUpdate_PayloadTooLarge(t *testing.T) {
 	if !errors.As(err, &we) || we.kind != wsPayloadTooLarge {
 		t.Fatalf("expected wsPayloadTooLarge, got %v", err)
 	}
-	if we.retryable() {
-		t.Error("an oversized frame is a permanent error, not retryable")
+	if we.retryPolicy() != wsRetryNever {
+		t.Error("an oversized frame is permanent: only a spec edit shrinks it, and that is watched")
 	}
 }
 
@@ -523,8 +600,11 @@ func TestProviderPushRuntimeUpdate_UnreachableIsRetryable(t *testing.T) {
 	if errors.Is(err, provider.ErrRuntimePushRejected) {
 		t.Fatalf("an unreachable endpoint must be retryable, not permanent: %v", err)
 	}
+	if errors.Is(err, provider.ErrRuntimePushRetryLater) {
+		t.Fatalf("an unreachable endpoint is transient, not a refused handshake: %v", err)
+	}
 	var we *wsError
-	if !errors.As(err, &we) || !we.retryable() {
-		t.Fatalf("expected a retryable wsError (wsUnreachable), got %v", err)
+	if !errors.As(err, &we) || we.retryPolicy() != wsRetryTight {
+		t.Fatalf("expected a tight-retry wsError (wsUnreachable), got %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

`pushNTNConfigUpdate` classifies **every** non-101 handshake response in the 3xx/4xx band as permanent:

```go
if resp != nil && resp.StatusCode >= 300 && resp.StatusCode < 500 {
    return &wsError{wsHandshakeRejected, ...}
}
```

That becomes `ErrRuntimePushRejected` → `ProviderPushRejected`, which is in `ephemerisPushShouldRequeue`'s no-requeue set.

That set has a precise contract, stated in its own doc comment: *the fix is a **watched** change* — a spec edit bumps the generation, a SatelliteEphemeris refresh brings a new marker — so the reconcile returns on its own and a self-requeue would just hammer a still-failing push.

**A refused handshake never meets that contract.** A 401/403 after a credential rotation, a 429 from a proxy, a redirect from a misconfigured ingress, a 404 from a restarting gNB — all are fixed by state the operator does not watch (the Secret, the proxy, the gNB). Nothing bumps the generation, nothing changes the marker.

This is the *same* wrong assumption #282 already fixed on the **local** credential path: `RemoteControlConfigInvalid` was moved off "no requeue" onto a bounded 5m self-heal poll precisely because a Secret edit does not re-trigger reconcile. The **remote** rejection path kept the old behaviour — so the operator treats "I couldn't read the credential" as recoverable and "the gNB rejected the credential I read" as terminal.

### Honest scoping of the impact

The cell is **not** permanently dead today: the NTNCellConfig↔SatelliteEphemeris watch carries no predicate, and the producer's ~3-minute propagation heartbeat always writes status, so the fan-out re-drives the push roughly every 3 minutes. Recovery in the common case is already ~3 min, not "never".

The real defects are:
1. Correctness of the self-heal contract — recovery depends on a *different* CR's heartbeat. If that producer stalls, is paused, or the cell's ephemeris stops advancing, the cell is stranded until the 10h controller-runtime resync. `ntncellconfig_controller.go` already says this in prose ("and never if the producer stalls") — for the other path.
2. 408 and 425 are simply misclassified: both explicitly invite the client to repeat the same request (RFC 9110 §15.5.9, RFC 8470 §5.2).
3. 429 is definitionally transient and was treated as terminal.

## Change

- `wsError` gets a three-valued `retryPolicy()` — **tight / slow / never** — replacing the `retryable() bool`. "Must not tight-requeue" and "must never retry" are different claims, and only the second is safe when the fix is unwatched.
- A refused handshake surfaces a new `provider.ErrRuntimePushRetryLater` sentinel and a new `RemoteEndpointRejected` condition reason, requeued on the same bounded 5m poll as `RemoteControlConfigInvalid`.
- 408 / 425 reclassified transient (tight cadence).
- 5xx and connection-level failures: unchanged, already transient.
- Redirects are **still never followed** — the `ErrUseLastResponse` bearer-downgrade guard is untouched. They are retried later, not written off.
- A post-handshake gNB `{"error":...}` **stays permanent**: there the fix genuinely is a spec edit, which is watched.

## Deliberately not done

- **429 does not parse `Retry-After`.** Plumbing a duration through a sentinel-based error API is real complexity for a speculative gNB-side rate limiter. The fixed 5m poll is strictly gentler than the 1m tight retry the review proposed and needs no header parsing. If a real rate-limiting proxy shows up, that is the moment to add it.
- **A 2xx answer to an Upgrade** (a proxy that swallows `Upgrade`) still takes the tight cadence — unchanged from before this PR, and erring toward faster recovery is harmless there.
- **`wsRejected` (post-handshake `{"error":...}`) left permanent.** A gNB that rejects because its cell is not yet provisioned would benefit from the same poll, but that is a different failure surface with a different argument, and it would change an established tested contract. Flagged for a separate decision rather than folded in here.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2` (the real one, custom plugins): **0 issues**.
- `go test ./internal/controller/... ./pkg/...` green; `-race` green.
- Merge-skew check per the parallel-PR rule: #295 touches the same file (`wsclient.go`, the dial options). Merged the real HEAD locally — clean merge, build + tests green, and #295 does not touch the `retryable()` API this PR removes.
- **Mutation-verified** (each reverted in turn, confirming the tests fail for the right reason):
  - handshake rejection → `wsRetryNever`: all rejection cases red, 408/425 stay green.
  - remove the 408/425 carve-out: **only** `Request_Timeout` and `Too_Early` red.
  - drop `RemoteEndpointRejected` from the slow-poll set: requeue assertion red at `1m0s, want 5m0s`.

New tests pin the policy for 14 status codes end-to-end through the provider boundary, and assert that **nothing** in the handshake range can be classified never-retry.

## Operational note

A 401 previously incremented `ephemeris_push_errors_total{reason="ProviderPushRejected"}` exactly once. It now increments `{reason="RemoteEndpointRejected"}` every 5m while broken, so **NTNEphemerisPushFailing** (the `increase[15m]` alert) now fires for it too, alongside **NTNEphemerisPushNotReady**. Runbook updated with the new reason and its triage.

No CRD schema change (a condition reason value, not a field), so no `make manifests bundle nephio-sync` needed.


---

## ⚠ Merge order vs #296 — resolution verified locally

#296 is open on the **same function** (`ephemerisPushRequeueInterval`) and renames `ephemerisReasonRemoteControlConfig` → `ephemerisReasonRemoteControlCredential`. Whichever of the two lands second needs a manual resolution. I merged them locally and verified the result, so the resolution is not guesswork:

**Conflicts git DOES flag** (2 files): `internal/controller/ntncellconfig_controller.go`, `pkg/provider/ocudu/wsclient.go`.

- `wsclient.go` — #296's hunk is a **comment-only** edit (it drops the "(mirroring RemoteControlConfigInvalid)" phrase). This PR rewrites that whole comment and adds the 408/425 carve-out. **Take this PR's side.**
- `ntncellconfig_controller.go` — a **union**: keep #296's `ephemerisReasonRemoteControlCredential` (and its oracle rationale) *and* this PR's `ephemerisReasonRemoteEndpointRejected`; `ephemerisPushRequeueInterval` becomes a `switch` listing **both** in the 5m case.

**The one git does NOT flag — this is the dangerous one:** `internal/controller/runtime_push_test.go` **auto-merges cleanly and then fails to compile**, because this PR adds `ephemerisReasonRemoteControlConfig` to the requeue list in `TestEphemerisPushShouldRequeue` and #296 deletes that identifier. Same shape as the #289/#291 → #293 skew. After resolving, rename the identifier there too and rebuild the real merged HEAD.

Verified: with those resolutions the merged tree builds, `go vet` is clean, and `./internal/controller/... ./pkg/provider/...` pass.

To shrink the blast radius, the last commit here **reverts a purely cosmetic rename** (`remoteControlConfigRequeue` → `unwatchedFixRequeue`). That drops `ntncellconfig_tls_test.go` — which #296 rewrites — from this PR's diff entirely, taking the conflict from three files to two.

**No semantic conflict.** #296 makes the credential-failure cadence uniform to close a Secret existence oracle; `RemoteEndpointRejected` uses the *same* 5m cadence, so it adds no differential signal. It is also only reachable *after* credential resolution has already succeeded, so it reveals nothing about Secret existence or type that a successful push would not.


---

**Skew note refreshed (main @ `3ca522c`).** This PR's own merged HEAD against current `main` is **green** — build, `go vet`, and `./internal/controller/... ./pkg/...` (8 packages, no failures).

The #296 resolution written above was derived against `d83de6e` and is **stale**: #296 no longer compiles against `main` on its own, because #300 added a new use of the constant #296 deletes (see thc1006/ntn-operators#296 for the one-line fix). The resolution here will be re-derived once #296 is rebased. Nothing to do on this branch.
