### PR TITLE
feat(metrics): config-apply readiness gauge — the half of #216 that never shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ntn_operators_config_apply_ready` — the config-apply half of #216, which shipped only the
+  push half.** `ntn_operators_config_apply_errors_total` is incremented **only** by an
+  `ApplyCellConfig` failure, so three other ways the apply can be broken incremented it **zero**
+  times *and* returned a nil error — making them invisible to `NTNConfigApplyErrors` (a rate alert
+  on that counter) **and** to `controller_runtime_reconcile_errors_total`: `InternalError` (the
+  provider registry is not configured), `UnsupportedProvider` (`spec.provider.type` unregistered,
+  which additionally does **not requeue** — exactly the permanent case a rate alert can never
+  sustain on), and `StatusCheckFailed` (the write may have landed but the post-apply read could not
+  verify it). The new gauge is 1 only on a verified apply and 0 on all four failure paths, holds its
+  value across scrapes regardless of requeue, and is released on CR deletion. Alert
+  **`NTNConfigApplyNotReady`** (`== 0` for 15m) and a runbook section keyed by the `ConfigApplied`
+  reason ship with it. Keyed `namespace`+`config` like `ephemeris_push_ready`, deliberately without
+  the counter's `provider` label so a provider-type edit cannot strand a stale series at 0.
+
 - **Durable conditional-GET validators for the OMM cache (polite restart/failover refetch).** The
   CelesTrak fetcher already used an in-memory `If-None-Match` conditional GET, but the ETag was lost on
   a process restart or leader failover, so the first post-failover fetch re-downloaded the full GP body.

--- a/dist/chart/templates/monitoring/prometheusrule.yaml
+++ b/dist/chart/templates/monitoring/prometheusrule.yaml
@@ -91,6 +91,20 @@ spec:
           annotations:
             summary: "NTNCellConfig {{`{{ $labels.namespace }}/{{ $labels.config }}`}} provider apply is erroring"
             description: "Static provider config apply has failed in the last 15m."
+        # The config is not verifiably applied — the durable companion to the rate alert
+        # above. ConfigApplyErrorsTotal is incremented ONLY by an ApplyCellConfig failure, so
+        # InternalError (no provider registry), UnsupportedProvider (unregistered type, which
+        # does not even requeue) and StatusCheckFailed (post-apply verification) increment it
+        # zero times and return a nil error — invisible to both the rate alert and
+        # controller_runtime_reconcile_errors_total. This gauge holds 0 across all of them.
+        - alert: NTNConfigApplyNotReady
+          expr: ntn_operators_config_apply_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NTNCellConfig {{`{{ $labels.namespace }}/{{ $labels.config }}`}} config is not verifiably applied"
+            description: "NTN config apply has been unverified or failing for 15m; read the ConfigApplied condition for the reason."
     - name: ntn-operators.failover
       rules:
         # Sustained failover churn — flapping between terrestrial and satellite.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -35,6 +35,7 @@ Metric → alert map:
 | `NTNEphemerisPushNotReady` | `ntn_operators_ephemeris_push_ready == 0` | 15m |
 | `NTNSliceFailoverFlapping` | `increase(ntn_operators_failover_total[15m]) > 4` | 5m |
 | `NTNConfigApplyErrors` | `increase(ntn_operators_config_apply_errors_total[15m]) > 0` | 15m |
+| `NTNConfigApplyNotReady` | `ntn_operators_config_apply_ready == 0` | 15m |
 | `NTNNoSatellitesTracked` | `ntn_operators_gp_satellite_count == 0` | 30m |
 | `NTNGPFetchNotReady` | `ntn_operators_gp_fetch_ready == 0` | 30m |
 | `NTNDeepSpaceElementsRejected` | `ntn_operators_gp_deep_space_rejected_count > 0` | 15m |
@@ -281,6 +282,45 @@ change (koffset, SIB schedule, ephemeris) never reaches the gNB's next boot.
 `ApplyFailed` / `StatusCheckFailed` Events. **Mitigate** by correcting the spec
 (a `ConfigValid=False` message names the field) or the provider target.
 **Escalate** to whoever owns the NTNCellConfig spec.
+
+---
+
+## NTNConfigApplyNotReady
+
+**Fires when** `ntn_operators_config_apply_ready == 0` for 15m. Labels:
+`namespace`, `config`. This is the durable companion to **NTNConfigApplyErrors**,
+and it covers strictly more: `ntn_operators_config_apply_errors_total` is
+incremented **only** by an `ApplyCellConfig` failure, so three other ways the
+apply can be broken increment it **zero** times and return a nil error — meaning
+neither the rate alert nor `controller_runtime_reconcile_errors_total` sees them:
+
+| `ConfigApplied` reason | What it means | Requeues? |
+|---|---|---|
+| `InternalError` | the provider registry is not configured (operator wiring bug) | 1m |
+| `UnsupportedProvider` | `spec.provider.type` is not registered — **no requeue at all**, so a rate alert could never sustain on it | no |
+| `StatusCheckFailed` | the write may have landed but the post-apply read could not verify it | 1m |
+
+**Impact.** The gNB's bootstrap ConfigMap is not known to reflect the CR. Under
+`UnsupportedProvider` nothing will retry until the spec is edited or the operator
+restarts.
+
+**Diagnose.** Read the reason off the condition — that is what distinguishes the
+three cases:
+
+```bash
+kubectl get ntncellconfig "$CONFIG" -n "$NS" \
+  -o jsonpath='{range .status.conditions[?(@.type=="ConfigApplied")]}{.status}{" "}{.reason}{" "}{.message}{"\n"}{end}'
+```
+
+**Mitigate.** `InternalError` — an operator-side wiring fault; check the
+controller logs and restart. `UnsupportedProvider` — set `spec.provider.type` to a
+registered provider (`ocudu`); the spec edit bumps the generation and re-triggers
+the reconcile immediately. `StatusCheckFailed` — check the ConfigMap named by
+`status.configMapRef` still exists and carries `geo_ntn.yml`; the next reconcile
+re-applies it, so a persistent one points at an API-access problem.
+
+**Escalate** to the operator owner for `InternalError`, to whoever owns the
+NTNCellConfig spec for `UnsupportedProvider`.
 
 ---
 

--- a/internal/controller/ntncellconfig_applyready_test.go
+++ b/internal/controller/ntncellconfig_applyready_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// gaugeValue reads a single gauge series WITHOUT creating it. testutil.ToFloat64 goes through
+// GaugeVec.With, which instantiates a missing series at 0 — so it cannot tell "explicitly set
+// to 0" from "never set at all", and a test built on it would pass even if the code stopped
+// setting the gauge entirely. The bool is what makes these assertions load-bearing.
+func gaugeValue(t *testing.T, g *prometheus.GaugeVec, labels prometheus.Labels) (float64, bool) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 128)
+	g.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		got := make(map[string]string, len(pb.Label))
+		for _, lp := range pb.Label {
+			got[lp.GetName()] = lp.GetValue()
+		}
+		match := true
+		for k, v := range labels {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return pb.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+// counterValue is the same no-instantiate read for a CounterVec.
+func counterValue(t *testing.T, c *prometheus.CounterVec, labels prometheus.Labels) (float64, bool) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 128)
+	c.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		got := make(map[string]string, len(pb.Label))
+		for _, lp := range pb.Label {
+			got[lp.GetName()] = lp.GetValue()
+		}
+		match := true
+		for k, v := range labels {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return pb.GetCounter().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+const applyReadyNS = "apply-ready-ns"
+
+func applyReadyLabels(name string) prometheus.Labels {
+	return prometheus.Labels{"namespace": applyReadyNS, "config": name}
+}
+
+// ccForApplyReady builds a CR that already carries the cleanup finalizer, so the first
+// Reconcile reaches the provider-validation step instead of stopping to add it.
+func ccForApplyReady(name, providerType string) *ntnv1alpha1.NTNCellConfig {
+	return &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: applyReadyNS, Generation: 1,
+			Finalizers: []string{"ntn.operators.dev/configmap-cleanup"},
+		},
+		Spec: ntnv1alpha1.NTNCellConfigSpec{
+			Provider: ntnv1alpha1.ProviderRef{Type: providerType, Namespace: applyReadyNS},
+		},
+	}
+}
+
+func applyReadyScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+	return s
+}
+
+// TestConfigApplyReady_CoversTheCounterlessFailures is why this gauge exists. Each branch
+// below leaves ConfigApplied non-True, increments ConfigApplyErrorsTotal ZERO times, and
+// returns a NIL error — so neither NTNConfigApplyErrors (a rate alert on that counter) nor
+// controller_runtime_reconcile_errors_total can see it. Before the gauge these three failures
+// were invisible to every shipped alert. UnsupportedProvider additionally does not requeue,
+// which is the permanent case a rate alert could never sustain on (issue #216).
+func TestConfigApplyReady_CoversTheCounterlessFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		providers    map[string]provider.NTNProvider
+		providerType string
+		wantReason   string
+	}{
+		{"registry not configured", nil, "ocudu", "InternalError"},
+		{"provider type unregistered", map[string]provider.NTNProvider{"ocudu": &provider.MockProvider{}}, "other", "UnsupportedProvider"},
+		{"post-apply verification failed", map[string]provider.NTNProvider{
+			"ocudu": &provider.MockProvider{StatusErr: errors.New("configmap read failed")},
+		}, "ocudu", "StatusCheckFailed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "cell-" + tc.wantReason
+			ntnmetrics.ConfigApplyReady.DeletePartialMatch(applyReadyLabels(name))
+			ntnmetrics.ConfigApplyErrorsTotal.DeletePartialMatch(applyReadyLabels(name))
+
+			s := applyReadyScheme(t)
+			cc := ccForApplyReady(name, tc.providerType)
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(cc).WithStatusSubresource(cc).Build()
+			r := &NTNCellConfigReconciler{
+				Client: c, Scheme: s, Providers: tc.providers,
+				Recorder: events.NewFakeRecorder(20),
+			}
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: name, Namespace: applyReadyNS},
+			})
+			if err != nil {
+				t.Fatalf("this branch must return a nil error (that is the whole problem): %v", err)
+			}
+
+			// The condition records the failure...
+			got := &ntnv1alpha1.NTNCellConfig{}
+			if err := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: applyReadyNS}, got); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			cond := findCond(got, ntnv1alpha1.ConditionConfigApplied)
+			if cond == nil || cond.Reason != tc.wantReason {
+				t.Fatalf("ConfigApplied reason = %v, want %s", cond, tc.wantReason)
+			}
+			// ...but the counter does not even get a series, so a rate alert stays silent...
+			if v, found := counterValue(t, ntnmetrics.ConfigApplyErrorsTotal, applyReadyLabels(name)); found && v != 0 {
+				t.Errorf("ConfigApplyErrorsTotal = %v, want 0: this branch is exactly the one the counter misses", v)
+			}
+			// ...so the gauge is the only alertable signal. It must EXIST and be 0 — a missing
+			// series is not "ready 0", it is nothing for `== 0` to ever match.
+			v, found := gaugeValue(t, ntnmetrics.ConfigApplyReady, applyReadyLabels(name))
+			if !found {
+				t.Fatalf("no config_apply_ready series for %s: an absent series can never fire `== 0`", tc.wantReason)
+			}
+			if v != 0 {
+				t.Errorf("config_apply_ready = %v, want 0 for %s", v, tc.wantReason)
+			}
+		})
+	}
+}
+
+// The one failure that DOES increment the counter must also drop the gauge, so the two
+// signals never disagree about whether the apply is currently broken.
+func TestConfigApplyReady_ZeroOnApplyFailure(t *testing.T) {
+	const name = "cell-apply-fail"
+	ntnmetrics.ConfigApplyReady.DeletePartialMatch(applyReadyLabels(name))
+
+	s := applyReadyScheme(t)
+	cc := ccForApplyReady(name, "ocudu")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cc).WithStatusSubresource(cc).Build()
+	r := &NTNCellConfigReconciler{
+		Client: c, Scheme: s, Recorder: events.NewFakeRecorder(20),
+		Providers: map[string]provider.NTNProvider{"ocudu": &provider.MockProvider{ApplyErr: errors.New("boom")}},
+	}
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: applyReadyNS},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if v, found := gaugeValue(t, ntnmetrics.ConfigApplyReady, applyReadyLabels(name)); !found || v != 0 {
+		t.Errorf("config_apply_ready = %v (found=%v), want 0 on an apply failure", v, found)
+	}
+}
+
+// Ready is 1 only after the apply is VERIFIED, and a recovery clears a previous 0 — otherwise
+// the alert would latch on forever once anything had ever failed.
+func TestConfigApplyReady_OneOnVerifiedSuccessAndOnRecovery(t *testing.T) {
+	const name = "cell-recovers"
+	ntnmetrics.ConfigApplyReady.DeletePartialMatch(applyReadyLabels(name))
+
+	s := applyReadyScheme(t)
+	cc := ccForApplyReady(name, "ocudu")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cc).WithStatusSubresource(cc).Build()
+	mock := &provider.MockProvider{StatusErr: errors.New("cannot verify yet")}
+	r := &NTNCellConfigReconciler{
+		Client: c, Scheme: s, Recorder: events.NewFakeRecorder(20),
+		Providers: map[string]provider.NTNProvider{"ocudu": mock},
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: applyReadyNS}}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	if v, found := gaugeValue(t, ntnmetrics.ConfigApplyReady, applyReadyLabels(name)); !found || v != 0 {
+		t.Fatalf("config_apply_ready = %v (found=%v), want 0 while verification fails", v, found)
+	}
+
+	// Cause removed → the next reconcile must flip it back to 1.
+	mock.StatusErr = nil
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	if v, found := gaugeValue(t, ntnmetrics.ConfigApplyReady, applyReadyLabels(name)); !found || v != 1 {
+		t.Errorf("config_apply_ready = %v (found=%v), want 1 once the apply verifies", v, found)
+	}
+}
+
+// The series must be released on CR deletion, like every other per-CR series, or /metrics
+// accumulates dead series across create/delete churn — and a stale 0 would alert forever.
+// Checked via DeletePartialMatch's return count, because reading a deleted gauge with
+// ToFloat64 would silently re-create it at 0 and look identical to "not deleted".
+func TestConfigApplyReady_ReleasedOnDelete(t *testing.T) {
+	const name = "cell-deleted"
+	ntnmetrics.ConfigApplyReady.With(applyReadyLabels(name)).Set(0)
+
+	s := applyReadyScheme(t)
+	cc := ccForApplyReady(name, "ocudu")
+	cc.DeletionTimestamp = &metav1.Time{Time: time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cc).WithStatusSubresource(cc).Build()
+	r := &NTNCellConfigReconciler{Client: c, Scheme: s, Recorder: events.NewFakeRecorder(20)}
+
+	if _, _, err := r.handleFinalizer(context.Background(), cc, nil); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if n := ntnmetrics.ConfigApplyReady.DeletePartialMatch(applyReadyLabels(name)); n != 0 {
+		t.Errorf("the finalizer left %d config_apply_ready series behind; it must release them", n)
+	}
+}
+
+func findCond(cc *ntnv1alpha1.NTNCellConfig, condType string) *metav1.Condition {
+	for i := range cc.Status.Conditions {
+		if cc.Status.Conditions[i].Type == condType {
+			return &cc.Status.Conditions[i]
+		}
+	}
+	return nil
+}

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -262,6 +262,11 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if r.Providers == nil {
 		// Clear stale koffset but preserve ConfigMapRef for best-effort finalizer cleanup.
 		cc.Status.AppliedKoffset = 0
+		// Not ready: this branch increments no counter and returns a nil error, so the gauge
+		// is the only signal an operator can alert on (issue #216).
+		ntnmetrics.ConfigApplyReady.With(prometheus.Labels{
+			"namespace": cc.Namespace, "config": cc.Name,
+		}).Set(0)
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -277,6 +282,11 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if prov == nil {
 		// Clear stale koffset but preserve ConfigMapRef for best-effort finalizer cleanup.
 		cc.Status.AppliedKoffset = 0
+		// Not ready, and this branch does NOT requeue — the permanent case a rate alert can
+		// never sustain on, which is precisely why the gauge exists (issue #216).
+		ntnmetrics.ConfigApplyReady.With(prometheus.Labels{
+			"namespace": cc.Namespace, "config": cc.Name,
+		}).Set(0)
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionFalse,
@@ -308,6 +318,9 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		ntnmetrics.ConfigApplyErrorsTotal.With(prometheus.Labels{
 			"namespace": cc.Namespace, "config": cc.Name, "provider": spec.Provider.Type,
 		}).Inc()
+		ntnmetrics.ConfigApplyReady.With(prometheus.Labels{
+			"namespace": cc.Namespace, "config": cc.Name,
+		}).Set(0)
 		cc.Status.AppliedKoffset = 0
 		// A ConfigMap-ownership collision is distinct from a generic apply failure:
 		// the operator refuses to overwrite a ConfigMap it does not own.
@@ -344,6 +357,12 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	status, err := prov.GetCellStatus(ctx, cc)
 	if err != nil {
 		log.Error(err, "failed to get cell status after apply")
+		// The write may well have landed, but we could not VERIFY it — report not-ready
+		// rather than ready, matching the Unknown condition this branch sets. Like the two
+		// branches above it increments no counter and returns a nil error.
+		ntnmetrics.ConfigApplyReady.With(prometheus.Labels{
+			"namespace": cc.Namespace, "config": cc.Name,
+		}).Set(0)
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionConfigApplied,
 			Status:             metav1.ConditionUnknown,
@@ -358,6 +377,11 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	cc.Status.AppliedKoffset = status.AppliedKoffset
 	cc.Status.ConfigMapRef = status.ConfigMapRef
+	// Applied AND verified — the only path that earns ready=1. This also clears a 0 left by
+	// any of the failure branches above once the cause is fixed.
+	ntnmetrics.ConfigApplyReady.With(prometheus.Labels{
+		"namespace": cc.Namespace, "config": cc.Name,
+	}).Set(1)
 
 	// Step 7: Set success condition. Capture whether it actually changed (status/
 	// reason/generation, or a new object) so the ConfigApplied event fires once per
@@ -511,6 +535,7 @@ func (r *NTNCellConfigReconciler) handleFinalizer(
 		// Release the CR's per-CR metric series on deletion so /metrics does not
 		// accumulate dead series across create/delete churn (idempotent).
 		ntnmetrics.ConfigApplyErrorsTotal.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
+		ntnmetrics.ConfigApplyReady.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		ntnmetrics.EphemerisPushErrorsTotal.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		ntnmetrics.EphemerisPushReady.DeletePartialMatch(prometheus.Labels{"namespace": cc.Namespace, "config": cc.Name})
 		if controllerutil.ContainsFinalizer(cc, finalizerName) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -183,6 +183,25 @@ var (
 		[]string{"namespace", "config"},
 	)
 
+	// ConfigApplyReady is 1 when the CR's NTN config is verifiably applied and 0 when any
+	// step of getting it there failed. It is the config-apply half of issue #216, whose
+	// argument applies here even more strongly than to the push path: ConfigApplyErrorsTotal
+	// is incremented ONLY by an ApplyCellConfig failure, so an unconfigured provider registry
+	// (InternalError), an unregistered provider type (UnsupportedProvider) and a failed
+	// post-apply verification (StatusCheckFailed) increment it ZERO times — and they return a
+	// nil error, so controller_runtime_reconcile_errors_total does not see them either. Those
+	// failures were invisible to every shipped alert. UnsupportedProvider additionally does
+	// not requeue, so it is exactly the permanent case a rate alert can never catch. Keyed
+	// namespace+config like EphemerisPushReady — deliberately WITHOUT the counter's provider
+	// label, so a provider-type edit cannot strand a stale series at 0 under the old value.
+	ConfigApplyReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ntn_operators_config_apply_ready",
+			Help: "1 if the CR's NTN config is verifiably applied, 0 if applying or verifying it failed.",
+		},
+		[]string{"namespace", "config"},
+	)
+
 	// ReaderQueryDuration measures how long a single PromQL fetch made
 	// through a pkg/slice/metrics Reader takes, split by source
 	// ("prometheus") and outcome ("success" or "error"). A higher-level
@@ -260,6 +279,7 @@ func init() {
 		SatellitePassAvailable,
 		GroundStationHealth,
 		ConfigApplyErrorsTotal,
+		ConfigApplyReady,
 		GPFetchDuration,
 		GPSatelliteCount,
 		GPDeepSpaceRejectedCount,


### PR DESCRIPTION
Completes #216. Every claim below was checked against the code before being accepted.

## The tracking gap is real

#216's body scopes **both** gauges, in as many words:

> Apply the same readiness pattern to `ConfigApplyErrorsTotal` (`ntn_operators_config_apply_ready`) so runtime push and config apply are consistent, rather than leaving an asymmetry (push has readiness, apply does not).

…under a heading that reads *"Do this **holistically**, not as a one-metric bolt-on."*

PR #218 — titled "readiness gauges for ephemeris push & GP fetch (#216)" — shipped `ephemeris_push_ready` and `gp_fetch_ready` and closed the issue. `config_apply_ready` was never written. The closure was premature; I've left a correction on #216.

## The gap is worse than a missing symmetry

`ConfigApplyErrorsTotal` is incremented in exactly **one** place — the `ApplyCellConfig` failure branch. Three other ways the apply can be broken increment it **zero** times *and* return a **nil error**, so neither `NTNConfigApplyErrors` (a rate alert on that counter) nor `controller_runtime_reconcile_errors_total` can see them:

| `ConfigApplied` reason | Cause | Requeues? | Counter? | Reconcile error? |
|---|---|---|---|---|
| `InternalError` | provider registry not configured | 1m | ✗ | ✗ |
| `UnsupportedProvider` | `spec.provider.type` unregistered | **no** | ✗ | ✗ |
| `StatusCheckFailed` | post-apply read could not verify | 1m | ✗ | ✗ |
| `ApplyFailed` / `OwnershipConflict` | `ApplyCellConfig` failed | 1m | ✓ | ✗ |

`UnsupportedProvider` is the permanent, non-requeuing case that motivated the gauge for the push path in the first place — and here the counter does not even emit the single sample the push path got. Config apply was therefore *strictly worse off* than ephemeris push was before #216.

The review's own counter-consideration is fair and I checked it: `ProviderRef.Type` carries `+kubebuilder:validation:Enum=ocudu`, so a newly created CR cannot reach `UnsupportedProvider`. That constrains one row. It does not touch `InternalError` or `StatusCheckFailed`, and it does not apply to objects stored before the enum or if the enum widens.

## Change

- `ntn_operators_config_apply_ready{namespace,config}` — 1 only on a **verified** apply, 0 on all four failure paths, `DeletePartialMatch` on CR deletion.
- Alert **`NTNConfigApplyNotReady`** (`== 0` for 15m), companion to the existing rate alert.
- Runbook section that triages **by `ConfigApplied` reason**, because the three causes have genuinely different fixes (operator wiring / spec edit / ConfigMap access) — including the `jsonpath` to read the reason.

### Deliberate deviation from the proposal

The proposal was `{namespace, config, provider}`, matching the counter's labels. **I dropped the `provider` label.** Both existing readiness gauges are 2-label (`ephemeris_push_ready{namespace,config}`, `gp_fetch_ready{namespace,ephemeris}`), and a label that can change identity needs stale-series management a 2-label gauge simply does not have: a `spec.provider.type` edit would otherwise strand a series at 0 under the old value and alert forever. That also makes the proposal's "clean up stale series when the provider path is disabled" requirement unnecessary rather than implemented-and-fragile. Joining to the counter on `{namespace,config}` still works.

## SmallCL / Boy Scout notes

One logical change, ~200 lines including tests and docs. I deliberately did **not** factor out the repeated `prometheus.Labels{"namespace": …, "config": …}` map even though it now appears nine times in this file: #297, #301 and #304 are all open against `ntncellconfig_controller.go`, and one of them touches the adjacent `EphemerisPushReady` metric block. Tidying there would buy a cosmetic win and pay for it in merge conflicts. Left as-is, matching the surrounding idiom.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2`: **0 issues**; `gofmt` clean.
- `go test ./internal/controller/... ./pkg/...` green (envtest 1.36.2).
- `helm template` renders the new rule.
- **The tests read gauges without instantiating them.** `testutil.ToFloat64(g.With(labels))` creates a missing series at 0, so a naive "want 0" assertion passes even with the production code deleted — the first version of these tests had exactly that hole. `gaugeValue`/`counterValue` collect and match labels, returning a `found` bool, which is what makes the assertions load-bearing.
- **Mutation-verified per set-point**, each reverting only itself:
  - drop the three `Set(0)` calls → `no config_apply_ready series for InternalError: an absent series can never fire == 0`
  - drop the success `Set(1)` → `config_apply_ready = 0 (found=true), want 1 once the apply verifies`
  - drop the `DeletePartialMatch` → `the finalizer left 1 config_apply_ready series behind`
