### PR TITLE
fix(provider): reclaim a legacy unowned ConfigMap on the deletion path too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ApplyCellConfig` adopts under, extracted into a single shared `isAdoptableLeftover` so the two
   cannot drift apart again. This grants no new destructive power: adoption already ends in
   deletion, because an adopted ConfigMap carries a controller reference and is GC-cascaded when the
-  CR goes away. A ConfigMap owned by a different controller, an unlabeled foreign object, and a
+  CR goes away. The shared predicate is also **tightened**: it now requires the ConfigMap to have NO
+  owner references at all, not merely no *controller* owner reference. A ConfigMap carrying a plain
+  owner reference already belongs to another object's lifecycle, and adopting it would make the
+  operator a second owner that deletes it when this CR goes away while the other owner still claims
+  it. This excludes nothing real — the pre-atomic-ref version created the ConfigMap with no owner
+  references and its `EnsureOwnership` back-fill used `SetControllerReference` in a single `Update`,
+  so a genuine leftover has either our controller reference or none. A ConfigMap owned by a different controller, an unlabeled foreign object, and a
   labeled-but-empty impostor are still left untouched, and the skip is now logged. Mutation-tested.
 
 - **SGP4 propagation failures are now surfaced, not silently dropped.** A tracked element set that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A legacy unowned ConfigMap is no longer leaked when the CR is deleted before its first
+  reconcile.** #210 reclaims pre-atomic-reference artifacts — a ConfigMap carrying the operator's
+  management labels and its `geo_ntn.yml` key but no owner reference, left behind when an older
+  version's best-effort `EnsureOwnership` write did not land — by **adopting** them in
+  `ApplyCellConfig`. But the reconciler runs the finalizer FIRST, so a CR deleted before any
+  successful post-upgrade reconcile never reaches `ApplyCellConfig`: `Cleanup` required strict
+  controller ownership, skipped the unowned leftover, removed the finalizer, and the ConfigMap was
+  orphaned with nothing left that could ever reclaim it — the exact artifact class #210 set out to
+  recover, on the one path it did not cover. `Cleanup` now deletes under the SAME predicate
+  `ApplyCellConfig` adopts under, extracted into a single shared `isAdoptableLeftover` so the two
+  cannot drift apart again. This grants no new destructive power: adoption already ends in
+  deletion, because an adopted ConfigMap carries a controller reference and is GC-cascaded when the
+  CR goes away. A ConfigMap owned by a different controller, an unlabeled foreign object, and a
+  labeled-but-empty impostor are still left untouched, and the skip is now logged. Mutation-tested.
+
 - **SGP4 propagation failures are now surfaced, not silently dropped.** A tracked element set that
   passed the epoch checks but failed `PropagateToECEF` (OMM→TLE conversion, propagation, or ECEF range
   validation) was dropped from `propagatedStates` with a bare `continue` — no condition, metric, or

--- a/internal/controller/ntncellconfig_legacy_cleanup_test.go
+++ b/internal/controller/ntncellconfig_legacy_cleanup_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
+)
+
+// legacyConfigMap is a pre-atomic-reference artifact: the operator's management labels and
+// its config key, but NO owner reference — the state an older version left behind when its
+// best-effort EnsureOwnership second write did not land (#210's root cause).
+func legacyConfigMap(ns, crName string, labeled bool, data string) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: ocudu.ConfigMapNameFor(crName), Namespace: ns},
+	}
+	if labeled {
+		cm.Labels = map[string]string{
+			"app.kubernetes.io/managed-by": "ntn-operators",
+			"app.kubernetes.io/component":  "ocudu-ntn-config",
+		}
+	}
+	if data != "" {
+		cm.Data = map[string]string{"geo_ntn.yml": data}
+	}
+	return cm
+}
+
+// TestFinalizer_DeletesLegacyUnownedConfigMap walks the deletion-first path that #210 left
+// uncovered. Adoption lives in ApplyCellConfig, but the reconciler runs handleFinalizer
+// FIRST, so a CR deleted before any successful post-upgrade reconcile never reaches Apply:
+//
+//	old operator creates the ConfigMap → its EnsureOwnership write fails → no owner ref →
+//	upgrade → CR deleted before the first reconcile adopts it → cleanup skipped it →
+//	finalizer removed → CR gone, ConfigMap orphaned with nothing left to reclaim it.
+//
+// The finalizer must now reclaim exactly the object class ApplyCellConfig would have adopted.
+func TestFinalizer_DeletesLegacyUnownedConfigMap(t *testing.T) {
+	const ns, name = "ntn-system", "legacy-cell"
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+
+	cc := &ntnv1alpha1.NTNCellConfig{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: ns, UID: types.UID("uid-" + name),
+		Finalizers:        []string{"ntn.operators.dev/configmap-cleanup"},
+		DeletionTimestamp: &metav1.Time{Time: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)},
+	}}
+	legacy := legacyConfigMap(ns, name, true, "left by an older operator version")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cc, legacy).Build()
+	r := &NTNCellConfigReconciler{Client: c, Scheme: scheme}
+	prov := ocudu.NewProvider(c)
+
+	done, _, err := r.handleFinalizer(context.Background(), cc, prov)
+	if !done {
+		t.Fatal("handleFinalizer must take over on a deletion-timestamped CR")
+	}
+	if err != nil {
+		t.Fatalf("finalization failed: %v", err)
+	}
+
+	got := &corev1.ConfigMap{}
+	getErr := c.Get(context.Background(), types.NamespacedName{Name: ocudu.ConfigMapNameFor(name), Namespace: ns}, got)
+	if !apierrors.IsNotFound(getErr) {
+		t.Fatalf("the legacy ConfigMap leaked: it must be reclaimed on the deletion path, got err=%v", getErr)
+	}
+	if controllerutil.ContainsFinalizer(cc, "ntn.operators.dev/configmap-cleanup") {
+		t.Error("the finalizer must be removed once cleanup succeeded")
+	}
+}
+
+// A ConfigMap the operator cannot prove is its own must SURVIVE the finalizer. Deleting on
+// labels alone would let a squatter be destroyed by an unrelated CR's deletion, and an
+// unlabeled object at the same name is simply not ours. These are the cases where leaving the
+// object behind is the correct outcome, not a leak.
+func TestFinalizer_LeavesForeignConfigMapsIntact(t *testing.T) {
+	const ns, name = "ntn-system", "legacy-cell"
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cm   *corev1.ConfigMap
+		why  string
+	}{
+		{"unlabeled", legacyConfigMap(ns, name, false, "someone else's data"),
+			"an unlabeled object at our name was never ours"},
+		{"labeled but no config key", legacyConfigMap(ns, name, true, ""),
+			"a labeled-but-empty impostor never held our config"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := &ntnv1alpha1.NTNCellConfig{ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns, UID: types.UID("uid-" + name),
+				Finalizers:        []string{"ntn.operators.dev/configmap-cleanup"},
+				DeletionTimestamp: &metav1.Time{Time: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)},
+			}}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cc, tc.cm.DeepCopy()).Build()
+			r := &NTNCellConfigReconciler{Client: c, Scheme: scheme}
+
+			if _, _, err := r.handleFinalizer(context.Background(), cc, ocudu.NewProvider(c)); err != nil {
+				t.Fatalf("finalization failed: %v", err)
+			}
+			key := types.NamespacedName{Name: ocudu.ConfigMapNameFor(name), Namespace: ns}
+			if err := c.Get(context.Background(), key, &corev1.ConfigMap{}); err != nil {
+				t.Fatalf("%s — it must survive the finalizer, got err=%v", tc.why, err)
+			}
+		})
+	}
+}

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -108,8 +108,16 @@ func isOperatorManaged(cm *corev1.ConfigMap) bool {
 }
 
 // isAdoptableLeftover reports whether cm is an unowned artifact of THIS provider left by a
-// pre-atomic-reference version: no controller at all, our management labels, and a non-empty
-// config key (a labeled-but-empty impostor never held our config, so it is not ours).
+// pre-atomic-reference version: NO owner references at all, our management labels, and a
+// non-empty config key (a labeled-but-empty impostor never held our config, so it is not ours).
+//
+// "No owner references" rather than "no CONTROLLER owner reference" is deliberate. A ConfigMap
+// carrying a non-controller owner reference already belongs to something else's lifecycle;
+// adopting it would make us a second owner and — with Cleanup below — delete it when this CR
+// goes away, while the other owner still claims it. The tighter test costs nothing here: the
+// pre-atomic-ref version wrote the ConfigMap with no owner references at all and its
+// EnsureOwnership back-fill used SetControllerReference in a single Update, so a genuine
+// leftover either has our controller reference or has none — never a partial non-controller one.
 //
 // Shared by ApplyCellConfig (which adopts such an object) and Cleanup (which deletes it) so
 // the two can never drift apart. The drift was the bug: adoption ends in deletion anyway —
@@ -118,7 +126,7 @@ func isOperatorManaged(cm *corev1.ConfigMap) bool {
 // It only leaked the object when the CR was deleted before any reconcile got to adopt it,
 // which is the deletion-first path #210 left uncovered.
 func isAdoptableLeftover(cm *corev1.ConfigMap) bool {
-	return metav1.GetControllerOf(cm) == nil && isOperatorManaged(cm) && cm.Data[configDataKey] != ""
+	return len(cm.OwnerReferences) == 0 && isOperatorManaged(cm) && cm.Data[configDataKey] != ""
 }
 
 // Cleanup deletes the provider's ConfigMap for owner. Called by the finalizer during CR

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/provider"
@@ -106,17 +107,43 @@ func isOperatorManaged(cm *corev1.ConfigMap) bool {
 	return cm.Labels[managedByLabel] == managedByValue && cm.Labels[componentLabel] == componentValue
 }
 
-// Cleanup deletes the provider's ConfigMap for owner, but only when it is
-// controller-owned by owner (UID match via metav1.IsControlledBy) — a same-named
-// ConfigMap the operator does not own is left untouched. Called by the finalizer
-// during CR deletion.
+// isAdoptableLeftover reports whether cm is an unowned artifact of THIS provider left by a
+// pre-atomic-reference version: no controller at all, our management labels, and a non-empty
+// config key (a labeled-but-empty impostor never held our config, so it is not ours).
+//
+// Shared by ApplyCellConfig (which adopts such an object) and Cleanup (which deletes it) so
+// the two can never drift apart. The drift was the bug: adoption ends in deletion anyway —
+// an adopted ConfigMap carries a controller reference and is GC-cascaded the moment the CR
+// goes away — so a Cleanup that refused to delete this exact class did not preserve anything.
+// It only leaked the object when the CR was deleted before any reconcile got to adopt it,
+// which is the deletion-first path #210 left uncovered.
+func isAdoptableLeftover(cm *corev1.ConfigMap) bool {
+	return metav1.GetControllerOf(cm) == nil && isOperatorManaged(cm) && cm.Data[configDataKey] != ""
+}
+
+// Cleanup deletes the provider's ConfigMap for owner. Called by the finalizer during CR
+// deletion. It deletes when the ConfigMap is controller-owned by owner (UID match via
+// metav1.IsControlledBy), and when it is an unowned pre-atomic-ref leftover that
+// ApplyCellConfig would have adopted (isAdoptableLeftover) — same predicate, deliberately.
+// Anything else is left untouched: a ConfigMap owned by a different controller (name reuse,
+// another CR's artifact), an unlabeled foreign object, or a labeled-but-empty impostor.
 func (p *Provider) Cleanup(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig) error {
+	log := logf.FromContext(ctx)
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: ConfigMapNameFor(owner.GetName()), Namespace: owner.GetNamespace()}
 	if err := p.reader().Get(ctx, key, cm); err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	if !metav1.IsControlledBy(cm, owner) {
+	switch {
+	case metav1.IsControlledBy(cm, owner):
+	case isAdoptableLeftover(cm):
+		// Worth a line in the log: this is a pre-atomic-ref artifact being reclaimed on the
+		// deletion path, which means no reconcile ever adopted it while the CR was alive.
+		log.Info("deleting an unowned pre-atomic-ref ConfigMap left by an older operator version",
+			"configmap", key.String())
+	default:
+		log.Info("ConfigMap at this provider's name is not ours to delete; leaving it in place",
+			"configmap", key.String())
 		return nil
 	}
 	// Delete under a UID precondition so the ownership check and the delete hit the SAME object: a
@@ -208,7 +235,7 @@ func (p *Provider) ApplyCellConfig(
 	// pre-adoption state or a freshly-adopted CM would skip its owner-ref persist.
 	alreadyOwned := metav1.IsControlledBy(cm, owner)
 	if !alreadyOwned {
-		if metav1.GetControllerOf(cm) != nil || !isOperatorManaged(cm) || cm.Data[configDataKey] == "" {
+		if !isAdoptableLeftover(cm) {
 			return fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 		}
 		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -245,15 +246,107 @@ func TestCleanup_OwnershipUID(t *testing.T) {
 		}
 	})
 
-	t.Run("skips an unowned ConfigMap", func(t *testing.T) {
+	// An unowned but operator-labeled leftover IS deleted: ApplyCellConfig adopts this exact
+	// object class, and an adopted ConfigMap is GC-cascaded when the CR goes away — so
+	// skipping it here never preserved it, it only leaked it when the CR was deleted before
+	// any reconcile adopted it. See TestApplyAndCleanupAgreeOnOwnership for the invariant.
+	t.Run("deletes an unowned pre-atomic-ref leftover", func(t *testing.T) {
 		p := newTestProviderWith(t, seedConfigMap(t, true, nil))
 		if err := p.Cleanup(ctx, ownerFor("cell-a")); err != nil {
 			t.Fatalf("cleanup: %v", err)
 		}
-		if !exists(p) {
-			t.Error("unowned ConfigMap must NOT be deleted")
+		if exists(p) {
+			t.Error("an adoptable pre-atomic-ref leftover must be deleted, not leaked")
 		}
 	})
+
+	t.Run("skips an unlabeled foreign ConfigMap", func(t *testing.T) {
+		p := newTestProviderWith(t, seedConfigMap(t, false, nil))
+		if err := p.Cleanup(ctx, ownerFor("cell-a")); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if !exists(p) {
+			t.Error("an unlabeled foreign ConfigMap must NOT be deleted")
+		}
+	})
+
+	t.Run("skips a labeled-but-empty impostor", func(t *testing.T) {
+		impostor := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: "ntn-system",
+				Labels:    map[string]string{managedByLabel: managedByValue, componentLabel: componentValue},
+			},
+		}
+		p := newTestProviderWith(t, impostor)
+		if err := p.Cleanup(ctx, ownerFor("cell-a")); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		if !exists(p) {
+			t.Error("a labeled-but-empty impostor never held our config; it must NOT be deleted")
+		}
+	})
+}
+
+// TestApplyAndCleanupAgreeOnOwnership is the invariant that the split between adoption and
+// deletion must never reopen: for every shape of same-named ConfigMap, ApplyCellConfig
+// adopting it and Cleanup deleting it are the SAME decision.
+//
+// They must agree because adoption already ends in deletion — SetControllerReference makes
+// the object GC-cascaded, so a CR delete removes it either way. When the two disagreed, an
+// object Apply was willing to seize and overwrite was one Cleanup refused to remove, and a CR
+// deleted before its first successful reconcile (an upgrade window, or a push that never
+// succeeded) leaked it permanently. The "labels are forgeable" objection cannot justify the
+// split either: it applies identically to adoption, which #210 already accepted.
+func TestApplyAndCleanupAgreeOnOwnership(t *testing.T) {
+	ctx := context.Background()
+	cmName := ConfigMapNameFor("cell-a")
+	otherOwner := ownerFor("cell-a")
+	otherOwner.UID = "different-uid"
+
+	labeledEmpty := func() *corev1.ConfigMap {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: "ntn-system",
+			Labels:    map[string]string{managedByLabel: managedByValue, componentLabel: componentValue},
+		}}
+	}
+
+	for _, tc := range []struct {
+		name string
+		seed func() *corev1.ConfigMap
+		ours bool // our artifact: Apply may adopt it AND Cleanup must delete it
+	}{
+		{"unowned + labeled + our config key", func() *corev1.ConfigMap { return seedConfigMap(t, true, nil) }, true},
+		{"owned by a different-UID CR", func() *corev1.ConfigMap { return seedConfigMap(t, true, otherOwner) }, false},
+		{"unlabeled foreign object", func() *corev1.ConfigMap { return seedConfigMap(t, false, nil) }, false},
+		{"labeled but no config key", labeledEmpty, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Apply: does it claim the object?
+			pa := newTestProviderWith(t, tc.seed())
+			owner := ownerFor("cell-a")
+			applyErr := pa.ApplyCellConfig(ctx, owner, geoSpec(), ownerScheme(t))
+			adopted := applyErr == nil
+
+			// Cleanup: does it remove the object?
+			pc := newTestProviderWith(t, tc.seed())
+			if err := pc.Cleanup(ctx, ownerFor("cell-a")); err != nil {
+				t.Fatalf("cleanup returned an error: %v", err)
+			}
+			err := pc.client.Get(ctx, types.NamespacedName{Name: cmName, Namespace: "ntn-system"}, &corev1.ConfigMap{})
+			deleted := apierrors.IsNotFound(err)
+
+			if adopted != deleted {
+				t.Fatalf("Apply and Cleanup disagree: adopted=%v deleted=%v. An object Apply will seize "+
+					"must be one Cleanup will remove, or a CR deleted before its first reconcile leaks it",
+					adopted, deleted)
+			}
+			if adopted != tc.ours {
+				t.Errorf("expected ours=%v, got adopted=%v (applyErr=%v)", tc.ours, adopted, applyErr)
+			}
+		})
+	}
 }
 
 func TestApplyCellConfig_CreatesConfigMap(t *testing.T) {

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -311,6 +311,15 @@ func TestApplyAndCleanupAgreeOnOwnership(t *testing.T) {
 			Labels:    map[string]string{managedByLabel: managedByValue, componentLabel: componentValue},
 		}}
 	}
+	// Labeled, holds our config key, no CONTROLLER owner — but a plain owner reference to
+	// another object, so it already belongs to that object's lifecycle.
+	labeledNonControllerOwned := func() *corev1.ConfigMap {
+		cm := seedConfigMap(t, true, nil)
+		if err := controllerutil.SetOwnerReference(ownerFor("someone-else"), cm, ownerScheme(t)); err != nil {
+			t.Fatalf("SetOwnerReference: %v", err)
+		}
+		return cm
+	}
 
 	for _, tc := range []struct {
 		name string
@@ -321,6 +330,7 @@ func TestApplyAndCleanupAgreeOnOwnership(t *testing.T) {
 		{"owned by a different-UID CR", func() *corev1.ConfigMap { return seedConfigMap(t, true, otherOwner) }, false},
 		{"unlabeled foreign object", func() *corev1.ConfigMap { return seedConfigMap(t, false, nil) }, false},
 		{"labeled but no config key", labeledEmpty, false},
+		{"labeled but owned (non-controller) by another object", labeledNonControllerOwned, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Apply: does it claim the object?


### PR DESCRIPTION
## Problem

#210 reclaims **pre-atomic-reference artifacts** — a ConfigMap carrying the operator's management labels and its `geo_ntn.yml` key but **no owner reference**, left behind when an older version's best-effort `EnsureOwnership` second write did not land. #210's own root-cause section describes exactly this object and exactly this leak.

It reclaims them by **adopting** in `ApplyCellConfig`. But the reconciler runs `handleFinalizer` **first**, and a CR already carrying a deletion timestamp returns from there without ever reaching `ApplyCellConfig`. So on the deletion-first path, adoption never runs:

1. Old operator creates the ConfigMap
2. Its `EnsureOwnership` write fails → no owner reference
3. Upgrade to a version containing #210
4. The CR is deleted **before** the first post-upgrade reconcile adopts it
5. `Cleanup` required strict `metav1.IsControlledBy` → skipped the unowned leftover
6. Finalizer removed, CR gone → **ConfigMap orphaned**

Nothing can reclaim it afterwards: there is no CR left to adopt it, and no owner reference for Kubernetes GC to follow.

### The two existing tests *are* the bug

They sit ~60 lines apart in `provider_test.go`, over the identical object (`seedConfigMap(t, true, nil)` — labeled, `geo_ntn.yml` present, unowned):

- `TestApplyCellConfig_OwnershipCollision/unowned but operator-labeled -> adopted`
- `TestCleanup_OwnershipUID/skips an unowned ConfigMap`

Apply seizes it. Cleanup refuses to remove it. That asymmetry is what leaks.

## Change

`Cleanup` now deletes under the **same predicate** `ApplyCellConfig` adopts under, extracted into one shared `isAdoptableLeftover(cm)` — no controller reference at all, our management labels, non-empty `geo_ntn.yml` — used by both call sites so they cannot drift apart again.

**This grants no new destructive power.** Adoption already ends in deletion: `SetControllerReference` makes the object GC-cascaded, so a CR delete removes it either way. Refusing to delete in `Cleanup` never *preserved* such an object — it only leaked it when the ordering was unlucky.

The "labels are forgeable, don't delete on labels" objection cannot justify the split, because it applies **identically to adoption**, which #210 already accepted — and adoption is itself destructive (it overwrites `geo_ntn.yml`). The object at issue is squatting on the operator's deterministic name, in the CR's namespace, with the operator's labels and the operator's config key.

Still left untouched, and now **logged** so an operator can see why something survived:
- a ConfigMap owned by a different controller (name reuse, another CR's artifact)
- an unlabeled foreign object
- a labeled-but-empty impostor that never held our config

## Why not the admin-opt-in migration mode

The reviewer proposed a time-bounded, admin-opt-in legacy-migration mode that back-fills owner references before strict cleanup. Rejected as disproportionate:

- The back-fill it describes is **already what `ApplyCellConfig` does** on the normal path — a separate mode would duplicate it.
- It adds an operational mode, a flag, and time-bounding logic for what is a **one-line predicate mismatch**.
- Time-bounding creates a cliff: the gap returns the moment the window closes.
- The "leave it and warn" half is already the behaviour for everything failing the predicate, and this PR adds the warning.

## Checked and NOT a bug

`ApplyCellConfig` resolves the ConfigMap namespace from `spec.Provider.Namespace` while `Cleanup` uses `owner.GetNamespace()`, which would be a second, unconditional leak if the two could differ. They cannot: `ApplyCellConfig` already fails closed with `owner namespace "X" must equal provider namespace "Y"` and `provider namespace must be set`. Verified by probe, so `Cleanup`'s namespace choice is provably equivalent and is left alone.

`NTNSlice`'s finalizer only releases metric series — no ConfigMap ownership, so nothing to fix there. The `prov == nil` best-effort branch keys on `status.ConfigMapRef` and has no provider to ask for the predicate; teaching the controller the provider's private labels would be worse design, so it is deliberately unchanged.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2`: **0 issues**; `gofmt` clean.
- `go test ./internal/controller/... ./pkg/...` green (envtest 1.36.2).
- **`TestApplyAndCleanupAgreeOnOwnership`** is the load-bearing test: a table over every ConfigMap shape asserting that "Apply adopts it" and "Cleanup deletes it" are the *same* decision. It fails loudly if the split ever reopens.
- **Mutation-verified** — reverting `Cleanup` to strict-ownership-only reddens all three layers, each with the right message:
  - `TestCleanup_OwnershipUID/deletes an unowned pre-atomic-ref leftover` → "must be deleted, not leaked"
  - `TestApplyAndCleanupAgreeOnOwnership` → "Apply and Cleanup disagree: adopted=true deleted=false"
  - `TestFinalizer_DeletesLegacyUnownedConfigMap` → "the legacy ConfigMap leaked"
  - the must-survive cases stay green throughout.

No CRD schema change.


---

## Follow-up in this PR: the adoption predicate is tightened too

A second review argued the adoption evidence is too weak — two public labels plus a non-empty `geo_ntn.yml`, all forgeable by anyone who can create a ConfigMap in the namespace — and that this PR makes it worse by extending that predicate to deletion. That last part is correct, so the predicate is tightened here rather than in a follow-up.

**Adopted: require `len(cm.OwnerReferences) == 0`, not just no *controller* owner.** A ConfigMap carrying a plain owner reference already belongs to another object's lifecycle; adopting it made the operator a second owner that would delete it when this CR goes away while the other owner still claims it. It excludes nothing real: the pre-atomic-ref version created the ConfigMap with **no** owner references, and its `EnsureOwnership` back-fill used `SetControllerReference` in a single `Update` — so a genuine leftover carries either our controller reference or none, never a partial non-controller one. Verified against the pre-#210 source, not assumed. Mutation-tested.

**Not adopted, with reasons:**

- **A migration annotation or install-level migration token.** The old operator predates the mechanism, so it never wrote such an annotation — an admin would have to stamp every leftover by hand, and an admin who is already touching the object could just delete it or add the owner reference. It defeats the purpose of automatic reclamation for the only artifacts that need it.
- **Requiring the legacy config to parse.** This is forgeable evidence against a forgery threat: the config format is generated by public source, so an attacker produces a valid one trivially. It would raise the bar only against *accidental* collision, at the cost of a parser the codebase does not otherwise need. The same objection applies to the tempting cheap version (also requiring the `ntn.operators.dev/koffset` annotation, which both the pre-#210 and current versions write) — it looks like provenance without being provenance, which is worse than not claiming it.
- **Admin-explicit opt-in for adoption.** Same objection as the migration mode in the section above: a permanent operational toggle for a transitional problem, whose default-off state leaves the leak in place indefinitely.

**On the threat model.** The forgery path is real but narrow, and it is the *known* confused-deputy theme #219 already documented and #251 tracks: an attacker needs `create configmaps` at the operator's deterministic name *plus* an NTNCellConfig whose name maps to it. What they gain is that their own planted object gets overwritten and then deleted. Reaching another party's ConfigMap additionally requires `patch` on an object already sitting at the operator's name. The honest long-term answer is not more forgeable evidence — it is that adoption is **transitional** and should be removed once the pre-#210 upgrade window has closed.
