### PR TITLE
feat(ntncellconfig): interim confused-deputy endpoint allow-list for credentialed pushes (#251, ADR-0009)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,6 +165,15 @@ func main() {
 			"Set this only to enable internal CelesTrak mirrors (e.g. air-gapped "+
 			"deployments) or E2E test mock servers. Production clusters with public "+
 			"CelesTrak access should leave this empty.")
+	var remoteControlAllowedHosts string
+	flag.StringVar(&remoteControlAllowedHosts, "remote-control-allowed-endpoint-hosts", "",
+		"Comma-separated list of hostnames a CREDENTIALED NTNCellConfig "+
+			"spec.provider.remoteControl (remoteControl.tls set) may push to. Empty (default) "+
+			"permits any endpoint (opt-in). When set, a credentialed push to a host not on the "+
+			"list is refused BEFORE the credential leaves the operator — an interim confused-deputy "+
+			"boundary (#251) so a principal who can write NTNCellConfig but not read the referenced "+
+			"Secret cannot aim a labelled credential at an arbitrary host. Plaintext pushes "+
+			"(no remoteControl.tls) are never gated.")
 	// Default to the Zap PRODUCTION config (JSON encoder, info level, sampling,
 	// error-level stacktraces) rather than the kubebuilder scaffold's Development
 	// default (console, warning stacktraces, no sampling), so a deployed operator
@@ -277,12 +286,13 @@ func main() {
 		"ocudu": ocudu.NewProvider(mgr.GetClient()).WithAPIReader(mgr.GetAPIReader()),
 	}
 	if err := (&controller.NTNCellConfigReconciler{
-		Client:                  mgr.GetClient(),
-		APIReader:               mgr.GetAPIReader(),
-		Scheme:                  mgr.GetScheme(),
-		Recorder:                mgr.GetEventRecorder("ntncellconfig-controller"),
-		Providers:               providers,
-		MaxConcurrentReconciles: maxConcurrentReconciles,
+		Client:                    mgr.GetClient(),
+		APIReader:                 mgr.GetAPIReader(),
+		Scheme:                    mgr.GetScheme(),
+		Recorder:                  mgr.GetEventRecorder("ntncellconfig-controller"),
+		Providers:                 providers,
+		MaxConcurrentReconciles:   maxConcurrentReconciles,
+		RemoteControlAllowedHosts: netutil.ParseEndpointAllowlist(remoteControlAllowedHosts),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NTNCellConfig")
 		os.Exit(1)

--- a/docs/adr/0009-remote-control-credential-confused-deputy.md
+++ b/docs/adr/0009-remote-control-credential-confused-deputy.md
@@ -1,0 +1,48 @@
+# ADR 0009 — Confused-deputy boundary for remoteControl.tls credential reads
+
+- Status: **Accepted** (interim endpoint allow-list shipped here); full per-CR authorization **deferred**
+- Date: 2026-07-31
+- Deciders: @thc1006
+- Relates to: #219 (label/type opt-in gate), #251 (this confused-deputy follow-up), the N-12 runtime TLS/bearer/mTLS push. Builds on the existing SSRF allow-list (`--prometheus-allowed-endpoint-hosts`, `--ephemeris-allowed-private-hosts`) and `pkg/netutil.EndpointAllowlist`.
+
+## Context
+
+`NTNCellConfig.spec.provider.remoteControl.tls.secretName` references a Secret (in the CR's own namespace) holding a bearer token and/or mTLS client cert + key. The operator reads that Secret (with its `secrets get`) and authenticates to `remoteControl.endpoint` — an **arbitrary, CR-author-controlled `host:port`** (the endpoint CEL validates only *format*, not destination).
+
+This is a **confused deputy**: the operator lends its Secret-read privilege on behalf of whoever wrote the CR.
+
+- The shipped `ntncellconfig-editor-role` grants `create/update/patch/get` on `NTNCellConfig` but **no** `secrets get`. A principal with that role — but who cannot read the Secret — can create an NTNCellConfig that points a labelled credential at an **attacker endpoint**.
+- For a **bearer** token this is direct **credential exfiltration** (the token is sent as `Authorization: Bearer`). For **mTLS** it is identity *misuse* (the operator authenticates to the attacker with its client identity; the private key is proven, not transmitted) — lower impact but still a confused deputy.
+
+The #219 mitigation — the Secret owner must label it `ntn.operators.dev/remote-control-credential: true`, and API-credential Secret types are refused — reduces *which* Secrets can be targeted but is **not an authorization boundary**: the label is namespace-scoped, so **any** NTNCellConfig in the namespace may use **any** labelled Secret, and it does not bind the *endpoint*. The code comment on `RemoteControlTLS.secretName` already states this; #251 tracks the real fix.
+
+## Decision
+
+Two-part, matching the actual (same-namespace, low-adoption) shape of the problem:
+
+1. **Ship an admin endpoint allow-list now** (this PR) as the interim boundary. `--remote-control-allowed-endpoint-hosts` gates the endpoint a **credentialed** push may target: when set, a push whose `remoteControl.tls` is present and whose endpoint host is not on the list is **refused before the referenced Secret is even read** (`RemoteControlConfigInvalid`, bounded self-heal requeue) — so no credential leaves the operator, and the refusal is identical whether or not the Secret resolves (no "Secret is valid" oracle). Empty (default) = permit-all (opt-in), so existing deployments and all plaintext pushes are unaffected. This closes the **worst** outcome — bearer exfiltration to an external host — because the destination is now admin-controlled (the CR author cannot change it), and it composes with the egress NetworkPolicy.
+
+2. **Defer the full per-CR authorization**, and when it is built, prefer **SubjectAccessReview at admission ("the principal creating the reference must be able to read the Secret")** over a ReferenceGrant-style CRD. Rationale below.
+
+## Rationale
+
+- **This is same-namespace.** The Secret lives in the NTNCellConfig's own namespace. The standard same-namespace confused-deputy fix is "if you can reference the Secret, you must be able to read it" — a SAR against the *requester* at admission. That reuses existing RBAC and needs no new API surface. ReferenceGrant (Gateway API) exists for the **cross**-namespace case, where the source's RBAC cannot be checked from the sink; applying its owner-opt-in-object machinery to a same-namespace reference is heavier than the problem warrants.
+- **The feature is advanced and uncommon.** OCUDU's `remote_control` server is plaintext/unauthenticated localhost by default; the safe deployment is a gNB sidecar. Credentialed (wss:///bearer/mTLS) remote control is a minority deployment. A whole grant-CRD subsystem (new CRD + controller + lifecycle + 4-copy CRD sync + samples/chart) for a minority feature is disproportionate.
+- **Endpoint hardening is the highest-leverage, lowest-cost control** and is strictly beneficial under *any* eventual design: the exfiltration requires an attacker *destination*, so constraining the destination neuters it regardless of which reference-authz model lands later.
+- **SAR needs infrastructure we do not have yet.** There is no admission webhook in the operator today; a SAR check requires the requester identity (`req.UserInfo`), which a reconcile does not carry — only a validating webhook does. That is real infrastructure (serving cert, `failurePolicy`, envtest wiring) and should be a deliberate, separately-reviewed step, not bundled here.
+
+## Consequences
+
+- The interim boundary is **opt-in** (empty allow-list permits all) to avoid breaking existing credentialed deployments on upgrade. Operators who use credentials SHOULD set `--remote-control-allowed-endpoint-hosts` to the sanctioned gNB hosts; until they do, the #219 label gate + the RBAC guidance ("do not grant `NTNCellConfig` write to principals who should not use every labelled credential") remain the only controls, as today.
+- A future tightening (fail-closed default once adoption is understood) or the full SAR boundary is a follow-up on #251; this ADR does not close #251, it de-risks it and records the recommended direction.
+- No API/CRD change: the endpoint field and label gate are unchanged; this adds one operator flag and one controller check.
+
+## Alternatives considered
+
+- **ReferenceGrant-style `RemoteControlCredentialGrant` CRD** (the reviewer's proposal: `secretRef` + `allowedNTNCellConfig{name,uid}` + `allowedEndpoint`). Strongest binding (owner opt-in, per-CR-UID, per-endpoint), but a cross-namespace pattern applied to a same-namespace, minority feature — disproportionate. Not rejected on merit for a future cross-namespace credential story; deferred as over-scoped for #251.
+- **SAR admission webhook** (requester must be able to read the Secret). The recommended *full* fix; deferred because it requires building webhook infrastructure from zero. Recorded as the preferred direction for #251.
+- **Do nothing beyond #219.** Rejected: the shipped editor-role makes the confused deputy reachable under the default role model, and a documented-but-unmitigated credential-exfil path is too weak for the credentialed feature.
+
+## Testing
+
+`TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist` pins all four arms: a credentialed push to a non-allowlisted endpoint is refused (`RemoteControlConfigInvalid`, `errRemoteControlEndpointNotAllowed`) **and the provider is never called** (the credential does not leave the operator) — the refused case provisions **no** Secret, so getting the endpoint error (rather than credential-unavailable) proves the endpoint is checked before the Secret read (no oracle); an allowlisted credentialed push proceeds; an empty allow-list permits any endpoint (opt-in); and a plaintext push is never gated. Mutation-verified by neutering the `rc.TLS != nil` check (the attacker-endpoint case then pushes).

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -49,6 +49,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
@@ -64,6 +65,11 @@ type NTNCellConfigReconciler struct {
 	Recorder                events.EventRecorder
 	Providers               map[string]provider.NTNProvider
 	MaxConcurrentReconciles int
+	// RemoteControlAllowedHosts gates the endpoint a CREDENTIALED remoteControl.tls push may target
+	// (#251 confused-deputy containment). Empty = permit-all (opt-in), so existing deployments are
+	// unaffected; when set, a credentialed push to a host not on the list is refused before the
+	// credential is sent. Plaintext pushes are never gated. Interim boundary — see ADR-0009.
+	RemoteControlAllowedHosts netutil.EndpointAllowlist
 }
 
 const (
@@ -761,6 +767,22 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 			update.SatSwitch = spec.NTN.SatSwitchWithResync
 		}
 	}
+	// Confused-deputy containment (#251): when a credential is attached, the destination must be on the
+	// admin allow-list. Checked BEFORE the Secret is read, so a non-allowlisted endpoint is refused
+	// without touching the credential — no needless Secret read, and (unlike a post-resolve check) no
+	// "Secret is valid" oracle: the refusal is identical whether or not the Secret resolves. The endpoint
+	// is CR-author-controlled, so without this a principal who can write NTNCellConfig but not read the
+	// Secret could aim a labelled credential at an attacker host and exfiltrate it. Empty allow-list =
+	// opt-in (Check permits all); plaintext pushes (no rc.TLS) are never gated (nothing to exfiltrate).
+	// See ADR-0009. The synthetic https:// prefix lets EndpointAllowlist.Check parse the host:port
+	// endpoint (the CRD forbids a scheme in the field).
+	if rc := spec.Provider.RemoteControl; rc.TLS != nil {
+		if err := r.RemoteControlAllowedHosts.Check("https://" + rc.Endpoint); err != nil {
+			logf.FromContext(ctx).Error(err, "refusing to send a remoteControl.tls credential to an "+
+				"endpoint outside --remote-control-allowed-endpoint-hosts", "cell", cc.Name, "endpoint", rc.Endpoint)
+			return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlConfig, errRemoteControlEndpointNotAllowed)
+		}
+	}
 	// Resolve opt-in transport security (wss:// + shared secret / mTLS) from the
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
 	tlsConfig, authToken, tlsErr := r.resolveRemoteControlTLS(ctx, eph.Namespace, spec.Provider.RemoteControl)
@@ -841,6 +863,12 @@ var errRemoteControlCredentialInvalid = errors.New("not a usable remote-control 
 // on the CR condition/event: it would otherwise let a principal who can write the CR
 // but not read Secrets probe Secret existence and type (an oracle).
 var errRemoteControlCredentialUnavailable = errors.New("referenced remote-control credential is unavailable or not authorized")
+
+// errRemoteControlEndpointNotAllowed tags a credentialed push whose endpoint is outside the operator's
+// --remote-control-allowed-endpoint-hosts allow-list (#251). Unlike the credential-unavailable message
+// this is NOT a Secret oracle — the endpoint is CR-author-set and already known to the writer — so it
+// names the endpoint. It is deterministic (config), so it self-heals on a spec/flag change, not a retry.
+var errRemoteControlEndpointNotAllowed = errors.New("remoteControl.tls endpoint is not in the operator's remote-control allow-list")
 
 // resolveRemoteControlTLS builds the TLS config and bearer token for the runtime
 // push from the Secret referenced by remoteControl.tls. It reads the Secret from

--- a/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
+++ b/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist pins the #251 confused-deputy interim
+// boundary (ADR-0009): a CREDENTIALED remoteControl.tls push is refused BEFORE the credential is sent
+// when its endpoint host is outside --remote-control-allowed-endpoint-hosts. An empty allow-list permits
+// any endpoint (opt-in), and a plaintext push (no credential to exfiltrate) is never gated. Mutation:
+// drop the `tlsConfig != nil` allow-list check and the "attacker endpoint" case pushes (the mock is
+// called), failing the "must NOT be sent" assertion.
+func TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	certPEM, _ := selfSignedPEM(t)
+
+	// run performs one push with the given allow-list CSV and endpoint. withTLS sets remoteControl.tls
+	// (makes it a credentialed push); withSecret provisions the opted-in Secret. Returns the push error
+	// and whether the provider was actually invoked (i.e. the credential left the operator).
+	run := func(t *testing.T, allow, endpoint string, withTLS, withSecret bool) (error, bool) {
+		t.Helper()
+		eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+		objs := []client.Object{eph}
+		cc := ccWithRemoteControl()
+		cc.Spec.Provider.RemoteControl.Endpoint = endpoint
+		if withTLS {
+			cc.Spec.Provider.RemoteControl.TLS = &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "cred"}
+		}
+		if withSecret {
+			objs = append(objs, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cred", Namespace: eph.Namespace,
+					Labels: map[string]string{remoteControlCredentialLabel: "true"},
+				},
+				Data: map[string][]byte{"ca.crt": certPEM},
+			})
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		r := &NTNCellConfigReconciler{
+			Client: c, APIReader: c,
+			RemoteControlAllowedHosts: netutil.ParseEndpointAllowlist(allow),
+		}
+		mock := &provider.MockProvider{}
+		_, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+		return err, mock.LastTarget != nil
+	}
+
+	t.Run("credentialed push to a non-allowlisted endpoint is refused before the Secret is read", func(t *testing.T) {
+		// No Secret is provisioned on purpose: the endpoint check must run FIRST, so the refusal is
+		// errRemoteControlEndpointNotAllowed — NOT the credential-unavailable error a missing Secret
+		// would give if resolution ran first. This proves there is no "Secret is valid" oracle.
+		err, pushed := run(t, "gnb.allowed.svc", "attacker.evil.example:8001", true, false)
+		if err == nil || !errors.Is(err, errRemoteControlEndpointNotAllowed) {
+			t.Fatalf("want errRemoteControlEndpointNotAllowed (endpoint checked before the Secret read), got %v", err)
+		}
+		if reason := ephemerisPushConditionReason(err); reason != ephemerisReasonRemoteControlConfig {
+			t.Fatalf("must classify as %q, got %q", ephemerisReasonRemoteControlConfig, reason)
+		}
+		if pushed {
+			t.Fatal("the credential must NOT be sent to a non-allowlisted endpoint (the provider was called)")
+		}
+	})
+
+	t.Run("credentialed push to an allowlisted endpoint proceeds", func(t *testing.T) {
+		err, pushed := run(t, "gnb.allowed.svc", "gnb.allowed.svc:8001", true, true)
+		if err != nil {
+			t.Fatalf("an allowlisted credentialed push must proceed, got %v", err)
+		}
+		if !pushed {
+			t.Fatal("an allowlisted credentialed push must reach the provider")
+		}
+	})
+
+	t.Run("empty allow-list permits any endpoint (opt-in)", func(t *testing.T) {
+		err, pushed := run(t, "", "attacker.evil.example:8001", true, true)
+		if err != nil {
+			t.Fatalf("an empty allow-list must permit any endpoint, got %v", err)
+		}
+		if !pushed {
+			t.Fatal("an empty allow-list must let the credentialed push proceed")
+		}
+	})
+
+	t.Run("plaintext push is never gated by the allow-list", func(t *testing.T) {
+		err, pushed := run(t, "gnb.allowed.svc", "attacker.evil.example:8001", false, false)
+		if err != nil {
+			t.Fatalf("a plaintext push must not be gated, got %v", err)
+		}
+		if !pushed {
+			t.Fatal("a plaintext push must proceed regardless of the allow-list")
+		}
+	})
+}


### PR DESCRIPTION
## What

Interim confused-deputy boundary for `remoteControl.tls` credential reads (**#251**, follow-up to #219), plus **ADR-0009** recording the design decision. **No API/CRD change** — one operator flag + one controller check + an ADR.

## The problem (verified against `main`)

`remoteControl.tls.secretName` references a Secret (bearer / mTLS) that the operator reads (`secrets:get`) and sends to `remoteControl.endpoint` — an **arbitrary, CR-author-controlled `host:port`** (the endpoint CEL validates only format). The shipped `ntncellconfig-editor-role` grants `NTNCellConfig` write but **no** `secrets:get`, so a principal who cannot read the Secret can point a labelled credential at an attacker endpoint and **exfiltrate the bearer** (or misuse the mTLS identity).

The #219 label gate is, by its own doc comment, *"a mitigation, not a full authorization boundary"* — namespace-scoped, and it does not bind the endpoint. #251 tracks the real fix; it was open with no PR because it's an architecture decision.

## Decision (ADR-0009)

This is a **same-namespace, low-adoption** feature (OCUDU `remote_control` is plaintext/unauthenticated localhost by default). So:

- **Defer** the full per-CR authorization, and when built prefer **SAR-at-admission** ("the principal referencing the Secret must be able to read it") over a **ReferenceGrant-style CRD** — ReferenceGrant is a *cross*-namespace pattern, disproportionate here; SAR needs admission-webhook infra the operator doesn't have yet, so it's a separate, deliberate step.
- **Ship the proportionate interim boundary now**: an admin endpoint allow-list. It's the highest-leverage, lowest-cost control and helps under *any* eventual design (the exfil needs an attacker *destination*).

## Change

`--remote-control-allowed-endpoint-hosts` gates the destination of a **credentialed** push. When set, a push whose `remoteControl.tls` is present and whose endpoint host is not on the list is **refused before the Secret is even read** (`RemoteControlConfigInvalid`, bounded self-heal requeue): no credential leaves the operator, and the refusal is identical whether or not the Secret resolves — **no Secret-validity oracle** (the existing `errRemoteControlCredentialUnavailable` was made uniform to avoid exactly that oracle; checking the endpoint *before* the read preserves it). Empty (default) = permit-all (opt-in), so existing deployments and all **plaintext** pushes are unaffected. Reuses `pkg/netutil.EndpointAllowlist`.

## Test

`TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist` — non-allowlisted credentialed endpoint refused with the **provider never called**; the refused case provisions **no Secret**, so getting the endpoint error (not credential-unavailable) proves the endpoint is checked **before** the Secret read. Allowlisted proceeds; empty permits; plaintext ungated. Mutation-verified (neutering the `rc.TLS != nil` check flips the refused case to credential-unavailable + push). `gofmt` / `go vet` / `golangci-lint` clean; full controller + cmd suites pass.
