### PR TITLE
fix(ntncellconfig): guard the failure early-return status writes (WO-20 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to every referencing `NTNCellConfig` and bumped the ConfigMap's `resourceVersion`, churning
   every watcher. It now skips the write when the stored content (config + koffset annotation)
   already matches and the ConfigMap is already owned (#204-G3).
+- **`NTNCellConfig` failure early returns no longer re-write an identical status every requeue.**
+  The reconcile already skipped a byte-identical *terminal* status write, but the failure early
+  returns — provider registry/type unusable, `ApplyCellConfig` failing, post-apply `GetCellStatus`
+  failing, and an ephemeris-push failure — still called `Status().Update` unconditionally, so a
+  persistent outage re-sent an identical `ConfigApplied=False`/`EphemerisPushed=False` through API
+  handling, admission, and the watch stream on every (minutely) requeue. A `persistStatusIfChanged`
+  helper (mirroring the NTNSlice one) now guards every status write, terminal and early-return alike;
+  the episode-gated events keep the WO-20 emit-after-persist discipline (any change that would emit
+  also fails the DeepEqual and writes). Verified by counting status subresource requests, since the
+  apiserver short-circuits a byte-identical write without a `resourceVersion` bump.
 - **`SatelliteEphemeris`→`NTNCellConfig` fan-out uses a `spec.ephemerisRef` field index.**
   The mapper resolved referencing cells by scanning every `NTNCellConfig` in the namespace and
   filtering in Go; it now uses an indexed cache lookup (registered in `SetupWithManager`), with

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -250,7 +250,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message:            "NTN provider registry is not configured",
 			ObservedGeneration: cc.Generation,
 		})
-		if err := r.Status().Update(ctx, cc); err != nil {
+		if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
@@ -265,7 +265,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message:            fmt.Sprintf("Provider type %q is not registered", cc.Spec.Provider.Type),
 			ObservedGeneration: cc.Generation,
 		})
-		if err := r.Status().Update(ctx, cc); err != nil {
+		if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -310,7 +310,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message:            err.Error(),
 			ObservedGeneration: cc.Generation,
 		})
-		if err := r.Status().Update(ctx, cc); err != nil {
+		if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
 			return ctrl.Result{}, err
 		}
 		if applyFailEpisode && r.Recorder != nil {
@@ -332,7 +332,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message:            fmt.Sprintf("Config applied but status verification failed: %v", err),
 			ObservedGeneration: cc.Generation,
 		})
-		if err := r.Status().Update(ctx, cc); err != nil {
+		if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
@@ -392,7 +392,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				Message:            message,
 				ObservedGeneration: cc.Generation,
 			})
-			if err := r.Status().Update(ctx, cc); err != nil {
+			if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
 				return ctrl.Result{}, err
 			}
 			// This persist path durably records the ConfigApplied=True transition, so
@@ -450,15 +450,11 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}).Set(1)
 	}
 
-	// Skip the write when this reconcile did not change the status (an ephemeris-watch fan-out or a
-	// periodic requeue that found nothing to do): a byte-identical Status().Update is producer churn
-	// the API server, admission and the watch stream still process. The events below stay
-	// episode-gated, so they self-limit independently of whether the write happened, and the state
-	// they describe is already persisted.
-	if !equality.Semantic.DeepEqual(oldStatus, &cc.Status) {
-		if err := r.Status().Update(ctx, cc); err != nil {
-			return ctrl.Result{}, err
-		}
+	// Terminal persist (skipped when unchanged — e.g. an ephemeris-watch fan-out that found the
+	// config already applied). The events below stay episode-gated, so they self-limit whether or
+	// not this write happened, and the state they describe is already persisted.
+	if err := r.persistStatusIfChanged(ctx, cc, oldStatus); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if configApplyChanged {
@@ -468,6 +464,20 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.Info("NTN cell configuration applied successfully")
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// persistStatusIfChanged writes cc.Status only when this reconcile changed it, so a no-op
+// reconcile — or a persistent-failure early return that re-derives an identical condition on
+// every requeue — does not churn the API server, admission, and the watch stream (#188). Event
+// emits stay gated on the SAME change, so a skipped write never breaks the WO-20
+// emit-after-persist discipline: any change that would emit also fails this DeepEqual and writes.
+func (r *NTNCellConfigReconciler) persistStatusIfChanged(
+	ctx context.Context, cc *ntnv1alpha1.NTNCellConfig, oldStatus *ntnv1alpha1.NTNCellConfigStatus,
+) error {
+	if equality.Semantic.DeepEqual(oldStatus, &cc.Status) {
+		return nil
+	}
+	return r.Status().Update(ctx, cc)
 }
 
 // handleFinalizer manages ConfigMap cleanup on NTNCellConfig deletion.

--- a/internal/controller/ntncellconfig_controller_test.go
+++ b/internal/controller/ntncellconfig_controller_test.go
@@ -581,6 +581,50 @@ var _ = Describe("NTNCellConfig Controller", func() {
 			Expect(statusUpdates).To(Equal(0), "a steady no-op reconcile must not issue a Status().Update request")
 		})
 
+		It("should not re-write status on a repeated identical early-return failure (WO-20 P2)", func() {
+			createReferencedEphemeris()
+			createCellConfig()
+
+			// #271 guarded only the terminal success write; the failure early returns still wrote
+			// unconditionally. A persistent ApplyCellConfig failure re-derives an identical
+			// ConfigApplied=False every requeue, so after the first persist the write must stop.
+			// Count Status().Update REQUESTS (not resourceVersion — the apiserver short-circuits a
+			// byte-identical write silently, hiding the request the controller still sent).
+			statusUpdates := 0
+			mock := &provider.MockProvider{ApplyErr: errors.New("apply boom")}
+			reconciler := &NTNCellConfigReconciler{
+				Client:    &countingStatusClient{Client: k8sClient, statusUpdates: &statusUpdates},
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(10),
+				Providers: map[string]provider.NTNProvider{"ocudu": mock},
+			}
+
+			// The very first reconcile only adds the finalizer and requeues (before ApplyCellConfig),
+			// so drive it once to get past that bootstrap; later reconciles exercise the apply failure.
+			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The first apply failure persists ConfigApplied=False exactly once.
+			statusUpdates = 0
+			_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusUpdates).To(Equal(1), "the first apply failure must persist ConfigApplied=False")
+
+			// A repeated identical failure must NOT re-write the byte-identical status.
+			statusUpdates = 0
+			result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+			Expect(statusUpdates).To(Equal(0), "a repeated identical apply failure must not re-write status")
+
+			// But a genuine change (recovery) must still write — the guard must not over-suppress.
+			mock.ApplyErr = nil
+			statusUpdates = 0
+			_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: cellNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusUpdates).To(BeNumerically(">=", 1), "recovery to ConfigApplied=True must write status")
+		})
+
 		It("should keep ConfigApplied true and set EphemerisPushed=false when push fails", func() {
 			createReferencedEphemeris()
 			createCellConfig()


### PR DESCRIPTION
Completes the WO-20 no-op-status-write hygiene for `NTNCellConfig`. Verified against current `origin/main` (`badf55e`).

## The gap (confirmed)

`Reconcile` snapshots `oldStatus` up front, but #271 used that guard only on the **terminal** success write. Every **failure early return** still called `Status().Update` unconditionally:

| line | path | requeue |
|---|---|---|
| provider registry `nil` (`InternalError`) | `r.Providers == nil` | 1 min |
| provider type unregistered (`UnsupportedProvider`) | `prov == nil` | none |
| `ApplyCellConfig` fails (`ApplyFailed`/`OwnershipConflict`) | Step 5 | 1 min |
| post-apply `GetCellStatus` fails (`StatusCheckFailed`) | Step 6 | 1 min |
| ephemeris push fails (`EphemerisPushed=False`) | Step 8 | 1 / 5 min |

During a persistent outage each re-derives a **byte-identical** condition and re-sends it through API handling, admission, and the watch stream every requeue. Not corruption — but real churn, and tests end up depending on the apiserver silently short-circuiting the identical write.

## Fix

Extract `persistStatusIfChanged` — a typed method mirroring the existing `NTNSliceReconciler.persistStatusIfChanged` (#281) — and route **every** status write through it, the early returns and the terminal one alike.

- **Scope note:** the reviewer listed four paths; I also guarded the fifth (the ephemeris-push failure at Step 8), which churns identically, for uniformity. It was safe to include: the `emitConfigApplied`/`emitCadenceWarn` calls after it are gated on the *same* change, so the WO-20 emit-after-persist discipline holds — any change that would emit also fails the DeepEqual and writes. The per-failure `EphemerisPushErrorsTotal` metric still increments every reconcile (it is intentionally independent of the write).
- **Design choice:** a typed per-controller helper rather than the reviewer's generic `persistStatusIfChanged(..., oldStatus, newStatus any, obj)` — it matches the existing NTNSlice helper and keeps type safety without `any`.
- **Boy Scout:** the terminal inline `if !DeepEqual { … }` is folded into the same helper, so the DeepEqual logic lives in one place.

## Test (mutation-verified)

`should not re-write status on a repeated identical early-return failure (WO-20 P2)` drives a persistent `ApplyCellConfig` failure and asserts, via `countingStatusClient`, that the **first** failure persists once, a **repeated identical** failure issues **zero** status writes, and a **recovery** writes again. It counts status-subresource *requests* (not `resourceVersion`, which the apiserver short-circuits on an identical write), as the reviewer asked.

Disabling the guard makes the "repeated identical failure" assertion fail — confirmed. Full `internal/controller` envtest suite green; `go vet`, `gofmt` clean.

Small, single-file CL (+ its test).