### PR TITLE
fix(provider): verify ConfigMap ownership in GetCellStatus

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -322,7 +322,7 @@ func (r *NTNCellConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// ApplyCellConfig, so no separate best-effort ownership step is needed.
 
 	// Step 6: Get applied status from provider.
-	status, err := prov.GetCellStatus(ctx, cc.Name, spec.Provider.Namespace)
+	status, err := prov.GetCellStatus(ctx, cc)
 	if err != nil {
 		log.Error(err, "failed to get cell status after apply")
 		meta.SetStatusCondition(&cc.Status.Conditions, metav1.Condition{

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -118,8 +118,11 @@ type NTNProvider interface {
 		ctx context.Context, owner *ntnv1alpha1.NTNCellConfig, spec *ntnv1alpha1.NTNCellConfigSpec, scheme *runtime.Scheme,
 	) error
 
-	// GetCellStatus returns the current applied configuration status.
-	GetCellStatus(ctx context.Context, crName, namespace string) (*ntnv1alpha1.NTNCellConfigStatus, error)
+	// GetCellStatus returns the applied configuration status for owner's ConfigMap. It verifies the
+	// ConfigMap is controller-owned by owner (metav1.IsControlledBy) before trusting it, so a same-name
+	// foreign object squatting the name — e.g. one created between ApplyCellConfig and this read-back —
+	// is never reported as the CR's applied config (ErrConfigMapNotOwned).
+	GetCellStatus(ctx context.Context, owner *ntnv1alpha1.NTNCellConfig) (*ntnv1alpha1.NTNCellConfigStatus, error)
 
 	// PushEphemerisUpdate pushes fresh ephemeris data to the backend by rewriting
 	// the bootstrap ConfigMap (the gNB must reload). Kept as the baseline path. It

--- a/pkg/provider/mock.go
+++ b/pkg/provider/mock.go
@@ -63,7 +63,9 @@ func (m *MockProvider) ApplyCellConfig(
 	return m.ApplyErr
 }
 
-func (m *MockProvider) GetCellStatus(_ context.Context, _, _ string) (*ntnv1alpha1.NTNCellConfigStatus, error) {
+func (m *MockProvider) GetCellStatus(
+	_ context.Context, _ *ntnv1alpha1.NTNCellConfig,
+) (*ntnv1alpha1.NTNCellConfigStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.StatusCalls++

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -244,10 +244,12 @@ func (p *Provider) ApplyCellConfig(
 
 // GetCellStatus derives status by reading the ConfigMap in the given namespace.
 func (p *Provider) GetCellStatus(
-	ctx context.Context, crName, namespace string,
+	ctx context.Context, owner *ntnv1alpha1.NTNCellConfig,
 ) (*ntnv1alpha1.NTNCellConfigStatus, error) {
 	status := &ntnv1alpha1.NTNCellConfigStatus{}
 
+	crName := owner.GetName()
+	namespace := owner.GetNamespace()
 	if namespace == "" {
 		return status, fmt.Errorf("namespace must not be empty")
 	}
@@ -259,6 +261,13 @@ func (p *Provider) GetCellStatus(
 			return status, nil
 		}
 		return status, fmt.Errorf("reading ConfigMap %s/%s: %w", namespace, ConfigMapNameFor(crName), err)
+	}
+
+	// Verify ownership before reporting status: a same-name ConfigMap the operator does not control
+	// (e.g. a foreign object created between ApplyCellConfig and this read-back) must NOT be reported as
+	// the CR's applied config. Mirrors Cleanup / PushEphemerisUpdate.
+	if !metav1.IsControlledBy(cm, owner) {
+		return status, fmt.Errorf("%w: %s/%s", provider.ErrConfigMapNotOwned, namespace, ConfigMapNameFor(crName))
 	}
 
 	status.ConfigMapRef = cm.Name

--- a/pkg/provider/ocudu/provider_test.go
+++ b/pkg/provider/ocudu/provider_test.go
@@ -323,7 +323,7 @@ func TestGetCellStatus_ReturnsAppliedConfig(t *testing.T) {
 		t.Fatalf("ApplyCellConfig: %v", err)
 	}
 
-	status, err := p.GetCellStatus(ctx, "test-cr", "ntn-system")
+	status, err := p.GetCellStatus(ctx, ownerFor("test-cr"))
 	if err != nil {
 		t.Fatalf("GetCellStatus error: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestGetCellStatus_NoConfigMap(t *testing.T) {
 	p := newTestProvider(t)
 	ctx := context.Background()
 
-	status, err := p.GetCellStatus(ctx, "test-cr", "ntn-system")
+	status, err := p.GetCellStatus(ctx, ownerFor("test-cr"))
 	if err != nil {
 		t.Fatalf("GetCellStatus should not error: %v", err)
 	}
@@ -415,9 +415,12 @@ func TestConfigMapNameFor_Short(t *testing.T) {
 }
 
 func TestGetCellStatus_MissingGeoNtn(t *testing.T) {
-	// ConfigMap exists but missing geo_ntn.yml key.
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
+	// ConfigMap exists AND is owned by the CR, but is missing the geo_ntn.yml key — so the missing-key
+	// error (not the ownership check) is what fires.
+	scheme := ownerScheme(t)
+	owner := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns", UID: types.UID("uid-test")},
+	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ConfigMapNameFor("test"),
@@ -428,11 +431,44 @@ func TestGetCellStatus_MissingGeoNtn(t *testing.T) {
 		},
 		Data: map[string]string{}, // missing geo_ntn.yml
 	}
+	if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
+		t.Fatalf("SetControllerReference: %v", err)
+	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 	p := &Provider{client: c}
-	_, err := p.GetCellStatus(context.Background(), "test", "ns")
+	_, err := p.GetCellStatus(context.Background(), owner)
 	if err == nil {
 		t.Fatal("expected error for missing geo_ntn.yml")
+	}
+}
+
+// TestGetCellStatus_ForeignConfigMapNotReported pins the ownership check: a same-name ConfigMap the CR
+// does NOT control — e.g. a foreign object that replaced the CR's ConfigMap between ApplyCellConfig and
+// this read-back — must not be reported as the CR's applied config. It returns ErrConfigMapNotOwned and
+// leaves status.ConfigMapRef empty, so the caller does not set ConfigApplied=True off a foreign object.
+func TestGetCellStatus_ForeignConfigMapNotReported(t *testing.T) {
+	scheme := ownerScheme(t)
+	owner := ownerFor("test-cr") // UID uid-test-cr
+	// A same-name ConfigMap controlled by a DIFFERENT CR.
+	foreignOwner := &ntnv1alpha1.NTNCellConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "intruder", Namespace: "ntn-system", UID: types.UID("uid-intruder")},
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapNameFor("test-cr"), Namespace: "ntn-system"},
+		Data:       map[string]string{configDataKey: "who: foreign"},
+	}
+	if err := controllerutil.SetControllerReference(foreignOwner, cm, scheme); err != nil {
+		t.Fatalf("SetControllerReference: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	p := &Provider{client: c}
+
+	status, err := p.GetCellStatus(context.Background(), owner)
+	if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+		t.Fatalf("a foreign same-name ConfigMap must return ErrConfigMapNotOwned, got %v", err)
+	}
+	if status.ConfigMapRef != "" {
+		t.Errorf("a foreign ConfigMap must not populate status.ConfigMapRef, got %q", status.ConfigMapRef)
 	}
 }
 


### PR DESCRIPTION
`GetCellStatus` was the only provider method reading the ConfigMap by name **without** `metav1.IsControlledBy` (unlike `Cleanup` / `PushEphemerisUpdate`). A same-name foreign ConfigMap at read-back (one that replaced the CR's between `ApplyCellConfig` and this read) would be reported as the CR's applied config → a brief false `ConfigApplied=True`.

**Fix (Option 1 from the review):** take `owner *NTNCellConfig`, verify `IsControlledBy` after the read, return `ErrConfigMapNotOwned` for a foreign object (→ controller sets `ConfigApplied=Unknown/StatusCheckFailed`, not a false True). `owner.GetNamespace()` equals the old `spec.Provider.Namespace` arg — the controller already forces them equal (cross-namespace controllerRef is illegal) — so it's behaviour-preserving for the owned case. Rejected Option 2 (ApplyCellConfig returns status) as over-scoped: it doesn't remove the need for read-back ownership verification.

**Test:** `TestGetCellStatus_ForeignConfigMapNotReported` (foreign same-name CM → `ErrConfigMapNotOwned`, empty `ConfigMapRef`), mutation-verified. Existing tests pass the owner. `gofmt`/`vet`/`golangci-lint` clean; full provider + controller suites pass.