### PR TITLE
fix(security): never send a remoteControl.tls bearer token to a publicly-trusted host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A `remoteControl.tls` bearer token is no longer sent to a server trusted only by the public
+  roots.** `resolveRemoteControlTLS` pinned `RootCAs` to the Secret's `ca.crt` when present and
+  otherwise fell back to the system trust store — and `remoteControl.endpoint` is CR-author
+  controlled, with `ServerName` derived from it. So a principal holding the shipped
+  `ntncellconfig-editor-role` (NTNCellConfig write, **no** `secrets get`) could reference any
+  opted-in Secret carrying a `token` but no `ca.crt`, point the endpoint at a host they own,
+  present an ordinary publicly-trusted certificate for it, and be handed the token verbatim — the
+  #251 confused deputy completing without the label gate being bypassed at all. A Secret carrying a
+  `token` must now also pin `ca.crt`, or the push is refused as a permanent credential error (the
+  same uniform, non-oracle failure as the other credential gates). `mode: mtls` without `ca.crt` is
+  still permitted: it **proves** a key rather than sending one, so a misdirected mTLS dial is
+  identity misuse rather than credential theft — the line ADR-0009 already draws. This is
+  **default-on** and complements the two opt-in controls that also cover this path but ship off:
+  the endpoint allow-list (#300) and the credential-reference admission policy (#251). Upstream
+  precedent: kubeadm pins a CA public key for token-based discovery rather than trusting the system
+  store before sending its bootstrap token. No test previously covered token-without-`ca.crt`;
+  the new invariant test asserts that **any** successful resolution returning a token has pinned
+  roots, so a future key or mode cannot reopen it case-by-case. Mutation-verified.
+
 - **External OMM `OBJECT_NAME` can no longer amplify the SatelliteEphemeris status past the etcd object
   limit.** `PropagatedState.satellite` was already bounded (MaxLength 64), but `PassWindow.satellite`
   copied the full external name into up to `MaxPassWindows` (500) windows, the pass-prediction
@@ -578,6 +597,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controller owner reference and is garbage-collected with the CR, but anything mounting it **by
   name** (a gNB Pod spec) must be repointed. Check with
   `kubectl get ntncellconfig -A -o name | awk 'length($0) > 250'` before upgrading.
+- **A `remoteControl.tls` Secret that carries `token` must now also carry `ca.crt`.** Pushes using
+  such a Secret without a pinned CA now fail with a permanent credential error instead of trusting
+  the system roots (see Security above). Find affected Secrets before upgrading:
+
+  ```bash
+  kubectl get secret -A -l ntn.operators.dev/remote-control-credential=true \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\t"}token={.data.token}{"\t"}ca={.data.ca\.crt}{"\n"}{end}' \
+    | awk -F'\t' '$2 != "token=" && $3 == "ca="'
+  ```
+
+  Add the gNB's CA to `ca.crt` in each. If a listed gNB genuinely uses a publicly-trusted
+  certificate, put that CA bundle in `ca.crt` to opt in explicitly.
 
 - **A satellite whose element set is stale beyond `maxEpochAge` now holds NTNSlice on terrestrial**
   instead of failing over to it — previously NTNSlice could steer traffic onto a satellite whose stale

--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -127,6 +127,11 @@ type RemoteControlTLS struct {
 	// "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
 	// replayable, so it is only ever sent over the wss:// (TLS) connection.
 	//
+	// "ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+	// token validated only by the public roots could be delivered to any host whose owner
+	// can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+	// ca.crt is still permitted — it proves a key rather than sending one.
+	//
 	// SECURITY: the Secret's owner must opt it in for remote-control use with the label
 	// "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
 	// credential (a service-account or bootstrap-token Secret) is refused. This is a

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -907,6 +907,11 @@ spec:
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
 
+                              "ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+                              token validated only by the public roots could be delivered to any host whose owner
+                              can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+                              ca.crt is still permitted — it proves a key rather than sending one.
+
                               SECURITY: the Secret's owner must opt it in for remote-control use with the label
                               "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
                               credential (a service-account or bootstrap-token Secret) is refused. This is a

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -907,6 +907,11 @@ spec:
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
 
+                              "ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+                              token validated only by the public roots could be delivered to any host whose owner
+                              can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+                              ca.crt is still permitted — it proves a key rather than sending one.
+
                               SECURITY: the Secret's owner must opt it in for remote-control use with the label
                               "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
                               credential (a service-account or bootstrap-token Secret) is refused. This is a

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -910,6 +910,11 @@ spec:
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
 
+                              "ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+                              token validated only by the public roots could be delivered to any host whose owner
+                              can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+                              ca.crt is still permitted — it proves a key rather than sending one.
+
                               SECURITY: the Secret's owner must opt it in for remote-control use with the label
                               "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
                               credential (a service-account or bootstrap-token Secret) is refused. This is a

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -595,7 +595,10 @@ the cell the gNB booted with. Unset ⇒ ConfigMap bootstrap path only.<br/>
         <td>
           ephemerisNoradID selects which satellite's propagated state vector, from the
 referenced SatelliteEphemeris (ephemerisRef), to push at runtime (#176). When
-unset, the referenced ephemeris's first propagated state is used.<br/>
+unset, the single tracked satellite's state is used; if the referenced ephemeris
+exposes more than one satellite the push fails closed (EphemerisPushed=False,
+reason EphemerisSelectionAmbiguous) until this field selects one — the controller
+never guesses which satellite to serve.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1971,6 +1974,11 @@ shared secret sent as Authorization: Bearer — optional), and, for mode=mtls,
 "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
 replayable, so it is only ever sent over the wss:// (TLS) connection.
 
+"ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+token validated only by the public roots could be delivered to any host whose owner
+can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+ca.crt is still permitted — it proves a key rather than sending one.
+
 SECURITY: the Secret's owner must opt it in for remote-control use with the label
 "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
 credential (a service-account or bootstrap-token Secret) is refused. This is a
@@ -2187,6 +2195,16 @@ NTNCellConfigStatus defines the observed state of NTNCellConfig.
         <td>string</td>
         <td>
           configMapRef is the name of the ConfigMap containing the generated config.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>lastPushedSatSwitchDigest</b></td>
+        <td>string</td>
+        <td>
+          lastPushedSatSwitchDigest is the content digest of the sat_switch_with_resync last delivered
+to the gNB by the runtime push. The switch is re-attached to a runtime update only when this
+changes, so a (possibly non-idempotent) MAC/RRC-resync command is not re-sent on every
+ephemeris heartbeat (issue #207). Empty when no switch has been sent.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2453,6 +2471,7 @@ resets on any healthy reliable sample; losing it on a controller restart or
 leader-election handoff only re-requires confirmation (a DELAY), never causes
 a spurious switch.<br/>
           <br/>
+            <i>Format</i>: int32<br/>
             <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 10<br/>
         </td>
@@ -2478,8 +2497,11 @@ after a switchback before another failover to satellite may be taken. It
 bounds sub-minute ping-pong after a hand-back. It is a soft, bounded delay
 — a genuinely failing terrestrial still fails over once the dwell elapses,
 so it never indefinitely blocks a real failover. 0 (the default) disables
-it; 30s–120s is a sane range relative to a LEO pass.<br/>
+it; 30s–120s is a sane range relative to a LEO pass. A negative value would
+silently disable the dwell (elapsed < negative is never true), so admission
+bounds it to [0s, 24h].<br/>
           <br/>
+            <i>Validations</i>:<li>duration(self) >= duration('0s') && duration(self) <= duration('24h'): minTerrestrialDwell must be a non-negative duration no greater than 24h</li>
             <i>Format</i>: duration<br/>
         </td>
         <td>false</td>
@@ -2497,8 +2519,11 @@ it; 30s–120s is a sane range relative to a LEO pass.<br/>
         <td>string</td>
         <td>
           switchbackDelay is how long to wait after terrestrial recovers
-before switching back (prevents flapping).<br/>
+before switching back (prevents flapping). A negative value is meaningless
+here, so admission bounds it to [0s, 24h] (24h is a fat-finger ceiling, far
+above any LEO-pass-relative value).<br/>
           <br/>
+            <i>Validations</i>:<li>duration(self) >= duration('0s') && duration(self) <= duration('24h'): switchbackDelay must be a non-negative duration no greater than 24h</li>
             <i>Format</i>: duration<br/>
             <i>Default</i>: 60s<br/>
         </td>
@@ -2527,8 +2552,12 @@ satellitePath defines the failover satellite connectivity.
         <td><b>ephemerisRef</b></td>
         <td>string</td>
         <td>
-          ephemerisRef is the name of the SatelliteEphemeris resource
-used to determine satellite pass availability.<br/>
+          ephemerisRef is the name of the SatelliteEphemeris resource used to determine
+satellite pass availability. The referenced ephemeris is treated as a
+CONSTELLATION POOL: the satellite path is available whenever ANY tracked member
+is overhead and deliverable — the slice is deliberately not pinned to one NORAD,
+because LEO members hand over. Which member a given cell broadcasts is
+NTNCellConfig.ephemerisNoradID's concern, not this path's. See ADR-0008.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -3577,9 +3606,20 @@ PassWindow represents a predicted contact opportunity between a satellite and gr
         <td><b>satellite</b></td>
         <td>string</td>
         <td>
-          satellite is the name or NORAD ID of the satellite.<br/>
+          satellite is the satellite's display name (externally sourced OMM ObjectName), bounded and
+rune-safe. The canonical identity is noradID; treat this as a label only.<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>noradID</b></td>
+        <td>integer</td>
+        <td>
+          noradID is the satellite's NORAD catalog number — the canonical key that maps this window
+to its propagatedStates entry, so a consumer (NTNSlice) can gate pass availability on the
+backing element set's delivery freshness (same contract as the runtime push). 0 only for
+windows written before this field existed (freshness then treated as unverifiable).<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -980,7 +980,9 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	// tracked follow-up): the opt-in is namespace-scoped — once labelled, ANY NTNCellConfig
 	// in the namespace may use the Secret; a principal with secrets `patch` but not `get`
 	// could add the label to a Secret it cannot read; and the type check does not stop an
-	// Opaque Secret from holding some other bearer token.
+	// Opaque Secret from holding some other bearer token. Those limits are about WHICH Secret
+	// may be named; the CA-pinning gate further down bounds where its token may be SENT,
+	// which is what turns "named the wrong Secret" into something less than exfiltration.
 	switch secret.Type {
 	case corev1.SecretTypeServiceAccountToken, secretTypeBootstrapToken:
 		return nil, "", fmt.Errorf("remoteControl.tls secret %q has type %q — a Kubernetes API credential must not be used as a gNB remote-control secret", t.SecretName, secret.Type)
@@ -1004,6 +1006,25 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 			return nil, "", fmt.Errorf("remoteControl.tls secret %q: ca.crt is not valid PEM", t.SecretName)
 		}
 		cfg.RootCAs = pool
+	} else if len(secret.Data["token"]) > 0 {
+		// Refuse to TRANSMIT a bearer token to a server vouched for only by the public
+		// roots. The endpoint is CR-author-controlled and ServerName is derived from it, so
+		// with system roots an attacker who owns any domain can get a publicly-trusted
+		// certificate for it and receive the token verbatim — the confused deputy of #251
+		// completing, without needing the label gate to be bypassed at all. Pinning the
+		// gNB's own CA is what makes the destination unforgeable. This is the same reason
+		// kubeadm pins a CA public key for token-based discovery rather than trusting the
+		// system store before sending its bootstrap token.
+		//
+		// Only the token path is gated: mode=mtls PROVES a key rather than sending it, so a
+		// misdirected mTLS dial is identity misuse (and leaks the pushed config), not
+		// credential theft — ADR-0009 draws the same line. A deployment that genuinely
+		// fronts its gNB with a publicly-trusted certificate can still opt in explicitly by
+		// putting that CA in ca.crt.
+		return nil, "", fmt.Errorf(
+			"remoteControl.tls secret %q carries a bearer token but no ca.crt: the token would be sent to "+
+				"a server trusted only by the system roots, and remoteControl.endpoint is caller-controlled — "+
+				"pin the gNB's CA in ca.crt", t.SecretName)
 	}
 	// mTLS: present a client certificate.
 	if t.Mode == "mtls" {

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -259,13 +259,15 @@ func TestResolveRemoteControlTLS_TokenValidation(t *testing.T) {
 	}
 	const ns = "ns1"
 	ctx := context.Background()
-	// A labelled Opaque Secret carrying only the token; ca.crt is omitted (system roots), which does
-	// not affect the token check.
+	certPEM, _ := selfSignedPEM(t)
+	// A labelled Opaque Secret carrying the token AND a pinned ca.crt — the latter is required for any
+	// bearer token (a token without ca.crt is refused before this token check), so it must be present
+	// for the token-content validation to be reachable.
 	newRWithToken := func(token []byte) *NTNCellConfigReconciler {
 		sec := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns,
 				Labels: map[string]string{remoteControlCredentialLabel: "true"}},
-			Data: map[string][]byte{"token": token},
+			Data: map[string][]byte{"token": token, "ca.crt": certPEM},
 		}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(sec).Build()
 		return &NTNCellConfigReconciler{Client: c, APIReader: c}
@@ -518,4 +520,102 @@ func TestPushEphemerisUpdateIfNeeded_CredentialFailuresUniform(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveRemoteControlTLS_BearerRequiresPinnedCA covers the transmit-a-secret gate. It lives
+// apart from TestResolveRemoteControlTLS because it needs no shared fixture beyond the helpers
+// below and keeps that (already large) table readable.
+func TestResolveRemoteControlTLS_BearerRequiresPinnedCA(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	certPEM, keyPEM := selfSignedPEM(t)
+	const ns = "ns1"
+	ctx := context.Background()
+
+	newR := func(objs ...runtime.Object) *NTNCellConfigReconciler {
+		b := fake.NewClientBuilder().WithScheme(scheme)
+		for _, o := range objs {
+			b = b.WithRuntimeObjects(o)
+		}
+		c := b.Build()
+		return &NTNCellConfigReconciler{Client: c, APIReader: c}
+	}
+	secret := func(name string, data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns,
+				Labels: map[string]string{remoteControlCredentialLabel: "true"},
+			},
+			Data: data,
+		}
+	}
+
+	// A bearer token must never be transmitted to a server vouched for only by the public
+	// roots. remoteControl.endpoint is caller-controlled and ServerName is derived from it,
+	// so with system roots anyone who owns a domain can obtain a publicly-trusted
+	// certificate for it and be handed the token verbatim — the #251 confused deputy
+	// completing without the label gate being bypassed at all.
+	t.Run("token without ca.crt → rejected (would trust the system roots)", func(t *testing.T) {
+		r := newR(secret("s", map[string][]byte{"token": []byte("shhh")}))
+		rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "attacker.example.com:443",
+			TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "s"}}
+		cfg, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
+		if err == nil {
+			t.Fatal("a bearer token with no pinned CA must be refused: the endpoint is caller-controlled, so the system roots make the destination forgeable")
+		}
+		if tok != "" || cfg != nil {
+			t.Fatalf("nothing may be returned on rejection, got cfg=%v tok=%q", cfg, tok)
+		}
+		// #296 surfaces EVERY resolveRemoteControlTLS failure uniformly
+		// (RemoteControlCredentialUnavailable, 5-minute self-heal), so this rejection is
+		// classified with the rest — see TestPushEphemerisUpdateIfNeeded_CredentialFailuresUniform.
+	})
+
+	// The line is drawn at TRANSMITTING a secret: mode=mtls proves a key rather than
+	// sending it, so a misdirected mTLS dial is identity misuse, not credential theft
+	// (ADR-0009 draws the same line). Pinning it would be a different, larger change.
+	t.Run("mtls without ca.crt and without token → still allowed", func(t *testing.T) {
+		r := newR(secret("s", map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM}))
+		rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+			TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "mtls", SecretName: "s"}}
+		if _, _, err := r.resolveRemoteControlTLS(ctx, ns, rc); err != nil {
+			t.Fatalf("mtls sends no secret, so the system roots are not a transmit risk: %v", err)
+		}
+	})
+
+	// The invariant behind both cases above, stated once so a future key/mode addition
+	// cannot reopen it case-by-case: ANY successful resolution that hands back a token must
+	// have pinned roots.
+	t.Run("invariant: a returned token always comes with pinned roots", func(t *testing.T) {
+		for name, data := range map[string]map[string][]byte{
+			"token only":          {"token": []byte("shhh")},
+			"token + ca":          {"token": []byte("shhh"), "ca.crt": certPEM},
+			"ca only":             {"ca.crt": certPEM},
+			"token + client cert": {"token": []byte("shhh"), "tls.crt": certPEM, "tls.key": keyPEM},
+			"everything":          {"token": []byte("shhh"), "ca.crt": certPEM, "tls.crt": certPEM, "tls.key": keyPEM},
+		} {
+			t.Run(name, func(t *testing.T) {
+				mode := "tls"
+				if len(data["tls.crt"]) > 0 {
+					mode = "mtls"
+				}
+				r := newR(secret("s", data))
+				rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+					TLS: &ntnv1alpha1.RemoteControlTLS{Mode: mode, SecretName: "s"}}
+				cfg, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
+				if err != nil || tok == "" {
+					return // refused, or nothing to transmit — both fine
+				}
+				if cfg == nil || cfg.RootCAs == nil {
+					t.Fatalf("a token was returned for %q with RootCAs=nil: it would be sent to whatever the public roots vouch for", name)
+				}
+			})
+		}
+	})
+
 }

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -907,6 +907,11 @@ spec:
                               "tls.crt" + "tls.key" (the client certificate/key). A bare shared secret is
                               replayable, so it is only ever sent over the wss:// (TLS) connection.
 
+                              "ca.crt" is REQUIRED whenever "token" is set: endpoint is caller-controlled, so a
+                              token validated only by the public roots could be delivered to any host whose owner
+                              can obtain a publicly-trusted certificate. Pin the gNB's own CA. mode=mtls without
+                              ca.crt is still permitted — it proves a key rather than sending one.
+
                               SECURITY: the Secret's owner must opt it in for remote-control use with the label
                               "ntn.operators.dev/remote-control-credential: true", and a Kubernetes API
                               credential (a service-account or bootstrap-token Secret) is refused. This is a


### PR DESCRIPTION
Addresses part of #251. **Default-on**, unlike the two existing controls for this path.

## The review is right, but it is the same ground as ADR-0009 — except for one clause

Everything the review lists (label-only opt-in, SA/bootstrap-token refusal, same-namespace, uniform error, and the three "known limits" the code comment itself admits) is already written down in ADR-0009 and #219, in the same terms. Its severity conditioning matches the ADR's. So on its own it does not move the position.

One clause does: **"在使用 system roots 或攻擊者能提供受信任憑證的情況下"**. That sent me to the trust-anchor code, and it is a real, concrete, *default-on* hole that ADR-0009 does not mention:

```go
// Trust a private CA when provided; otherwise fall back to the system roots.
if ca := secret.Data["ca.crt"]; len(ca) > 0 { … cfg.RootCAs = pool }
```

`ca.crt` absent → `RootCAs` nil → Go uses the **system trust store**. And `remoteControl.endpoint` is CR-author controlled, with `ServerName` derived from it.

## Why that completes the attack with stock settings

A principal holding the shipped `ntncellconfig-editor-role` (NTNCellConfig write, **no** `secrets get`):

1. references any opted-in Secret carrying a `token` but no `ca.crt`,
2. sets `endpoint` to a host they own,
3. presents an ordinary publicly-trusted certificate for it (any ACME CA will issue one for a domain you control),
4. and is handed the token verbatim.

**None of the label gate needs to be bypassed** — the label governs *which* Secret may be named, never *where* its contents may be sent. And both controls that do cover this path ship **off by default**: the endpoint allow-list (#300, empty = permit-all) and the credential-reference admission policy. The private-IP SSRF guard does not apply here either — it inverts on this path, since a legitimate gNB target *is* private.

So the review's "release blocker" framing is defensible for the default configuration, and this PR is the part that can be fixed **without asking the operator to turn anything on**.

## Change

A Secret carrying `token` must now also pin `ca.crt`, or the push is refused as a permanent credential error.

`mode: mtls` without `ca.crt` stays permitted — it **proves** a key rather than sending one, so a misdirected mTLS dial is identity misuse (and leaks the pushed config), not credential theft. That is the line ADR-0009 already draws between the two modes, so this PR does not redraw it. A deployment that genuinely fronts its gNB with a publicly-trusted certificate opts in explicitly by putting that CA bundle in `ca.crt`.

**Upstream precedent:** kubeadm pins a CA public key (RFC 7469 style) for token-based discovery rather than trusting the system store before sending its bootstrap token — the same "we are about to transmit a token, so the destination must be unforgeable" reasoning.

## What this does NOT claim

It is **not** the authorization boundary #251 asks for, and the `resolveRemoteControlTLS` comment still says "partial mitigation", because it still is. This bounds where a named credential may be *sent*; it does not change *who* may name it. The three known limits from #219 are untouched.

## Adversarial pass on my own change

- **No new oracle.** The refusal wraps `errRemoteControlCredentialInvalid`, and the controller surfaces only the uniform `errRemoteControlCredentialUnavailable` on the CR while logging the specific cause for the operator. Verified at the call site, not assumed.
- **Self-heals.** It is a deterministic credential error, so it takes the 5m poll (#282): adding `ca.crt` recovers without a spec edit.
- **No behaviour change for the no-token cases.** `ca.crt` present but invalid PEM still fails in the existing branch (it does not fall through to the new one); no token and no `ca.crt` is unchanged.
- **Ordering.** The gate sits after the type and label gates, so an unlabelled Secret still fails on the label first — no reordering of what a caller can learn.
- The new tests are a separate top-level function because adding them inline tripped `gocyclo` on an already-large table — which is also just better placement.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2`: **0 issues**; `gofmt` clean.
- `go test ./internal/controller/... ./pkg/...` green (envtest 1.36.2).
- **No test covered `token` without `ca.crt` at all** — every existing case supplied `ca.crt`, which is exactly why the fallback went unnoticed. Beyond the direct case, the new test states the **invariant** once: *any* successful resolution that returns a token must have pinned roots, so a future key or mode cannot reopen this case-by-case.
- **Mutation-verified:** removing the gate reddens both the direct case (`must be refused: the endpoint is caller-controlled…`) and the invariant (`a token was returned for "token only" with RootCAs=nil`).

## Two things a reviewer should look at deliberately

1. **Breaking change**, with an upgrade note and a detection one-liner in the CHANGELOG: any Secret with `token` and no `ca.crt` starts failing. Worth confirming that matches your deployments.
2. **`docs/api-reference.md` carries pre-existing drift.** Regenerating it (unavoidable, since I changed an API field doc) also pulled in `lastPushedSatSwitchDigest` from #285, `EphemerisSelectionAmbiguous`, and the `minTerrestrialDwell` CEL bounds. That file is generated but **no CI step checks it is current**. I deliberately did *not* add that gate here — bundling a CI-policy change into a security fix makes the fix harder to review — but it is worth a follow-up.

## Merge skew with #296

#296 **deletes** `errRemoteControlCredentialInvalid` and routes every credential failure to a single `RemoteControlCredentialUnavailable` reason. The new `return` here wraps that sentinel and sits in a block #296 rewrites, so whichever lands second drops the wrap — after #296 the uniform reason already applies. One-identifier resolution, in code #296 is touching anyway.


---

**Skew note refreshed (main @ `3ca522c`).** This PR's own merged HEAD against current `main` is **green** — build, `go vet`, and `./internal/controller/... ./pkg/...` (8 packages, no failures).

The #296 resolution written above was derived against `d83de6e` and is **stale**: #296 no longer compiles against `main` on its own, because #300 added a new use of the constant #296 deletes (see thc1006/ntn-operators#296 for the one-line fix). The resolution here will be re-derived once #296 is rebased. Nothing to do on this branch.
