### PR TITLE
feat(chart): opt-in admission policy closing the remoteControl.tls confused deputy (#251)

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -139,6 +139,25 @@ jobs:
           { [ -n "$lease" ] && [ "$lease" -le 15 ]; } || { echo "FAIL: leaderLeaseDuration='$lease's exceeds the pinned 15s HA failover budget"; exit 1; }
           echo "leaderLeaseDuration=${lease}s (<= 15s HA budget) OK"
 
+      # #251 / ADR-0009: the credential-reference admission policy must be OFF by default (turning
+      # it on is a real tightening) and, when on, must carry the authorizer check that IS the
+      # boundary. A render that silently dropped the authorizer expression would look installed
+      # while authorizing nothing, so assert the expression itself, not just the object count.
+      - name: Verify credential-ref admission policy (default off, authorizer present when on)
+        run: |
+          set -euo pipefail
+          H=./bin/helm
+          off=$($H template t ./dist/chart | grep -c '^kind: ValidatingAdmissionPolicy' || true)
+          [ "$off" = "0" ] || { echo "FAIL: credentialRefPolicy must be opt-in; default render produced $off policies"; exit 1; }
+          on=$($H template t ./dist/chart --set credentialRefPolicy.enable=true \
+                 -s templates/admission/credential-ref-policy.yaml)
+          echo "$on" | grep -q 'kind: ValidatingAdmissionPolicy$' || { echo "FAIL: policy not rendered when enabled"; exit 1; }
+          echo "$on" | grep -q 'kind: ValidatingAdmissionPolicyBinding$' || { echo "FAIL: binding not rendered when enabled"; exit 1; }
+          echo "$on" | grep -q "authorizer.group('').resource('secrets')" || { echo "FAIL: the authorizer check is missing — the policy would authorize nothing"; exit 1; }
+          echo "$on" | grep -q "check('get').allowed()" || { echo "FAIL: the authorizer check does not assert 'get' is allowed"; exit 1; }
+          echo "$on" | grep -q 'failurePolicy: Fail' || { echo "FAIL: failurePolicy must default to Fail"; exit 1; }
+          echo "credential-ref policy OK (off by default; authorizer check present when enabled)"
+
       # #230 item 1: the active-passive HA topology the design relies on was never asserted structurally.
       # A drift that dropped the soft anti-affinity, changed the default replica count, misaligned the PDB
       # selector (so it stops selecting the manager pods → minAvailable silently protects nothing), or picked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **`NTNConfigApplyNotReady`** (`== 0` for 15m) and a runbook section keyed by the `ConfigApplied`
   reason ship with it. Keyed `namespace`+`config` like `ephemeris_push_ready`, deliberately without
   the counter's `provider` label so a provider-type edit cannot strand a stale series at 0.
+- **Opt-in `ValidatingAdmissionPolicy` closing the `remoteControl.tls` confused deputy (#251).** The
+  operator reads the Secret named by `spec.provider.remoteControl.tls.secretName` with its own
+  cluster-wide `secrets get` and presents it to a CR-author-controlled endpoint, so a principal
+  holding only `ntncellconfig-editor-role` — which grants NTNCellConfig write but **no** `secrets
+  get` — could cause a credential it cannot read to be used. #300 shipped an admin endpoint
+  allow-list as the interim control, constraining the *destination*; this adds the actual
+  authorization boundary on the *reference*: the principal writing the CR must hold `get` on the
+  Secret. ADR-0009 deferred this on the grounds that a SAR needs admission-webhook infrastructure;
+  that rationale was wrong and the ADR is amended — `ValidatingAdmissionPolicy` (GA in Kubernetes
+  1.30; this chart already requires >= 1.31) evaluates CEL inside kube-apiserver and exposes the
+  authorizer library, so there is no webhook, no serving certificate, and **no new operator RBAC**
+  (the API server performs the check). Verified end-to-end on a live 1.36.3 cluster with the shipped
+  artifact: an unprivileged tenant is refused on CREATE and on UPDATE, is allowed once granted `get`,
+  and a plaintext push is never gated. **Off by default** (`credentialRefPolicy.enable=false`) —
+  enabling it is a real tightening, and stored objects are only re-checked on their next write, so
+  start with `validationActions: [Warn, Audit]`.
 
 - **Durable conditional-GET validators for the OMM cache (polite restart/failover refetch).** The
   CelesTrak fetcher already used an in-memory `If-None-Match` conditional GET, but the ETag was lost on

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,7 @@ This project implements the following security practices:
 - **Namespace isolation**: Controllers enforce that provider operations stay within the CR's own namespace
 - **CEL CRD validation**: Server-side validation rules (URL scheme, lat/lon range, credential requirements) without webhook infrastructure
 - **Secret management**: SpaceTrack credentials read from K8s Secrets with a minimal RBAC of `secrets:get` only — an uncached, per-request read. The operator holds no `list` or `watch` on Secrets.
+- **Credential-reference authorization** (opt-in, `credentialRefPolicy.enable`): a `ValidatingAdmissionPolicy` requiring the principal who writes an `NTNCellConfig` to hold `get` on the Secret its `spec.provider.remoteControl.tls.secretName` references. The operator reads that Secret with its own privilege and presents it to a CR-author-chosen endpoint, so without this a principal who can write the CR but not read the Secret can still cause it to be used — a confused deputy (#251, ADR-0009). Enforced inside kube-apiserver, so it needs no webhook and grants the operator no extra RBAC. **Off by default**: enabling it is a real tightening, so run it with `validationActions: [Warn, Audit]` first. Complements the admin endpoint allow-list (`--remote-control-allowed-endpoint-hosts`), which constrains the destination rather than the reference.
 - **Read-only filesystem**: Container runs with `readOnlyRootFilesystem: true`
 - **Non-root execution**: Container runs as UID 65532 (distroless nonroot)
 - **Minimal capabilities**: All Linux capabilities are dropped

--- a/dist/chart/templates/admission/credential-ref-policy.yaml
+++ b/dist/chart/templates/admission/credential-ref-policy.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.credentialRefPolicy.enable }}
+# Closes the remoteControl.tls confused deputy (#251, ADR-0009) at admission: the principal
+# writing the NTNCellConfig must itself be able to `get` the Secret it references.
+#
+# The operator holds cluster-wide `secrets get` and authenticates to a CR-author-controlled
+# endpoint, so without this a principal holding only `ntncellconfig-editor-role` can point a
+# credential it cannot read at a destination it chooses. ADR-0009 shipped an admin endpoint
+# allow-list as the interim control; this is the real authorization boundary.
+#
+# It runs INSIDE kube-apiserver — no webhook, no serving certificate, no failurePolicy
+# plumbing, and the operator gains no new RBAC (the API server performs the check, not us).
+# The CEL `authorizer` library is available in all supported versions and this chart already
+# requires >=1.31, comfortably above ValidatingAdmissionPolicy's GA in 1.30.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "ntn-operators.fullname" . }}-credential-ref
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  failurePolicy: {{ .Values.credentialRefPolicy.failurePolicy }}
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["ntn.operators.dev"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["ntncellconfigs"]
+  validations:
+    # Only credentialed pushes are gated: a CR with no remoteControl.tls borrows no privilege,
+    # so it is none of this policy's business.
+    - expression: >-
+        !has(object.spec.provider.remoteControl) ||
+        !has(object.spec.provider.remoteControl.tls) ||
+        authorizer.group('').resource('secrets')
+          .namespace(request.namespace)
+          .name(object.spec.provider.remoteControl.tls.secretName)
+          .check('get').allowed()
+      reason: Forbidden
+      message: >-
+        spec.provider.remoteControl.tls.secretName references a Secret you cannot read.
+        The operator would read it on your behalf and present it to
+        spec.provider.remoteControl.endpoint, so you must hold `get` on that Secret to
+        reference it (ADR-0009 / issue #251).
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "ntn-operators.fullname" . }}-credential-ref
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ntn-operators.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  policyName: {{ include "ntn-operators.fullname" . }}-credential-ref
+  validationActions: {{ toYaml .Values.credentialRefPolicy.validationActions | nindent 4 }}
+  {{- with .Values.credentialRefPolicy.namespaceSelector }}
+  matchResources:
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -116,6 +116,36 @@ metrics:
   # Metrics server port
   port: 8443
 
+## Admission policy closing the remoteControl.tls confused deputy (#251, ADR-0009).
+## Requires the principal writing an NTNCellConfig to hold `get` on the Secret its
+## spec.provider.remoteControl.tls.secretName references — the operator reads that Secret
+## with its own cluster-wide privilege and presents it to a CR-author-chosen endpoint, so
+## without this a principal who can write the CR but not read the Secret can still use it.
+##
+## Runs inside kube-apiserver as a ValidatingAdmissionPolicy: no webhook, no serving
+## certificate, and the operator gains no extra RBAC. Needs Kubernetes >= 1.30 (this chart
+## already requires >= 1.31).
+##
+## Default OFF because it is a real tightening: any existing NTNCellConfig whose author
+## cannot read the referenced Secret will fail its NEXT write (the policy gates admission,
+## so objects already stored are untouched until updated). Turn it on once you have checked
+## who writes these CRs. Start with validationActions [Warn, Audit] to find violators
+## without breaking them, then move to [Deny].
+##
+credentialRefPolicy:
+  enable: false
+  # Deny | Warn | Audit — combine as needed, e.g. [Warn, Audit] for a dry run.
+  validationActions:
+    - Deny
+  # Fail is correct here: a policy that cannot evaluate must not silently permit a
+  # privilege-borrowing reference.
+  failurePolicy: Fail
+  # Optional: limit the policy to selected namespaces, e.g.
+  #   namespaceSelector:
+  #     matchLabels:
+  #       ntn.operators.dev/multi-tenant: "true"
+  namespaceSelector: {}
+
 ## Cert-manager integration for TLS certificates.
 ## Required for the metrics endpoint certificates.
 ##

--- a/docs/adr/0009-remote-control-credential-confused-deputy.md
+++ b/docs/adr/0009-remote-control-credential-confused-deputy.md
@@ -1,6 +1,6 @@
 # ADR 0009 — Confused-deputy boundary for remoteControl.tls credential reads
 
-- Status: **Accepted** (interim endpoint allow-list shipped here); full per-CR authorization **deferred**
+- Status: **Accepted**, **amended 2026-07-31** — see [Amendment](#amendment-2026-07-31--the-deferral-rationale-was-wrong). The interim endpoint allow-list stands; the deferral of the full per-CR authorization does **not**.
 - Date: 2026-07-31
 - Deciders: @thc1006
 - Relates to: #219 (label/type opt-in gate), #251 (this confused-deputy follow-up), the N-12 runtime TLS/bearer/mTLS push. Builds on the existing SSRF allow-list (`--prometheus-allowed-endpoint-hosts`, `--ephemeris-allowed-private-hosts`) and `pkg/netutil.EndpointAllowlist`.
@@ -46,3 +46,45 @@ Two-part, matching the actual (same-namespace, low-adoption) shape of the proble
 ## Testing
 
 `TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist` pins all four arms: a credentialed push to a non-allowlisted endpoint is refused (`RemoteControlConfigInvalid`, `errRemoteControlEndpointNotAllowed`) **and the provider is never called** (the credential does not leave the operator) — the refused case provisions **no** Secret, so getting the endpoint error (rather than credential-unavailable) proves the endpoint is checked before the Secret read (no oracle); an allowlisted credentialed push proceeds; an empty allow-list permits any endpoint (opt-in); and a plaintext push is never gated. Mutation-verified by neutering the `rc.TLS != nil` check (the attacker-endpoint case then pushes).
+
+---
+
+## Amendment 2026-07-31 — the deferral rationale was wrong
+
+The Rationale bullet **"SAR needs infrastructure we do not have yet"** is incorrect, and with it the decision to defer the full boundary. It reads:
+
+> There is no admission webhook in the operator today; a SAR check requires the requester identity (`req.UserInfo`), which a reconcile does not carry — only a validating webhook does. That is real infrastructure (serving cert, `failurePolicy`, envtest wiring) and should be a deliberate, separately-reviewed step, not bundled here.
+
+**A validating webhook is not the only thing that carries the requester identity.** `ValidatingAdmissionPolicy` — GA since Kubernetes 1.30, and this chart already requires `>=1.31` — evaluates CEL *inside kube-apiserver*, and its CEL environment exposes the Kubernetes **authorizer library**. The exact check this ADR wanted can be written declaratively:
+
+```cel
+authorizer.group('').resource('secrets')
+  .namespace(request.namespace)
+  .name(object.spec.provider.remoteControl.tls.secretName)
+  .check('get').allowed()
+```
+
+None of the deferred cost is real for this route: no webhook deployment, **no serving certificate**, no `failurePolicy` plumbing beyond a field, and — importantly — **the operator gains no new RBAC**, because the API server performs the authorization check rather than the controller. A reconcile-time SAR would have needed `create subjectaccessreviews`; this needs nothing.
+
+### Verified, not assumed
+
+Checked end-to-end against a live Kubernetes **1.36.3** cluster using the artifact this chart now ships (not a hand-written approximation), with a ServiceAccount holding `ntncellconfigs` write and **no** `secrets get`:
+
+| Case | Result |
+|---|---|
+| tenant without `secrets get`, CR references a labelled credential | **Forbidden** by the policy |
+| same tenant after being granted `get` on that Secret | created |
+| same tenant, **plaintext** CR (no `remoteControl.tls`) | created — correctly ungated |
+| tenant without `secrets get`, **UPDATE** of an existing credentialed CR | **Forbidden** |
+
+### Revised decision
+
+1. The interim endpoint allow-list **stands** and is still worth having: it constrains the *destination*, which is orthogonal to who may *reference* the credential, and it protects the CRs that already exist.
+2. The per-CR authorization boundary ships as an **opt-in chart artifact** (`credentialRefPolicy.enable`, default `false`), because turning it on is a real tightening: the policy gates admission, so stored objects are untouched until their next write, and an operator should first run it with `validationActions: [Warn, Audit]` to find violators.
+3. What remains deferred is only the **default**: flipping `credentialRefPolicy.enable` to `true`, once adoption is understood. That is a much smaller open question than "build webhook infrastructure".
+
+### What this does NOT solve
+
+- **Objects already stored** are not re-validated; the policy applies on their next write.
+- **A privileged writer acting for someone else** — a GitOps controller or CI identity with broad rights — passes the check, because the authorized principal is whoever submits the object. This is inherent to authorization-at-admission and would be equally true of a webhook; where tenants submit through such a pipeline, the pipeline is the trust boundary.
+- The `patch`-without-`get` labelling vector from #219 is unchanged: this gates *who may reference* a labelled Secret, not who may label one.


### PR DESCRIPTION
Addresses #251. **The review is right on every factual claim — but ADR-0009, accepted earlier today, already says all of it, and more precisely.** What the review does not have, and what this PR is actually about, is that **ADR-0009's reason for deferring the fix is wrong.**

## What the review adds over ADR-0009: nothing, and that is fine

ADR-0009 already states, in its own words, that the #219 mitigation "is **not an authorization boundary**"; that "the label is namespace-scoped, so **any** NTNCellConfig in the namespace may use **any** labelled Secret"; that a bearer token is direct **exfiltration** while mTLS is identity *misuse*; and that the shipped `ntncellconfig-editor-role` grants NTNCellConfig write without `secrets get`, which is what makes the confused deputy reachable under the default role model. The review's severity conditioning (trusted single-team namespace → P2; NTNCellConfig write delegated to untrusted tenants → P1) matches the ADR's framing.

So there was no documentation overclaim to correct — I went looking for one and did not find it. The ADR is honest.

## The actual finding: the deferral rationale does not hold

ADR-0009 deferred the real boundary on this basis:

> SAR needs infrastructure we do not have yet. There is no admission webhook in the operator today; a SAR check requires the requester identity (`req.UserInfo`), which a reconcile does not carry — only a validating webhook does. That is real infrastructure (serving cert, `failurePolicy`, envtest wiring).

A validating webhook is **not** the only thing that carries the requester identity. `ValidatingAdmissionPolicy` — GA since Kubernetes **1.30**, and this chart already declares `kubeVersion: ">=1.31.0-0"` — evaluates CEL *inside kube-apiserver* and exposes the Kubernetes **authorizer library**. The exact check the ADR wanted is one declarative expression:

```cel
authorizer.group('').resource('secrets')
  .namespace(request.namespace)
  .name(object.spec.provider.remoteControl.tls.secretName)
  .check('get').allowed()
```

None of the deferred cost is real on this route: **no webhook, no serving certificate**, no `failurePolicy` plumbing beyond a field, and — the part that matters most operationally — **the operator gains no new RBAC**, because the API server performs the authorization check rather than the controller. A reconcile-time SAR would have needed `create subjectaccessreviews`; this needs nothing.

## Verified on a live cluster, not asserted from docs

The web sources I checked disagreed with each other on whether `authorizer` is usable inside `validations`, so I stopped reading and tested it — against a live Kubernetes **1.36.3** cluster, using **the artifact this chart renders** (`helm template -s templates/admission/credential-ref-policy.yaml`), not a hand-written approximation. A ServiceAccount with `ntncellconfigs` write and **no** `secrets get`:

| Case | Result |
|---|---|
| references a labelled credential | **Forbidden** by the policy |
| after being granted `get` on that Secret | created |
| **plaintext** CR (no `remoteControl.tls`) | created — correctly ungated |
| **UPDATE** of an existing credentialed CR | **Forbidden** |

## Change

- `dist/chart/templates/admission/credential-ref-policy.yaml` — the policy + binding, release-scoped names.
- `values.yaml` — `credentialRefPolicy` (`enable`, `validationActions`, `failurePolicy`, `namespaceSelector`), **default off**.
- ADR-0009 — an **amendment**, not a rewrite: the status line now warns that the deferral no longer stands, and the amendment records the corrected rationale, the live-cluster evidence, the revised decision, and an explicit *What this does NOT solve*.
- `SECURITY.md`, `CHANGELOG.md`, and a CI assertion.

**Off by default, deliberately.** Enabling it is a real tightening: the policy gates *admission*, so objects already stored are untouched until their next write, and an operator should run `validationActions: [Warn, Audit]` first to find violators. What remains deferred is only the default — a far smaller question than "build webhook infrastructure".

The interim endpoint allow-list from #300 **stands**: it constrains the *destination*, which is orthogonal to who may *reference* the credential, and it still covers CRs that already exist.

## What this does NOT solve (stated in the ADR too)

- Stored objects are not re-validated; the policy applies on their next write.
- A **privileged writer acting for someone else** — a GitOps controller or CI identity with broad rights — passes the check, because the authorized principal is whoever submits the object. Inherent to authorization-at-admission; a webhook would behave identically. Where tenants submit through such a pipeline, the pipeline is the trust boundary.
- The `patch`-without-`get` labelling vector from #219 is unchanged: this gates who may *reference* a labelled Secret, not who may *label* one.

## Adversarial pass on my own change

- `spec.provider` is a **required** field and `tls.secretName` has `minLength: 1`, so the expression cannot dereference a missing field or run an empty-name authorization check (which would silently widen to "get any Secret in the namespace"). Read off the CRD, not assumed.
- **Schema validation runs before the policy.** I tested a CR missing `spec.provider`: the API server rejects it as invalid and reports that the rules were not checked. So `failurePolicy: Fail` cannot turn a malformed object into a confusing denial, and an extra `has()` guard would have been dead code — so it is not there.
- The policy name is release-scoped through the `fullname` helper, so two chart releases cannot collide on this cluster-scoped object.
- `matchConstraints` cover `ntncellconfigs` only, not `ntncellconfigs/status`, so the operator's own status writes are never matched.
- CI asserts the policy is **absent by default** and that the enabled render still carries the authorizer expression and `failurePolicy: Fail` — a render that silently dropped the check would otherwise look installed while authorizing nothing. Assertion run locally: default `0` policies; enabled render passes all five checks.
- Cluster left clean: every probe object removed and verified gone.

## Verification

`helm lint` clean with the policy both off and on; `helm template` renders 0 objects by default and policy+binding when enabled; `go build ./...` unaffected (no Go change in this PR).

Sources consulted before testing: [KEP-3488 secondary authz for ValidatingAdmissionPolicy](https://github.com/kubernetes/kubernetes/pull/116054), [Validating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/), [CEL in Kubernetes](https://kubernetes.io/docs/reference/using-api/cel/), [VAP is GA in 1.30](https://kubernetes.io/blog/2024/04/24/validating-admission-policy-ga/).
