### PR TITLE
feat(ntncellconfig): admin allowlist for remoteControl.endpoint (SSRF egress gate, #299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Optional admin allowlist for the `remoteControl.endpoint` the operator will dial (SSRF egress lever, #299).**
+  `NTNCellConfig.spec.provider.remoteControl.endpoint` is a free-form `host:port` chosen by whoever writes
+  the CR, and the operator opens a WebSocket to it from its own in-cluster identity — so a principal with
+  `NTNCellConfig` write but no network access could aim it at arbitrary cluster-internal services (port/
+  service probing, WS interaction). A new operator flag `--remote-control-allowed-endpoint-hosts` (comma-
+  separated bare hosts; IPv6 without brackets) restricts which endpoint hosts the runtime push may target.
+  It is admin-controlled and tenant-immutable (a process flag, not a CR field). **Empty (the default)
+  permits any endpoint, so existing deployments are unchanged.** Unlike the GP-fetch SSRF guard, this is an
+  allowlist rather than a private-IP block: the legitimate gNB target is normally a localhost sidecar or an
+  in-cluster ClusterIP, both of which a private-IP denylist would wrongly reject. A disallowed endpoint
+  fails the push closed with reason `RemoteControlEndpointNotAllowed` **before** any Secret read (so it never
+  triggers a credential resolution) and does not self-requeue (it clears on a watched spec edit). This is
+  the app-layer half of #299; pair it with an operator egress NetworkPolicy for network-layer enforcement.
+
 - **External OMM `OBJECT_NAME` can no longer amplify the SatelliteEphemeris status past the etcd object
   limit.** `PropagatedState.satellite` was already bounded (MaxLength 64), but `PassWindow.satellite`
   copied the full external name into up to `MaxPassWindows` (500) windows, the pass-prediction

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -157,6 +157,16 @@ func main() {
 			"An in-cluster Prometheus at a private ClusterIP must be listed here (by host), "+
 			"and multi-tenant clusters should list only the sanctioned endpoints so a tenant "+
 			"cannot aim the operator at arbitrary cluster-internal services.")
+	var remoteControlAllowedHosts string
+	flag.StringVar(&remoteControlAllowedHosts, "remote-control-allowed-endpoint-hosts", "",
+		"Comma-separated list of hostnames (bare host, IPv6 without brackets) that "+
+			"NTNCellConfig.spec.provider.remoteControl.endpoint is allowed to target. "+
+			"Empty (default) permits ANY endpoint — the legitimate gNB target is normally "+
+			"a localhost sidecar or an in-cluster ClusterIP, so unlike the GP-fetch guard "+
+			"this is an allowlist, not a private-IP block. Multi-tenant clusters should "+
+			"list only the sanctioned gNB endpoints so a tenant with NTNCellConfig write "+
+			"but no network access cannot aim the operator at arbitrary cluster-internal "+
+			"services (SSRF, #299). Pair with an operator egress NetworkPolicy.")
 	var ephemerisAllowedPrivateHosts string
 	flag.StringVar(&ephemerisAllowedPrivateHosts, "ephemeris-allowed-private-hosts", "",
 		"Comma-separated list of hostnames whose resolved private/reserved IPs are "+
@@ -277,12 +287,13 @@ func main() {
 		"ocudu": ocudu.NewProvider(mgr.GetClient()).WithAPIReader(mgr.GetAPIReader()),
 	}
 	if err := (&controller.NTNCellConfigReconciler{
-		Client:                  mgr.GetClient(),
-		APIReader:               mgr.GetAPIReader(),
-		Scheme:                  mgr.GetScheme(),
-		Recorder:                mgr.GetEventRecorder("ntncellconfig-controller"),
-		Providers:               providers,
-		MaxConcurrentReconciles: maxConcurrentReconciles,
+		Client:                         mgr.GetClient(),
+		APIReader:                      mgr.GetAPIReader(),
+		Scheme:                         mgr.GetScheme(),
+		Recorder:                       mgr.GetEventRecorder("ntncellconfig-controller"),
+		Providers:                      providers,
+		RemoteControlEndpointAllowlist: netutil.ParseEndpointAllowlist(remoteControlAllowedHosts),
+		MaxConcurrentReconciles:        maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "NTNCellConfig")
 		os.Exit(1)

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -49,6 +49,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
 	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
@@ -59,11 +60,19 @@ type NTNCellConfigReconciler struct {
 	// remoteControl.tls Secret. The cached client would need secrets list;watch to
 	// start an informer (and would then cache every Secret in the cluster); an
 	// uncached Get needs only secrets get. Falls back to the cached client if unset.
-	APIReader               client.Reader
-	Scheme                  *runtime.Scheme
-	Recorder                events.EventRecorder
-	Providers               map[string]provider.NTNProvider
-	MaxConcurrentReconciles int
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
+	Providers map[string]provider.NTNProvider
+	// RemoteControlEndpointAllowlist, when non-empty, restricts which hosts a
+	// spec.provider.remoteControl.endpoint may target — an admin-controlled,
+	// tenant-immutable egress gate (operator flag, not a CR field). Empty (the
+	// default) permits any endpoint, preserving pre-flag behavior. Unlike the GP
+	// fetch path (netutil's private-IP block), the legitimate remote-control
+	// target is ALWAYS private (a localhost sidecar or an in-cluster ClusterIP),
+	// so an allowlist — not a private-IP denylist — is the fit here (see #299).
+	RemoteControlEndpointAllowlist netutil.EndpointAllowlist
+	MaxConcurrentReconciles        int
 }
 
 const (
@@ -75,6 +84,13 @@ const (
 	ephemerisReasonProviderPushRejected = "ProviderPushRejected"
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
 	ephemerisReasonRemoteControlConfig  = "RemoteControlConfigInvalid"
+	// ephemerisReasonRemoteControlEndpointNotAllowed fails a push CLOSED when the
+	// operator's --remote-control-allowed-endpoint-hosts allowlist is set and the
+	// cell's remoteControl.endpoint host is not in it. Permanent (clears only on a
+	// spec edit — watched — or an operator restart with a new allowlist), so it
+	// does not self-requeue. Checked BEFORE the Secret read, so a disallowed
+	// endpoint never triggers a credential resolution.
+	ephemerisReasonRemoteControlEndpointNotAllowed = "RemoteControlEndpointNotAllowed"
 	// ephemerisReasonSelectionAmbiguous fails a push CLOSED when spec.ephemerisNoradID is unset but
 	// the referenced SatelliteEphemeris exposes more than one satellite: the controller refuses to
 	// guess which one to serve (silently pushing the first would switch satellites whenever the
@@ -150,7 +166,8 @@ func ephemerisPushShouldRequeue(reason string) bool {
 		ephemerisReasonPayloadMissing,
 		ephemerisReasonEphemerisStale,
 		ephemerisReasonInputsStale,
-		ephemerisReasonProviderPushRejected:
+		ephemerisReasonProviderPushRejected,
+		ephemerisReasonRemoteControlEndpointNotAllowed:
 		return false
 	default:
 		return true
@@ -761,6 +778,13 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 			update.SatSwitch = spec.NTN.SatSwitchWithResync
 		}
 	}
+	// Egress gate (SSRF, #299): when the admin has set an allowlist, refuse to dial
+	// an endpoint host outside it — BEFORE the Secret read, so a disallowed endpoint
+	// never causes a credential resolution. A permanent config error (clears on a
+	// watched spec edit), so it does not self-requeue.
+	if err := r.checkRemoteControlEndpointAllowed(spec.Provider.RemoteControl.Endpoint); err != nil {
+		return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlEndpointNotAllowed, err)
+	}
 	// Resolve opt-in transport security (wss:// + shared secret / mTLS) from the
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
 	tlsConfig, authToken, tlsErr := r.resolveRemoteControlTLS(ctx, eph.Namespace, spec.Provider.RemoteControl)
@@ -841,6 +865,27 @@ var errRemoteControlCredentialInvalid = errors.New("not a usable remote-control 
 // on the CR condition/event: it would otherwise let a principal who can write the CR
 // but not read Secrets probe Secret existence and type (an oracle).
 var errRemoteControlCredentialUnavailable = errors.New("referenced remote-control credential is unavailable or not authorized")
+
+// checkRemoteControlEndpointAllowed enforces the operator's remote-control endpoint
+// allowlist (SSRF egress gate, #299). An empty allowlist permits everything —
+// backward-compatible with deployments predating the flag. When the allowlist is set,
+// the endpoint's host (bracketed IPv6 is unwrapped by net.SplitHostPort) must match a
+// listed host exactly, else the push fails closed. The allowlist holds bare hosts, not
+// scheme URLs, so it is matched with ContainsHost rather than Check. Admission already
+// guarantees a well-formed host:port, so a SplitHostPort error here is fail-closed.
+func (r *NTNCellConfigReconciler) checkRemoteControlEndpointAllowed(endpoint string) error {
+	if r.RemoteControlEndpointAllowlist.IsEmpty() {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return fmt.Errorf("remoteControl.endpoint %q is not a valid host:port: %w", endpoint, err)
+	}
+	if !r.RemoteControlEndpointAllowlist.ContainsHost(host) {
+		return fmt.Errorf("remoteControl.endpoint host %q is not permitted by the operator's remote-control endpoint allowlist", host)
+	}
+	return nil
+}
 
 // resolveRemoteControlTLS builds the TLS config and bearer token for the runtime
 // push from the Secret referenced by remoteControl.tls. It reads the Secret from

--- a/internal/controller/ntncellconfig_endpoint_allowlist_test.go
+++ b/internal/controller/ntncellconfig_endpoint_allowlist_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// TestCheckRemoteControlEndpointAllowed covers the SSRF egress gate's matching logic
+// (#299): empty = permit-all (backward compatible), otherwise the endpoint host must be
+// in the admin allowlist. IPv6 brackets are stripped by net.SplitHostPort; matching is
+// case-insensitive; a malformed endpoint fails closed once the allowlist is set.
+func TestCheckRemoteControlEndpointAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist string
+		endpoint  string
+		wantErr   bool
+	}{
+		{"empty allowlist permits any endpoint (backward compat)", "", "127.0.0.1:8001", false},
+		{"empty allowlist permits an external host too", "", "gnb.example.com:9000", false},
+		{"listed IPv4 host permitted", "127.0.0.1", "127.0.0.1:8001", false},
+		{"listed DNS host permitted", "gnb.ran.svc", "gnb.ran.svc:8001", false},
+		{"listed host, case-insensitive", "gnb.ran.svc", "GNB.RAN.SVC:8001", false},
+		{"listed IPv6 host permitted (brackets stripped)", "::1", "[::1]:8001", false},
+		{"unlisted host rejected", "gnb.ran.svc", "127.0.0.1:8001", true},
+		{"unlisted IPv6 rejected", "gnb.ran.svc", "[fd00::1]:8001", true},
+		{"one of several listed hosts permitted", "a.svc,gnb.ran.svc,b.svc", "gnb.ran.svc:8001", false},
+		{"malformed endpoint fails closed when allowlist set", "gnb.ran.svc", "no-port", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &NTNCellConfigReconciler{
+				RemoteControlEndpointAllowlist: netutil.ParseEndpointAllowlist(tc.allowlist),
+			}
+			err := r.checkRemoteControlEndpointAllowed(tc.endpoint)
+			if tc.wantErr && err == nil {
+				t.Fatalf("endpoint %q with allowlist %q: want error, got nil", tc.endpoint, tc.allowlist)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("endpoint %q with allowlist %q: want nil, got %v", tc.endpoint, tc.allowlist, err)
+			}
+		})
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_EndpointNotAllowed proves the gate is wired into the
+// runtime push path with the right classification AND fires BEFORE the Secret read.
+// The cell points remoteControl.tls at a MISSING Secret and its endpoint is outside the
+// allowlist: the failure must be RemoteControlEndpointNotAllowed (not a credential
+// error), which can only happen if the endpoint gate runs first. The reason is permanent
+// (clears on a watched spec edit), so it must NOT self-requeue.
+func TestPushEphemerisUpdateIfNeeded_EndpointNotAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{
+		Client:                         c,
+		APIReader:                      c,
+		RemoteControlEndpointAllowlist: netutil.ParseEndpointAllowlist("gnb.ran.svc"),
+	}
+	cc := ccWithRemoteControl() // endpoint 127.0.0.1:8001, NOT in the allowlist
+	// Point at a Secret that does not exist — if the gate ran AFTER the Secret read,
+	// this would surface a credential error instead of an endpoint error.
+	cc.Spec.Provider.RemoteControl.TLS = &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "missing"}
+
+	_, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, &provider.MockProvider{})
+	if err == nil {
+		t.Fatal("an endpoint outside the allowlist must fail the push")
+	}
+	reason := ephemerisPushConditionReason(err)
+	if reason != ephemerisReasonRemoteControlEndpointNotAllowed {
+		t.Fatalf("disallowed endpoint must classify as %q (before the Secret read), got %q",
+			ephemerisReasonRemoteControlEndpointNotAllowed, reason)
+	}
+	if ephemerisPushShouldRequeue(reason) {
+		t.Fatalf("a disallowed endpoint is a permanent config error and must not self-requeue")
+	}
+}
+
+// TestPushEphemerisUpdateIfNeeded_EndpointAllowed_Proceeds confirms the gate does not
+// block a legitimate endpoint: with the cell's host in the allowlist (and no TLS), the
+// runtime push reaches the provider and succeeds.
+func TestPushEphemerisUpdateIfNeeded_EndpointAllowed_Proceeds(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	eph := ephWithPropagatedState(time.Now().Add(time.Hour).UnixMilli())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eph).Build()
+	r := &NTNCellConfigReconciler{
+		Client:                         c,
+		RemoteControlEndpointAllowlist: netutil.ParseEndpointAllowlist("127.0.0.1"),
+	}
+	cc := ccWithRemoteControl() // endpoint 127.0.0.1:8001, IS in the allowlist
+	mock := &provider.MockProvider{}
+
+	pushed, _, err := r.pushEphemerisUpdateIfNeeded(context.Background(), cc, &cc.Spec, mock)
+	if err != nil {
+		t.Fatalf("an allow-listed endpoint must not be blocked: %v", err)
+	}
+	if !pushed {
+		t.Fatal("an allow-listed endpoint must complete the runtime push")
+	}
+	if mock.RuntimeCalls != 1 {
+		t.Fatalf("provider must receive exactly one runtime push, got %d", mock.RuntimeCalls)
+	}
+}

--- a/pkg/netutil/allowlist.go
+++ b/pkg/netutil/allowlist.go
@@ -79,6 +79,16 @@ func ParseEndpointAllowlist(csv string) EndpointAllowlist {
 	return EndpointAllowlist{hosts: hosts}
 }
 
+// IsEmpty reports whether the allowlist has no entries. Empty means "permit
+// all" to Check (the user-supplied-URL gate) and "whitelist nothing" to
+// ContainsHost (the dialer bypass) — the two callers deliberately read the
+// empty list with opposite senses. A caller that needs permit-all-when-empty
+// on a bare host:port (no URL to hand to Check, e.g. the remote-control WS
+// endpoint) composes IsEmpty with ContainsHost to make that choice explicit.
+func (a EndpointAllowlist) IsEmpty() bool {
+	return len(a.hosts) == 0
+}
+
 // ContainsHost reports whether a bare hostname is in the allowlist.
 // It lowercases the input for DNS-equivalent matching (allowlist hosts
 // are stored lowercased by ParseEndpointAllowlist). Unlike Check, this

--- a/pkg/netutil/allowlist_test.go
+++ b/pkg/netutil/allowlist_test.go
@@ -33,6 +33,18 @@ func TestEndpointAllowlist_Empty_AcceptsAnyHttpURL(t *testing.T) {
 	}
 }
 
+func TestEndpointAllowlist_IsEmpty(t *testing.T) {
+	if !netutil.ParseEndpointAllowlist("").IsEmpty() {
+		t.Error("a blank spec must produce an empty allowlist")
+	}
+	if !netutil.ParseEndpointAllowlist("  , ,").IsEmpty() {
+		t.Error("a spec of only blanks/whitespace must produce an empty allowlist")
+	}
+	if netutil.ParseEndpointAllowlist("gnb.ran.svc").IsEmpty() {
+		t.Error("a spec with one host must not be empty")
+	}
+}
+
 func TestEndpointAllowlist_NonEmpty_OnlyExactHostMatch(t *testing.T) {
 	a := netutil.ParseEndpointAllowlist("prom.monitoring.svc,prom.example.com")
 	ok := []string{


### PR DESCRIPTION
Non-breaking, app-layer half of #299. Gives cluster admins a lever to restrict which hosts the operator will open a runtime-control WebSocket to, without touching the CRD.

## Problem

`NTNCellConfig.spec.provider.remoteControl.endpoint` is a free-form `host:port` chosen by whoever writes the CR; the operator dials it (`pushRuntimeEphemeris` → `PushRuntimeUpdate` → `pushNTNConfigUpdate`) from its own in-cluster identity, with no egress control. A principal with `NTNCellConfig` write but no network access can aim it at arbitrary cluster-internal services (port/service probing, WS interaction). Tracked in #299; PR #219 already noted "an endpoint allowlist / Service reference is the real control, tracked separately."

## What this adds

- Operator flag **`--remote-control-allowed-endpoint-hosts`** (comma-separated bare hosts; IPv6 without brackets), parsed into the existing `netutil.EndpointAllowlist` and held on `NTNCellConfigReconciler`.
- Before dialing — **and before the `remoteControl.tls` Secret read** — the endpoint host is checked. A disallowed host fails the push closed with a new reason **`RemoteControlEndpointNotAllowed`**.
- **Empty allowlist (the default) permits any endpoint**, so existing deployments are unchanged.

## Why an allowlist, not the private-IP denylist we already have

`pkg/netutil` already blocks private/reserved IPs on the GP-fetch path, where the legitimate target is a public host. That rule **inverts** here: the legitimate gNB target is normally private — the documented default is a localhost sidecar (`127.0.0.1:8001`), and cross-pod is a ClusterIP — both of which `IsPrivateIP` would wrongly reject. So the fit is an allowlist (permit only admin-approved hosts), which is also the control #219 pointed at.

## Design notes

- **Gate before the Secret read**: a disallowed endpoint never triggers a credential resolution (no confused-deputy Secret read for a target we won't dial). Proven by a test that points at a *missing* Secret and still gets `RemoteControlEndpointNotAllowed`, not a credential error.
- **Non-requeuing**: it is a permanent config error that clears on a watched spec edit (or an operator restart with a new allowlist), so a self-requeue would only re-reject pointlessly. Added to `ephemerisPushShouldRequeue`'s false set.
- **Host-string match, not IP**: matching is on the endpoint host string (case-insensitive; IPv6 brackets stripped by `net.SplitHostPort`). IP-range egress enforcement is the operator NetworkPolicy's job — the same split the `netutil.EndpointAllowlist` doc already draws. The flag help says to pair the two.
- **Sole dial path**: verified `pushRuntimeEphemeris` is the only path that dials `remoteControl.endpoint` (`Cleanup`/`GetCellStatus` do not), so the single gate is complete.
- `netutil.EndpointAllowlist` gains `IsEmpty()` so a bare `host:port` caller can pick permit-all-when-empty explicitly (`ContainsHost` returns false for empty by design — the two callers read empty with opposite senses).

## Scope / not in this PR

The NetworkPolicy sample, a `ServiceReference` alternative, provider-level enforcement, and DNS pinning stay tracked in #299. This is the cheapest non-breaking lever.

## Tests

- `TestCheckRemoteControlEndpointAllowed` — table: empty (permit-all), listed IPv4/DNS, case-insensitive, IPv6 unwrap, unlisted rejected, malformed fails closed.
- `TestPushEphemerisUpdateIfNeeded_EndpointNotAllowed` — end-to-end: disallowed endpoint + missing Secret → `RemoteControlEndpointNotAllowed` (proves gate precedes the Secret read) + non-requeuing.
- `TestPushEphemerisUpdateIfNeeded_EndpointAllowed_Proceeds` — allow-listed host reaches the provider.
- `TestEndpointAllowlist_IsEmpty` — netutil.

`go build`, full `internal/controller` envtest suite, `pkg/netutil`, `gofmt`, `go vet` all green locally.

## Merge note

Branched off `origin/main`; independent of open PR #296 (which renames the `remoteControl.tls` credential reason). If #296 merges first this needs only a trivial rebase in the reason-const block.