### PR TITLE
feat(network-policy): opt-in operator egress NetworkPolicy for the kustomize base (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The kustomize base now ships an opt-in default-deny egress NetworkPolicy for the operator (#299).**
+  The Helm chart already restricts operator egress via `networkPolicy.enable`, but the kustomize base
+  (`config/network-policy/`) only had the metrics *ingress* rule, so a non-Helm deployment had no
+  egress control. `config/network-policy/allow-egress-traffic.yaml` adds the network-layer half of the
+  `remoteControl.endpoint` SSRF defense: default-deny egress with explicit allows for DNS, HTTPS 443
+  (API server / CelesTrak / Space-Track), and the per-CR Prometheus (9090) and gNB (8001) ports. It is
+  part of the already opt-in `config/network-policy` bundle (disabled by default; needs a
+  NetworkPolicy-enforcing CNI), so existing deployments are unchanged. The file documents that the
+  port-only gNB rule must be replaced with a CIDR-scoped `to:` block to actually bound where the
+  operator may dial — the app-layer `--remote-control-allowed-endpoint-hosts` allow-list is the
+  complementary control.
+
 - **Closed a residual Secret existence/type oracle in the `remoteControl.tls` credential path.** #219
   unified the CR-facing *message* for a `remoteControl.tls` resolution failure but not the *reason*: a
   missing/unreadable Secret classified as `ProviderPushFailed` (1 min requeue) while a present-but-bad

--- a/config/network-policy/allow-egress-traffic.yaml
+++ b/config/network-policy/allow-egress-traffic.yaml
@@ -1,0 +1,61 @@
+# Default-deny EGRESS for the operator, with explicit allows. This is the network-layer
+# half of the remoteControl.endpoint SSRF defense (issue #299); the app layer is the
+# --remote-control-allowed-endpoint-hosts / --prometheus-allowed-endpoint-hosts flags.
+# The Helm chart ships the same policy behind `networkPolicy.enable` (dist/chart) with
+# per-CR port values; this is the parity resource for the kustomize base.
+#
+# OPT-IN: the whole config/network-policy bundle is disabled by default (uncomment
+# `- ../network-policy` in config/default/kustomization.yaml to enable). It needs a CNI
+# that ENFORCES NetworkPolicy (Calico/Cilium) — Kind's default kindnet does NOT enforce it,
+# so this is inert on the e2e cluster.
+#
+# ⚠ SSRF NOTE: the gNB/Prometheus rules below allow those PORTS to ANY destination, which
+# does NOT stop the operator from dialing an arbitrary host on that port. To actually close
+# the probing surface, DELETE the port-only gNB rule and instead scope the port to your
+# sanctioned gNB subnet with a `to: [ipBlock: {cidr: ...}]` block (see the commented example).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-egress-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: ntn-operators
+  policyTypes:
+    - Egress
+  egress:
+    # HTTPS 443: Kubernetes API server + CelesTrak + Space-Track (GP-data fetch).
+    - ports:
+        - port: 443
+          protocol: TCP
+    # DNS resolution.
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+    # In-cluster Prometheus queried by NTNSlice.spec.metricsSource.prometheus (default 9090).
+    # Remove if no NTNSlice uses a prometheus metricsSource.
+    - ports:
+        - port: 9090
+          protocol: TCP
+    # gNB remote_control WebSocket targeted by NTNCellConfig.spec.provider.remoteControl.endpoint
+    # (default 8001). Remove if no NTNCellConfig configures a runtime push. See the SSRF note
+    # above: to bound WHERE the push may connect, replace this port-only rule with a scoped one:
+    #   - to:
+    #       - ipBlock:
+    #           cidr: 10.20.0.0/16    # your sanctioned gNB subnet
+    #     ports:
+    #       - port: 8001
+    #         protocol: TCP
+    - ports:
+        - port: 8001
+          protocol: TCP
+    # NOTE: the ground-station monitoring probe (GroundStationLifecycle.spec.monitoring.endpoint)
+    # is another CR-controlled egress. If you use it on a non-443 port, add that port here (and
+    # prefer a CIDR-scoped block, same as the gNB rule).

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - allow-metrics-traffic.yaml
+- allow-egress-traffic.yaml


### PR DESCRIPTION
The network-layer half of the `remoteControl.endpoint` SSRF defense tracked in #299.

## Context

#299's proposed defense is two-layer: an app-layer host allow-list (already shipped as `--remote-control-allowed-endpoint-hosts` in #300) **plus** a network-layer egress restriction. The **Helm chart already ships** the egress policy (`dist/chart/templates/manager/networkpolicy.yaml`, gated by `networkPolicy.enable`, with per-CR gNB/Prometheus port values and `extraEgress` for CIDR-scoping). But the **kustomize base** (`config/network-policy/`) only had the metrics *ingress* rule — so a non-Helm (`kubectl apply -k`) deployment had no egress control. This adds the parity resource.

## Change

`config/network-policy/allow-egress-traffic.yaml` — default-deny egress with explicit allows:
- DNS (53 TCP/UDP)
- HTTPS 443 (Kubernetes API server + CelesTrak + Space-Track GP fetch)
- Prometheus 9090 (NTNSlice `metricsSource`)
- gNB 8001 (NTNCellConfig runtime push)

Added to the **already opt-in** `config/network-policy` bundle (`config/default/kustomization.yaml` keeps `- ../network-policy` commented out), so existing deployments are unchanged. Needs a NetworkPolicy-enforcing CNI (Calico/Cilium; Kind's kindnet does not enforce, so it is inert on e2e).

## SSRF note (in the file)

The port-only gNB/Prometheus rules allow those ports to **any** destination, which does **not** stop the operator dialing an arbitrary host on that port. The file documents replacing the port-only gNB rule with a CIDR-scoped `to: [ipBlock]` block to actually bound egress to sanctioned gNB subnets — that, plus the app-layer allow-list, is what closes the probing surface. The ground-station monitoring endpoint (also CR-controlled) is called out as another egress to scope.

## Verification

`kustomize build config/network-policy` renders both policies (Egress + Ingress); `kustomize build config/default` unchanged (bundle stays commented out).

With this, #299's two-layer defense exists in both the Helm and kustomize paths; the remaining #299 items (a `ServiceReference` alternative to free-form `host:port`) stay tracked there.