### PR TITLE
fix(satelliteephemeris): typed pass-prediction failure reasons (P2-low)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Pass-prediction failures now carry a specific `PassesPredicted=False` reason instead of a blanket
+  `PredictionFailed`.** The failure event gate keys on `(Status, Reason, ObservedGeneration)` and
+  deliberately ignores the message, so two different root causes at the same generation (e.g. a
+  referenced ground station that is absent, then later created with an invalid latitude) produced no
+  fresh Event — the `.message` updated, but event history and event-driven alerting could not tell the
+  causes apart. Distinct causes are now tagged with stable, low-cardinality reasons —
+  `GroundStationNotFound`, `InvalidGroundStationLocation`, `InvalidPredictionConfig`,
+  `PredictionComputationFailed` — while a transient/unclassified read still falls back to
+  `PredictionFailed`. The message is still ignored by the gate (no Event flood on message-only
+  changes), and the `PassesPredicted` *status* is unchanged, so the NTNSlice consumer's 3-state gate
+  (which keys on `True`, not the reason) is unaffected. Operators that alerted specifically on
+  `reason == PredictionFailed` for these cases should widen to the `PassesPredicted=False` status.
+
 - **Pass prediction now runs on its own lower cadence, off the propagation heartbeat (#234, ADR 0006).**
   The SatelliteEphemeris reconcile propagates and publishes the runtime-push epoch **first**, then runs
   the expensive pass-window sweep only once per 15 minutes (was on every ~3-minute heartbeat) in a

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -1342,6 +1342,58 @@ func (r *SatelliteEphemerisReconciler) reportOrbitRegime(
 	return ""
 }
 
+// Pass-prediction failure reasons for the PassesPredicted=False condition. Kept stable and
+// low-cardinality so the message-insensitive episode gate (conditionEpisodeChanged) still emits a
+// fresh Warning when the ROOT CAUSE changes — an absent ground station later created with an invalid
+// latitude is a NEW episode, not a message-only churn. The varying detail stays in the message.
+const (
+	reasonPredictionFailed             = "PredictionFailed" // generic fallback (untagged / transient read)
+	reasonGroundStationNotFound        = "GroundStationNotFound"
+	reasonInvalidGroundStationLocation = "InvalidGroundStationLocation"
+	reasonInvalidPredictionConfig      = "InvalidPredictionConfig"
+	reasonPredictionComputationFailed  = "PredictionComputationFailed"
+)
+
+// predictionError tags a pass-prediction failure with the stable Reason its PassesPredicted=False
+// condition should carry, so the caller classifies without string-matching the message. Mirrors
+// ephemerisPushError. Unwrap keeps errors.Is working through the tag, so the caller's
+// context.Canceled/DeadlineExceeded short-circuit still fires before any classification.
+type predictionError struct {
+	reason string
+	err    error
+}
+
+func (e *predictionError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *predictionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newPredictionError(reason string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &predictionError{reason: reason, err: err}
+}
+
+// predictionConditionReason extracts the tagged reason, defaulting to the generic
+// reasonPredictionFailed for an untagged error (e.g. a transient ground-station read).
+func predictionConditionReason(err error) string {
+	var pe *predictionError
+	if errors.As(err, &pe) && pe.reason != "" {
+		return pe.reason
+	}
+	return reasonPredictionFailed
+}
+
 // handlePassPrediction runs pass prediction (when configured) and returns the
 // post-persist event notes: passNote (Normal, success) and passFailNote (Warning,
 // failure), each non-empty only on a real PassesPredicted-condition transition, so
@@ -1367,17 +1419,20 @@ func (r *SatelliteEphemerisReconciler) handlePassPrediction(
 		}
 		logf.FromContext(ctx).Error(err, "pass prediction failed")
 		eph.Status.NextPassWindows = nil // clear stale pass data
-		// Gate on the failure EPISODE (Status/Reason/Generation, ignoring the varying
-		// error Message) and defer the event to after the status persists (like
-		// reportOrbitRegime), so a rolled-back status update does not fire — and a
-		// message-only change does not re-fire — a PredictionFailed event.
+		// Classify the root cause into a stable Reason (predictPasses tags it) so a DIFFERENT
+		// cause is a new episode even when the message-insensitive gate ignores the message —
+		// e.g. an absent ground station later created with an invalid latitude. Gate on the
+		// failure EPISODE (Status/Reason/Generation) and defer the event to after the status
+		// persists (like reportOrbitRegime), so a rolled-back status update does not fire — and a
+		// same-reason message-only change does not re-fire — a failure event.
+		failReason := predictionConditionReason(err)
 		failEpisode := conditionEpisodeChanged(
 			meta.FindStatusCondition(eph.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted),
-			metav1.ConditionFalse, "PredictionFailed", eph.Generation)
+			metav1.ConditionFalse, failReason, eph.Generation)
 		meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 			Type:               ntnv1alpha1.ConditionPassesPredicted,
 			Status:             metav1.ConditionFalse,
-			Reason:             "PredictionFailed",
+			Reason:             failReason,
 			Message:            err.Error(),
 			ObservedGeneration: eph.Generation,
 		})
@@ -1408,7 +1463,12 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	for _, gsName := range pp.GroundStations {
 		gs := &ntnv1alpha1.GroundStationLifecycle{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: gsName}, gs); err != nil {
-			return "", fmt.Errorf("ground station %q not found: %w", gsName, err)
+			// A genuine absence is a distinct, stable root cause; any other read error (transient
+			// API failure, or a context error propagated by the caller) keeps the generic reason.
+			if apierrors.IsNotFound(err) {
+				return "", newPredictionError(reasonGroundStationNotFound, fmt.Errorf("ground station %q not found", gsName))
+			}
+			return "", newPredictionError(reasonPredictionFailed, fmt.Errorf("getting ground station %q: %w", gsName, err))
 		}
 		// A ground station under deletion (finalizer still holding the object) is being torn down — its
 		// contact windows can no longer be relied on, so exclude it from the sweep exactly as if it were
@@ -1420,17 +1480,17 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 		}
 		lat, err := ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Lat)
 		if err != nil {
-			return "", fmt.Errorf("invalid latitude for %q: %w", gsName, err)
+			return "", newPredictionError(reasonInvalidGroundStationLocation, fmt.Errorf("invalid latitude for %q: %w", gsName, err))
 		}
 		lon, err := ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Lon)
 		if err != nil {
-			return "", fmt.Errorf("invalid longitude for %q: %w", gsName, err)
+			return "", newPredictionError(reasonInvalidGroundStationLocation, fmt.Errorf("invalid longitude for %q: %w", gsName, err))
 		}
 		alt := 0.0
 		if gs.Spec.Deployment.Location.Alt != "" {
 			alt, err = ephemeris.ParseGeoCoord(gs.Spec.Deployment.Location.Alt)
 			if err != nil {
-				return "", fmt.Errorf("invalid altitude for %q: %w", gsName, err)
+				return "", newPredictionError(reasonInvalidGroundStationLocation, fmt.Errorf("invalid altitude for %q: %w", gsName, err))
 			}
 		}
 		stations = append(stations, ephemeris.GroundStation{
@@ -1444,7 +1504,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// Parse minElevation.
 	minEl, err := ephemeris.ParseElevation(pp.MinElevation)
 	if err != nil {
-		return "", fmt.Errorf("invalid minElevation: %w", err)
+		return "", newPredictionError(reasonInvalidPredictionConfig, fmt.Errorf("invalid minElevation: %w", err))
 	}
 
 	// Resolve the effective horizon (default when unset, clamped to maxPassHorizon otherwise):
@@ -1453,7 +1513,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// ratcheting-safe; MaxPassWindows already caps the stored output.
 	horizon, clamped, err := effectivePassHorizon(pp.Horizon.Duration)
 	if err != nil {
-		return "", err
+		return "", newPredictionError(reasonInvalidPredictionConfig, err)
 	}
 
 	// Build NORAD filter from SatelliteSelector.
@@ -1467,7 +1527,7 @@ func (r *SatelliteEphemerisReconciler) predictPasses(
 	// effectiveInterval (2–24h) in the past, which would start the window stale (#200-C3).
 	passes, err := ephemeris.PredictPasses(ctx, fetchResult.OMMs, stations, minEl, horizon, noradFilter, now)
 	if err != nil {
-		return "", fmt.Errorf("computing passes: %w", err)
+		return "", newPredictionError(reasonPredictionComputationFailed, fmt.Errorf("computing passes: %w", err))
 	}
 
 	// Convert to CRD PassWindow format.

--- a/internal/controller/satelliteephemeris_controller_test.go
+++ b/internal/controller/satelliteephemeris_controller_test.go
@@ -912,7 +912,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 		})
 		AfterEach(func() { deleteResource() })
 
-		It("should set PredictionFailed condition but still update fetch status", func() {
+		It("should set GroundStationNotFound condition but still update fetch status", func() {
 			mock := &mockGPFetcher{
 				result: ephemeris.GPFetchResult{
 					OMMs:           []sgp4.OMM{testISSOMM()},
@@ -938,7 +938,7 @@ var _ = Describe("SatelliteEphemeris Controller", func() {
 			predCond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionPassesPredicted)
 			Expect(predCond).NotTo(BeNil())
 			Expect(predCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(predCond.Reason).To(Equal("PredictionFailed"))
+			Expect(predCond.Reason).To(Equal("GroundStationNotFound"))
 		})
 	})
 

--- a/internal/controller/satelliteephemeris_prediction_reason_test.go
+++ b/internal/controller/satelliteephemeris_prediction_reason_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+)
+
+// TestPredictionConditionReason pins the tagged-reason extraction: a tagged error yields its
+// stable Reason, an untagged (or transient) error falls back to the generic reasonPredictionFailed,
+// and the tag survives further wrapping (so a caller that adds context does not lose the reason).
+func TestPredictionConditionReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"untagged error → generic fallback", errors.New("boom"), reasonPredictionFailed},
+		{"ground station not found", newPredictionError(reasonGroundStationNotFound, errors.New("x")), reasonGroundStationNotFound},
+		{"invalid location", newPredictionError(reasonInvalidGroundStationLocation, errors.New("x")), reasonInvalidGroundStationLocation},
+		{"invalid config", newPredictionError(reasonInvalidPredictionConfig, errors.New("x")), reasonInvalidPredictionConfig},
+		{"computation failed", newPredictionError(reasonPredictionComputationFailed, errors.New("x")), reasonPredictionComputationFailed},
+		{"tag survives outer wrapping", fmt.Errorf("outer: %w", newPredictionError(reasonGroundStationNotFound, errors.New("x"))), reasonGroundStationNotFound},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := predictionConditionReason(tc.err); got != tc.want {
+				t.Fatalf("predictionConditionReason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPredictionTagPreservesContextCancel guards the cancellation short-circuit in
+// handlePassPrediction: a context error tagged as a prediction failure must still satisfy
+// errors.Is (via Unwrap), so a shutdown/timeout is never recorded as a domain PredictionFailed.
+func TestPredictionTagPreservesContextCancel(t *testing.T) {
+	tagged := newPredictionError(reasonPredictionComputationFailed, fmt.Errorf("computing passes: %w", context.Canceled))
+	if !errors.Is(tagged, context.Canceled) {
+		t.Fatal("a tagged prediction error wrapping context.Canceled must still match errors.Is(context.Canceled)")
+	}
+}
+
+// TestPredictionReasonChange_IsNewEpisode is the finding's core: because the episode gate ignores
+// the Message, two DIFFERENT root causes at the SAME generation must still be distinct episodes so
+// event-driven alerting sees the change — an absent ground station later created with an invalid
+// latitude. The same cause at the same generation must NOT re-open an episode (no event flood).
+func TestPredictionReasonChange_IsNewEpisode(t *testing.T) {
+	const gen = int64(3)
+	r1 := predictionConditionReason(newPredictionError(reasonGroundStationNotFound, errors.New("ground station \"gs-1\" not found")))
+	cond := &metav1.Condition{
+		Type:               ntnv1alpha1.ConditionPassesPredicted,
+		Status:             metav1.ConditionFalse,
+		Reason:             r1,
+		ObservedGeneration: gen,
+	}
+	r2 := predictionConditionReason(newPredictionError(reasonInvalidGroundStationLocation, errors.New("invalid latitude for \"gs-1\"")))
+
+	if !conditionEpisodeChanged(cond, metav1.ConditionFalse, r2, gen) {
+		t.Fatalf("a different root cause (%s → %s) at the same generation must be a NEW episode", r1, r2)
+	}
+	if conditionEpisodeChanged(cond, metav1.ConditionFalse, r1, gen) {
+		t.Fatal("the same reason at the same generation must NOT re-open an episode (event flood)")
+	}
+}


### PR DESCRIPTION
Verified against current `origin/main` (`957b23b`).

## The finding (confirmed)

`conditionEpisodeChanged` keys the failure-event gate on `(Status, Reason, ObservedGeneration)` and **ignores the message** on purpose (a varying "dial timeout after 30.001s" must not re-emit a Warning every reconcile). But every pass-prediction failure in `handlePassPrediction` used the single reason `PredictionFailed`. So the reviewer's scenario is real:

1. A `SatelliteEphemeris` references a ground station that doesn't exist → `PassesPredicted=False / PredictionFailed`.
2. The ground station is later created, but with an invalid latitude.
3. The ephemeris generation is unchanged.
4. Status, Reason, ObservedGeneration are identical; only the message changed — which the gate ignores.
5. No new Event fires for the second root cause.

`.status.conditions[].message` still reflects the latest cause, so status isn't wrong — what's lost is Event history and event-driven alerting fidelity.

## Fix (adopted — pass-prediction path)

Tag each distinct cause with a stable, low-cardinality reason via a small `predictionError` (mirrors the existing `ephemerisPushError` pattern), classified once in `handlePassPrediction`:

| cause | reason |
|---|---|
| ground station `Get` returns NotFound | `GroundStationNotFound` |
| lat/lon/alt fails to parse | `InvalidGroundStationLocation` |
| minElevation / horizon invalid | `InvalidPredictionConfig` |
| `PredictPasses` computation error | `PredictionComputationFailed` |
| transient/unclassified read | `PredictionFailed` (fallback) |

- The message stays ignored by the gate (no Event flood on message-only churn — raw error text never enters the episode key, as the reviewer warned).
- The `PassesPredicted` **status** is unchanged, so the NTNSlice failover consumer (which keys on `True`, not the reason) is unaffected.
- The `context.Canceled`/`DeadlineExceeded` short-circuit is preserved — `predictionError` implements `Unwrap`, so `errors.Is` still catches a cancellation before any classification.
- No shipped alert or metric keys on the prediction reason, so nothing breaks; operators who alerted on `reason == PredictionFailed` should widen to the `PassesPredicted=False` status (noted in CHANGELOG).

## Not adopted — the provider-apply reasons (where the finding over-reaches)

- `ProviderStatusVerificationFailed` is a **rename** of the shipped `StatusCheckFailed` with no behavioural gain, and `docs/runbooks/alerts.md` references `StatusCheckFailed` — a rename would break that runbook and any operator alert keyed on the string.
- `ProviderUnavailable` / `ProviderRejected` are **runtime-push** concepts, and the runtime push path already distinguishes them (`ProviderPushFailed` / `ProviderPushRejected`). The ConfigMap-apply path (`ApplyCellConfig`) has no remote "unavailable/rejected" failure mode — its errors are k8s-API-transient, config-render, or internal-invariant — so splitting `ApplyFailed` would invent distinctions the code doesn't have. It already classifies the one meaningful non-transient case (`OwnershipConflict`).

## Tests (mutation-verified)

- `TestPredictionConditionReason` — table: each tag extracts its reason; untagged falls back; the tag survives outer wrapping.
- `TestPredictionTagPreservesContextCancel` — a tagged `context.Canceled` still satisfies `errors.Is` (the cancel short-circuit holds).
- `TestPredictionReasonChange_IsNewEpisode` — the finding's core: a different cause at the same generation IS a new episode; the same cause is NOT (no flood).
- Reclassified the existing "ground station does not exist" Ginkgo spec to assert `GroundStationNotFound`.

Neutering the tag extraction fails both the unit test and the Ginkgo spec. Full `internal/controller` envtest suite green; `go vet`, `gofmt` clean.

Small, focused CL (one controller file + tests).