### PR TITLE
fix(ephemeris): drop non-finite / out-of-range element sets after fetch (#227)

### DIFF
--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -208,9 +208,9 @@ func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 	if cm.Annotations[ommCacheAnnUID] != string(eph.UID) || cm.Annotations[ommCacheAnnFetchKey] != fetchKey {
 		return false // orphaned by delete-recreate, or a different source — do not restore
 	}
-	omms, err := sgp4.ParseOMMs([]byte(data))
+	omms, err := ephemeris.ParseValidOMMs(log, []byte(data))
 	if err != nil || len(omms) == 0 {
-		log.V(1).Info("omm-cache: payload unparseable; ignoring", "err", err)
+		log.V(1).Info("omm-cache: payload unparseable or fully invalid; ignoring", "err", err)
 		return false
 	}
 	// Unknown fetch time → zero, i.e. very old, so the next reconcile fetches and only serves

--- a/pkg/ephemeris/gp_fetcher.go
+++ b/pkg/ephemeris/gp_fetcher.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -317,7 +318,7 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 			return GPFetchResult{}, fmt.Errorf("response body exceeds %d bytes limit", maxResponseBody)
 		}
 
-		omms, err := sgp4.ParseOMMs(body)
+		omms, err := ParseValidOMMs(log, body)
 		if err != nil {
 			return GPFetchResult{}, fmt.Errorf("parsing OMM JSON: %w", err)
 		}
@@ -357,4 +358,67 @@ func (f *CelesTrakFetcher) Fetch(ctx context.Context, url string) (GPFetchResult
 	default:
 		return GPFetchResult{}, fmt.Errorf("%w: HTTP %d from %s", ErrBadResponse, resp.StatusCode, url)
 	}
+}
+
+// ParseValidOMMs parses OMM JSON and drops any element set whose orbital elements are non-finite or
+// physically out of range (see validOMM), so a malformed-but-valid-JSON member never reaches the OMM
+// cache or SGP4 — where it would propagate to NaN/garbage positions that flow into SIB19. It is the
+// single validated entry point for turning OMM bytes into element sets, shared by the CelesTrak fetch,
+// the Space-Track fetch, and the durable-cache restore so none of them can bypass validation (#227).
+func ParseValidOMMs(log logr.Logger, body []byte) ([]sgp4.OMM, error) {
+	omms, err := sgp4.ParseOMMs(body)
+	if err != nil {
+		return nil, err
+	}
+	return filterValidOMMs(log, omms), nil
+}
+
+// filterValidOMMs returns the element sets whose orbital elements are finite and physically in range,
+// dropping the rest. It logs a single line when anything was dropped (fetches are hours apart, so this
+// is not spammy) so a source data-quality regression is visible rather than silently propagated.
+func filterValidOMMs(log logr.Logger, omms []sgp4.OMM) []sgp4.OMM {
+	out := omms[:0:0] // fresh backing array; do not alias the caller's slice
+	dropped := 0
+	for _, o := range omms {
+		if err := validOMM(o); err != nil {
+			dropped++
+			log.V(1).Info("dropping malformed element set", "norad", o.NoradCatID, "object", o.ObjectName, "reason", err.Error())
+			continue
+		}
+		out = append(out, o)
+	}
+	if dropped > 0 {
+		log.Info("dropped malformed element sets", "dropped", dropped, "kept", len(out))
+	}
+	return out
+}
+
+// validOMM reports why an OMM's orbital elements are unusable, or nil when they are sound. SGP4 would
+// otherwise turn a non-finite or out-of-range set into NaN/garbage positions (eccentricity >= 1 is a
+// non-elliptical orbit SGP4 does not model; a non-positive mean motion is a malformed set). Angles are
+// only checked for finiteness — SGP4 normalises them modulo 360°. Epoch validity is NOT re-checked here:
+// the controller's source-epoch freshness/future-skew gate already rejects an absurd or stale epoch.
+func validOMM(o sgp4.OMM) error {
+	for _, e := range []struct {
+		name string
+		v    float64
+	}{
+		{"MEAN_MOTION", o.MeanMotion}, {"ECCENTRICITY", o.Eccentricity}, {"INCLINATION", o.Inclination},
+		{"RA_OF_ASC_NODE", o.RAOfAscNode}, {"ARG_OF_PERICENTER", o.ArgOfPericenter}, {"MEAN_ANOMALY", o.MeanAnomaly},
+		{"BSTAR", o.BStar}, {"MEAN_MOTION_DOT", o.MeanMotionDot}, {"MEAN_MOTION_DDOT", o.MeanMotionDDot},
+	} {
+		if math.IsNaN(e.v) || math.IsInf(e.v, 0) {
+			return fmt.Errorf("%s is not finite (%v)", e.name, e.v)
+		}
+	}
+	if o.MeanMotion <= 0 {
+		return fmt.Errorf("MEAN_MOTION %v must be positive", o.MeanMotion)
+	}
+	if o.Eccentricity < 0 || o.Eccentricity >= 1 {
+		return fmt.Errorf("ECCENTRICITY %v outside [0,1)", o.Eccentricity)
+	}
+	if o.Inclination < 0 || o.Inclination > 180 {
+		return fmt.Errorf("INCLINATION %v outside [0,180]", o.Inclination)
+	}
+	return nil
 }

--- a/pkg/ephemeris/gp_fetcher_validation_test.go
+++ b/pkg/ephemeris/gp_fetcher_validation_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"math"
+	"testing"
+
+	"github.com/akhenakh/sgp4"
+	"github.com/go-logr/logr"
+)
+
+// validLEO is a physically-sound ISS-like element set (the baseline each case mutates one field of).
+func validLEO() sgp4.OMM {
+	return sgp4.OMM{
+		NoradCatID: 25544, ObjectName: "ISS",
+		MeanMotion: 15.5, Eccentricity: 0.0007, Inclination: 51.6,
+		RAOfAscNode: 120.0, ArgOfPericenter: 80.0, MeanAnomaly: 280.0,
+	}
+}
+
+func TestValidOMM(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*sgp4.OMM)
+		ok   bool
+	}{
+		{"valid LEO", func(*sgp4.OMM) {}, true},
+		{"NaN inclination", func(o *sgp4.OMM) { o.Inclination = math.NaN() }, false},
+		{"Inf mean motion", func(o *sgp4.OMM) { o.MeanMotion = math.Inf(1) }, false},
+		{"NaN bstar", func(o *sgp4.OMM) { o.BStar = math.NaN() }, false},
+		{"eccentricity >= 1 (hyperbolic)", func(o *sgp4.OMM) { o.Eccentricity = 1.2 }, false},
+		{"eccentricity negative", func(o *sgp4.OMM) { o.Eccentricity = -0.01 }, false},
+		{"eccentricity 0 (circular) is ok", func(o *sgp4.OMM) { o.Eccentricity = 0 }, true},
+		{"inclination > 180", func(o *sgp4.OMM) { o.Inclination = 200 }, false},
+		{"inclination 180 (retrograde) is ok", func(o *sgp4.OMM) { o.Inclination = 180 }, true},
+		{"mean motion 0", func(o *sgp4.OMM) { o.MeanMotion = 0 }, false},
+		{"mean motion negative", func(o *sgp4.OMM) { o.MeanMotion = -1 }, false},
+		{"large but finite angles are ok (SGP4 normalises)", func(o *sgp4.OMM) { o.MeanAnomaly = 359.999 }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := validLEO()
+			tc.mut(&o)
+			err := validOMM(o)
+			if tc.ok && err != nil {
+				t.Fatalf("want valid, got error: %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("want invalid, got nil")
+			}
+		})
+	}
+}
+
+// TestFilterValidOMMs_DropsOnlyInvalid pins the pool behaviour: a malformed member is dropped while the
+// valid members survive, so one bad element set never poisons or discards a whole constellation.
+func TestFilterValidOMMs_DropsOnlyInvalid(t *testing.T) {
+	good1 := validLEO()
+	good1.NoradCatID = 111
+	good2 := validLEO()
+	good2.NoradCatID = 222
+	bad := validLEO()
+	bad.NoradCatID = 999
+	bad.Eccentricity = 2.0 // hyperbolic -> must be dropped
+
+	out := filterValidOMMs(logr.Discard(), []sgp4.OMM{good1, bad, good2})
+	if len(out) != 2 {
+		t.Fatalf("want the 2 valid members kept, got %d", len(out))
+	}
+	for _, o := range out {
+		if o.NoradCatID == 999 {
+			t.Fatal("the hyperbolic element set must have been dropped")
+		}
+	}
+}
+
+// TestParseValidOMMs_DropsInvalidFromJSON pins the SHARED validated entry point used by the CelesTrak
+// fetch, the Space-Track fetch, and the durable-cache restore: garbage that parses as valid JSON is
+// dropped at parse time, so no entry path can feed SGP4 a malformed element set.
+func TestParseValidOMMs_DropsInvalidFromJSON(t *testing.T) {
+	body := []byte(`[
+	  {
+	    "OBJECT_NAME":"GOOD", "EPOCH":"2026-04-17T00:00:00.000000", "MEAN_MOTION":12.85,
+	    "ECCENTRICITY":0.001, "INCLINATION":87.9, "RA_OF_ASC_NODE":100.0,
+	    "ARG_OF_PERICENTER":90.0, "MEAN_ANOMALY":270.0, "NORAD_CAT_ID":111, "BSTAR":0.0001
+	  },
+	  {
+	    "OBJECT_NAME":"HYPERBOLIC", "EPOCH":"2026-04-17T00:00:00.000000", "MEAN_MOTION":12.85,
+	    "ECCENTRICITY":2.0, "INCLINATION":87.9, "RA_OF_ASC_NODE":100.0,
+	    "ARG_OF_PERICENTER":90.0, "MEAN_ANOMALY":270.0, "NORAD_CAT_ID":999, "BSTAR":0.0001
+	  }
+	]`)
+	omms, err := ParseValidOMMs(logr.Discard(), body)
+	if err != nil {
+		t.Fatalf("ParseValidOMMs: %v", err)
+	}
+	if len(omms) != 1 || omms[0].NoradCatID != 111 {
+		t.Fatalf("must keep only the valid member (NORAD 111), got %d: %+v", len(omms), omms)
+	}
+}

--- a/pkg/ephemeris/spacetrack_fetcher.go
+++ b/pkg/ephemeris/spacetrack_fetcher.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/akhenakh/sgp4"
 	"github.com/go-logr/logr"
 	"golang.org/x/net/publicsuffix"
 )
@@ -199,7 +198,7 @@ func (f *SpaceTrackFetcher) FetchWithCredentials(
 	}
 
 	// Parse OMM JSON outside the lock — no shared state needed.
-	return parseGPResult(body, now)
+	return parseGPResult(logr.FromContextOrDiscard(ctx), body, now)
 }
 
 // doLogin authenticates with SpaceTrack via POST to /ajaxauth/login.
@@ -344,9 +343,10 @@ func (f *SpaceTrackFetcher) doFetchGPRaw(ctx context.Context, gpURL string) ([]b
 	}
 }
 
-// parseGPResult parses raw OMM JSON into a GPFetchResult. Does not require the mutex.
-func parseGPResult(body []byte, now time.Time) (GPFetchResult, error) {
-	omms, err := sgp4.ParseOMMs(body)
+// parseGPResult parses raw OMM JSON into a GPFetchResult, dropping non-finite / out-of-range element
+// sets (ParseValidOMMs) so the Space-Track path validates the same as CelesTrak. Does not require the mutex.
+func parseGPResult(log logr.Logger, body []byte, now time.Time) (GPFetchResult, error) {
+	omms, err := ParseValidOMMs(log, body)
 	if err != nil {
 		return GPFetchResult{}, fmt.Errorf("parsing OMM JSON: %w", err)
 	}


### PR DESCRIPTION
One focused Small CL from the #227 fetch-hardening backlog: the reviewer's **#1 priority, parsed OMM validation**.

## Gap
`sgp4.ParseOMMs` only unmarshals JSON — no element validation. A malformed-but-valid-JSON member (NaN inclination, eccentricity ≥ 1, non-positive mean motion) flows into the cache + SGP4 → NaN/garbage positions → SIB19.

## Fix — validated at *every* entry point
A single validated entry point `ParseValidOMMs` (parse + finite/range filter), routed through **all three** places that turn OMM bytes into element sets:
- the **CelesTrak** fetch,
- the **Space-Track** fetch (`parseGPResult`),
- the **durable-cache restore** (ADR-0007).

> My first cut validated only the CelesTrak path. The self-adversarial review caught that the Space-Track fetch and the durable-cache restore both re-parse OMMs via `sgp4.ParseOMMs` and would have bypassed validation — including a **pre-change persisted cache restored on cold start**. An incomplete validation is worse than a slightly larger complete one, so this routes all three through `ParseValidOMMs`.

`validOMM` drops a set when any element is non-finite, eccentricity ∉ [0,1) (≥1 is a non-elliptical orbit SGP4 can't model), inclination ∉ [0,180], or mean motion ≤ 0 (angles are finiteness-only — SGP4 normalises mod 360). A `SatelliteEphemeris` is a constellation **pool**, so valid members are kept and only bad ones dropped (one log line per fetch when anything drops). Epoch validity is **not** re-checked — the source-epoch freshness/future-skew gate handles it.

## Scope (Small CL)
Deliberately **no** upper mean-motion bound (over-strict; a garbage-high value decays to a NaN orbit downstream NaN-handling catches). Ranges are the SGP4/CCSDS physics (eccentricity 0..1, etc.). Other #227 items (proactive rate limiter, public-host allow-list, concurrent-fetch singleflight) are separate follow-ups.

## Test
`TestValidOMM` (each rule) + `TestFilterValidOMMs_DropsOnlyInvalid` (pool) + `TestParseValidOMMs_DropsInvalidFromJSON` (garbage dropped at the shared entry point); mutation-verified. `gofmt`/`vet`/`golangci-lint` clean; full `pkg/ephemeris` + controller suites pass.
