### PR TITLE
fix(configmap): atomic UID-scoped delete so a same-name recreate isn't wrongly deleted

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -498,9 +498,14 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 							return true, ctrl.Result{}, err // retry on transient errors
 						}
 					} else if metav1.IsControlledBy(cm, cc) {
-						if err := r.Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
+						// UID precondition: the ownership check and the delete must hit the SAME object — a
+						// same-name recreate (new UID) between the cached Get and here must not be deleted.
+						// UID not resourceVersion (the Get is cached → a stale RV would spuriously Conflict).
+						// A UID-mismatch Conflict propagates below, keeping the finalizer. Mirrors ocudu Cleanup.
+						uid := cm.GetUID()
+						if err := r.Delete(ctx, cm, client.Preconditions{UID: &uid}); client.IgnoreNotFound(err) != nil {
 							log.Error(err, "Failed to delete ConfigMap during best-effort finalization")
-							return true, ctrl.Result{}, err // retry on transient errors
+							return true, ctrl.Result{}, err // retry on transient errors (incl. UID-precondition Conflict)
 						}
 						log.Info("Deleted orphaned ConfigMap via configMapRef", "configmap", cmKey)
 					} else {

--- a/internal/controller/ntncellconfig_uid_delete_test.go
+++ b/internal/controller/ntncellconfig_uid_delete_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/provider/ocudu"
+)
+
+// This runs against the envtest API server because a fake client does not enforce delete
+// preconditions. It pins the atomic UID-scoped delete: the ownership check and the delete must hit the
+// SAME object, so a same-name ConfigMap recreated (new UID) between the Get and the delete is NOT
+// removed. The replacement is injected during the delete via an interceptor — exactly the "swap
+// between GET and DELETE" race. Mutation: drop the client.Preconditions{UID} in ocudu.Cleanup and the
+// replacement is deleted (this fails).
+var _ = Describe("NTNCellConfig ocudu.Cleanup UID-scoped delete", func() {
+	It("does not delete a same-name ConfigMap recreated between the ownership check and the delete", func() {
+		ctx := context.Background()
+		const ns = "default"
+
+		// ccWithRemoteControl() builds an admission-valid spec (spec.ntn.ephemerisECEF, cellID, ocudu);
+		// override the identity so envtest assigns a fresh name+UID in the default namespace.
+		cc := ccWithRemoteControl()
+		cc.ObjectMeta = metav1.ObjectMeta{GenerateName: "uid-del-", Namespace: ns}
+		Expect(k8sClient.Create(ctx, cc)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, cc) })
+
+		cmName := ocudu.ConfigMapNameFor(cc.Name)
+
+		sch := runtime.NewScheme()
+		Expect(ntnv1alpha1.AddToScheme(sch)).To(Succeed())
+		Expect(corev1.AddToScheme(sch)).To(Succeed())
+
+		// cmA: the CR's own ConfigMap (controller-owned by cc).
+		cmA := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns},
+			Data:       map[string]string{"who": "cmA-owned-by-cc"},
+		}
+		Expect(controllerutil.SetControllerReference(cc, cmA, sch)).To(Succeed())
+		Expect(k8sClient.Create(ctx, cmA)).To(Succeed())
+
+		// A WithWatch envtest client wrapped so the FIRST delete first swaps the ConfigMap for a
+		// same-name replacement with a different UID (and no owner) — the TOCTOU window — then delegates
+		// the real (UID-preconditioned) delete, which the API server must reject with Conflict.
+		base, err := client.NewWithWatch(cfg, client.Options{Scheme: sch})
+		Expect(err).NotTo(HaveOccurred())
+		swapped := false
+		racing := interceptor.NewClient(base, interceptor.Funcs{
+			Delete: func(dctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if !swapped {
+					swapped = true
+					cur := &corev1.ConfigMap{}
+					Expect(k8sClient.Get(dctx, client.ObjectKey{Name: cmName, Namespace: ns}, cur)).To(Succeed())
+					Expect(k8sClient.Delete(dctx, cur)).To(Succeed())
+					repl := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns},
+						Data:       map[string]string{"who": "replacement-not-owned-by-cc"},
+					}
+					Expect(k8sClient.Create(dctx, repl)).To(Succeed())
+				}
+				return c.Delete(dctx, obj, opts...)
+			},
+		})
+
+		err = ocudu.NewProvider(racing).Cleanup(ctx, cc)
+		Expect(err).To(HaveOccurred(), "the UID precondition must reject the delete of a replaced object")
+		Expect(apierrors.IsConflict(err)).To(BeTrue(), "want a UID-precondition Conflict, got %v", err)
+
+		// The replacement (a different object the CR does not own) must survive.
+		got := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cmName, Namespace: ns}, got)).To(Succeed())
+		Expect(got.Data["who"]).To(Equal("replacement-not-owned-by-cc"),
+			"the same-name replacement must NOT be deleted by the CR's cleanup")
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, got) })
+	})
+})

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -119,7 +119,13 @@ func (p *Provider) Cleanup(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig
 	if !metav1.IsControlledBy(cm, owner) {
 		return nil
 	}
-	return client.IgnoreNotFound(p.client.Delete(ctx, cm))
+	// Delete under a UID precondition so the ownership check and the delete hit the SAME object: a
+	// same-name ConfigMap recreated (new UID) between the cached Get and here must not be deleted. A
+	// UID-mismatch Conflict propagates so the finalizer requeues and re-evaluates. UID, not
+	// resourceVersion — the Get is cached, so a stale RV would spuriously Conflict on any benign update;
+	// the UID is stable for the object's life.
+	uid := cm.GetUID()
+	return client.IgnoreNotFound(p.client.Delete(ctx, cm, client.Preconditions{UID: &uid}))
 }
 
 // NewProvider creates an OCUDU Provider with the given K8s client.


### PR DESCRIPTION
## What

Make the ConfigMap cleanup delete **atomic** with its ownership check, so a same-name ConfigMap recreated between the GET and the DELETE is not wrongly deleted (a TOCTOU).

## The race

Both cleanup paths — the ocudu provider `Cleanup` and the finalizer's provider-missing fallback — did `GET → metav1.IsControlledBy(owner) → Delete(cm)` with **no delete precondition**:

```
T1  GET ConfigMap A (UID=A), IsControlledBy(A, CR) = true
T2  A is deleted; a same-name B (UID=B, not owned) is created
T3  Delete(name) unconditionally  →  B is deleted
```

The ownership check ran on A; the delete hit B. An unconditional delete-by-name removes the replacement — a foreign object the CR does not own. The (cached) reads widen the window.

## Fix

Delete under `client.Preconditions{UID}`, so the API server deletes only if the live object still has the UID the ownership check saw. A UID mismatch returns **Conflict**, which propagates (`IgnoreNotFound` passes it through) — the finalizer is kept and re-evaluated on the next reconcile, rather than reporting a delete it did not perform.

**UID only, not `resourceVersion`** — this is where I diverged from the review, and it's deliberate: both GETs are **cached** (`NewProvider` wires the cached manager client; `r.Get` is the cached reconciler client), so a stale cache `resourceVersion` would spuriously `Conflict` on *every* benign update. The UID is stable for the object's life, so it's the correct — and sufficient — precondition for the same-name-recreate race. Adding RV here would be over-engineering that actively breaks with cached reads.

## Test

`internal/controller/ntncellconfig_uid_delete_test.go` runs against **envtest** (a fake client does not enforce delete preconditions, as the review notes). An interceptor swaps the ConfigMap for a same-name replacement **during** the delete — the exact GET→DELETE window — and the CR's `Cleanup` must fail with `Conflict` while the replacement **survives**. Mutation-verified: dropping the precondition deletes the replacement (the test then fails). `gofmt` / `go vet` / `golangci-lint` clean; full provider + controller suites pass.
