### PR TITLE
fix(ocudu): classify every non-101 handshake answer, not just the 3xx/4xx band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   references and its `EnsureOwnership` back-fill used `SetControllerReference` in a single `Update`,
   so a genuine leftover has either our controller reference or none. A ConfigMap owned by a different controller, an unlabeled foreign object, and a
   labeled-but-empty impostor are still left untouched, and the skip is now logged. Mutation-tested.
+- **A handshake answered by something that is not a WebSocket server is no longer retried once a
+  minute forever.** The classifier keyed on a status BAND (`300 <= code < 500`), so everything else
+  fell through to "gNB unreachable" and the tight cadence. But coder/websocket accepts only a valid
+  101 and returns a **non-nil** response for every other outcome — verified against v1.8.15 — so the
+  band silently missed: a plain **200** from an HTTP server on the wrong port, a **204** from a proxy
+  that swallowed the `Upgrade`, and a **101 whose `Sec-WebSocket-Accept`, `Upgrade` header or
+  subprotocol is invalid**. Each is a deterministic protocol/config fault that the next minute cannot
+  fix, and each was being hammered indefinitely. Classification now keys on the response being
+  present rather than on a band: any definitive answer is a rejection (the bounded self-heal poll),
+  except `5xx` and `408`/`425`, which stay transient. `501 Not Implemented` and `505 HTTP Version Not
+  Supported` are deliberately excluded from that 5xx exception — they say the server is *incapable*,
+  not momentarily struggling, so banding them as transient would repeat the very mistake being fixed
+  here. A malformed 101 carries the library's reason, which names the offending header.
+
 - **A refused runtime-push handshake no longer strands the cell until an unrelated heartbeat.** Every
   non-101 HTTP response to the gNB `remote_control` WebSocket handshake in the 3xx/4xx band was
   classified `ProviderPushRejected`, which is in the never-requeue set — a set whose contract is "the

--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -252,9 +252,10 @@ func buildNTNConfigUpdate(u provider.RuntimeUpdate) (ntnConfigUpdateEnvelope, er
 type wsErrorKind int
 
 const (
-	// wsUnreachable: dial/write/read failed — transient, worth a requeue. Also covers a
-	// handshake the endpoint answered with a repeat-me status (408/425): the dial did fail,
-	// and the correct response is the same tight retry.
+	// wsUnreachable: dial/write/read failed — transient, worth a requeue. Also covers the
+	// handshake outcomes that are somebody else's transient problem rather than a verdict on
+	// us: a repeat-me status (408/425) and any 5xx. The dial did fail in each case, and the
+	// correct response is the same tight retry.
 	wsUnreachable wsErrorKind = iota
 	// wsPayloadTooLarge: frame exceeds OCUDU's 16 KB cap — permanent.
 	wsPayloadTooLarge
@@ -262,10 +263,11 @@ const (
 	wsMarshal
 	// wsRejected: the gNB replied {"error": ...} — permanent (bad config).
 	wsRejected
-	// wsHandshakeRejected: the handshake got a definitive HTTP response (a refused
-	// redirect, an auth rejection, or another non-101 in the 3xx/4xx range) rather
-	// than an Upgrade — the endpoint is reachable and said no, so a tight retry is
-	// pointless, but the fix is unwatched external state, so it must still be polled.
+	// wsHandshakeRejected: the handshake got a definitive HTTP response rather than a usable
+	// Upgrade — a refused redirect, an auth rejection, a plain 200/204 from something that is
+	// not a WebSocket server, or a 101 whose handshake headers are invalid. The endpoint is
+	// reachable and said no, so a tight retry is pointless, but the fix is unwatched external
+	// state, so it must still be polled.
 	wsHandshakeRejected
 )
 
@@ -365,23 +367,51 @@ func pushNTNConfigUpdate(
 	}
 	conn, resp, err := websocket.Dial(dialCtx, scheme+endpoint, dialOpts)
 	if err != nil {
-		// A definitive HTTP handshake response (a refused redirect, an auth rejection, or
-		// any other non-101 in the 3xx/4xx range) means the endpoint is reachable and said
-		// no — a tight per-minute retry cannot fix it. But it is NOT permanent either: the
-		// gNB, the proxy in front of it and the credential we present are all external
-		// state this controller does not watch, so "never retry" would strand the cell
-		// until some unrelated ephemeris heartbeat happens to fan out — and forever if the
-		// producer stalls. It gets the slow self-heal poll instead, exactly as the local
-		// credential path does (RemoteControlCredentialUnavailable, #282). A nil response is a
-		// connection-level failure (dial/TLS/timeout, or a 5xx) and keeps the tight
-		// cadence. coder/websocket owns resp.Body, so we only read the status.
-		if resp != nil && resp.StatusCode >= 300 && resp.StatusCode < 500 {
-			// 408 and 425 ask for the SAME request again (RFC 9110 §15.5.9, RFC 8470 §5.2),
-			// so they are the handshake's own transient failures, not a rejection.
-			if resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooEarly {
+		// A NON-NIL response means the endpoint answered the handshake definitively: it is
+		// reachable and is either refusing us or is not a WebSocket server at all, so a tight
+		// per-minute retry cannot fix it. But it is NOT permanent either — the gNB, the proxy
+		// in front of it and the credential we present are all external state this controller
+		// does not watch, so "never retry" would strand the cell until some unrelated ephemeris
+		// heartbeat happens to fan out, and forever if the producer stalls. It gets the slow
+		// self-heal poll, exactly as the local credential path does (RemoteControlCredentialUnavailable,
+		// #282).
+		//
+		// Keying on resp != nil rather than on a status BAND matters: coder/websocket accepts
+		// only a valid 101, and returns a non-nil response for everything else — a plain 200
+		// from an HTTP server on the wrong port, a 204 from a proxy that swallowed the Upgrade,
+		// and even a 101 whose Sec-WebSocket-Accept or Upgrade header is invalid (verified
+		// against v1.8.15). A 3xx/4xx band silently left all of those on the tight cadence,
+		// hammering a misconfiguration once a minute forever.
+		//
+		// A NIL response is a connection-level failure (dial/TLS/timeout) and keeps the tight
+		// cadence. coder/websocket owns resp.Body, so we only ever read the status.
+		if resp != nil {
+			switch {
+			case resp.StatusCode >= 500 &&
+				resp.StatusCode != http.StatusNotImplemented &&
+				resp.StatusCode != http.StatusHTTPVersionNotSupported:
+				// Server-side blip rather than a verdict on us — conventionally transient. 501 and
+				// 505 are excluded on purpose: they say the server is INCAPABLE of the request, not
+				// that it is momentarily struggling, so the next minute changes nothing. Splitting
+				// them out keeps this classified by what fixes the failure rather than by a status
+				// band — banding is the mistake this whole path is being corrected for.
+				return &wsError{
+					wsUnreachable,
+					fmt.Sprintf("handshake to %s failed: HTTP %d", endpoint, resp.StatusCode),
+				}
+			case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooEarly:
+				// 408 and 425 ask for the SAME request again (RFC 9110 §15.5.9, RFC 8470 §5.2).
 				return &wsError{
 					wsUnreachable,
 					fmt.Sprintf("handshake to %s did not complete: HTTP %d", endpoint, resp.StatusCode),
+				}
+			case resp.StatusCode == http.StatusSwitchingProtocols:
+				// 101 that failed validation: the peer speaks something that is not RFC 6455.
+				// Carry the library's reason — it names the offending header, which is the
+				// whole diagnostic value here.
+				return &wsError{
+					wsHandshakeRejected,
+					fmt.Sprintf("handshake to %s returned HTTP 101 but is not a valid WebSocket upgrade: %v", endpoint, err),
 				}
 			}
 			return &wsError{wsHandshakeRejected, fmt.Sprintf("handshake to %s rejected: HTTP %d", endpoint, resp.StatusCode)}

--- a/pkg/provider/ocudu/wsclient_test.go
+++ b/pkg/provider/ocudu/wsclient_test.go
@@ -407,6 +407,8 @@ func TestPushNTNConfigUpdate_HandshakeStatusRetryPolicy(t *testing.T) {
 		want   wsRetryPolicy
 		why    string
 	}{
+		{http.StatusOK, wsRetrySlow, "200: an HTTP server on the wrong port is a config error, not a blip"},
+		{http.StatusNoContent, wsRetrySlow, "204: a proxy that swallowed the Upgrade will keep doing so"},
 		{http.StatusMovedPermanently, wsRetrySlow, "301: never followed, but the proxy rule behind it can be fixed"},
 		{http.StatusFound, wsRetrySlow, "302: same as 301"},
 		{http.StatusTemporaryRedirect, wsRetrySlow, "307: same as 301"},
@@ -419,6 +421,8 @@ func TestPushNTNConfigUpdate_HandshakeStatusRetryPolicy(t *testing.T) {
 		{http.StatusRequestTimeout, wsRetryTight, "408: RFC 9110 §15.5.9 — the client MAY repeat the request"},
 		{http.StatusTooEarly, wsRetryTight, "425: RFC 8470 §5.2 — retry once the early-data replay risk is gone"},
 		{http.StatusTooManyRequests, wsRetrySlow, "429: transient, but hammering at 1/min is exactly what it forbids"},
+		{http.StatusNotImplemented, wsRetrySlow, "501: the server says it CANNOT do this, not that it is busy"},
+		{http.StatusHTTPVersionNotSupported, wsRetrySlow, "505: same — a capability refusal, not a blip"},
 		{http.StatusInternalServerError, wsRetryTight, "500: a server-side blip is the transient case"},
 		{http.StatusServiceUnavailable, wsRetryTight, "503: same as 500"},
 	} {
@@ -443,6 +447,55 @@ func TestPushNTNConfigUpdate_HandshakeStatusRetryPolicy(t *testing.T) {
 			}
 			if we.retryPolicy() == wsRetryNever {
 				t.Errorf("HTTP %d must never be classified wsRetryNever: no spec edit can fix external state", tc.status)
+			}
+		})
+	}
+}
+
+// A 101 is not automatically a successful handshake: coder/websocket still validates
+// Sec-WebSocket-Accept, the Upgrade header and any negotiated subprotocol, and returns an error
+// with a NON-NIL response carrying status 101 when they do not check out. That peer speaks
+// something that is not RFC 6455 — a deterministic protocol/config fault whose fix is outside
+// this controller, so it must poll rather than hammer the endpoint once a minute forever.
+func TestPushNTNConfigUpdate_Malformed101IsRejectedNotUnreachable(t *testing.T) {
+	raw := func(payload string) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			h, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				return
+			}
+			defer h.Close() //nolint:errcheck // best-effort in a test server
+			_, _ = h.Write([]byte(payload))
+		}
+	}
+	const upgrade101 = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+	for name, payload := range map[string]string{
+		"bad Sec-WebSocket-Accept": upgrade101 + "Sec-WebSocket-Accept: wrong\r\n\r\n",
+		"missing Upgrade header":   "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\n\r\n",
+		"unrequested subprotocol":  upgrade101 + "Sec-WebSocket-Protocol: nope\r\n\r\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(raw(payload))
+			t.Cleanup(srv.Close)
+
+			target := provider.ResolvedRemoteControl{Endpoint: strings.TrimPrefix(srv.URL, "http://")}
+			env, _ := buildNTNConfigUpdate(ecefRuntimeUpdate())
+			err := pushNTNConfigUpdate(context.Background(), target, env)
+			if err == nil {
+				t.Fatal("an invalid 101 upgrade must not be reported as a successful push")
+			}
+			var we *wsError
+			if !errors.As(err, &we) {
+				t.Fatalf("want a *wsError, got %T: %v", err, err)
+			}
+			if got := we.retryPolicy(); got != wsRetrySlow {
+				t.Errorf("retryPolicy = %d, want wsRetrySlow (%d): a peer that is not "+
+					"RFC 6455 will not become one on the next minute", got, wsRetrySlow)
+			}
+			// The library names the offending header; that detail is the whole diagnostic
+			// value, so it must reach the operator rather than being flattened to "dial failed".
+			if !strings.Contains(we.Error(), "not a valid WebSocket upgrade") {
+				t.Errorf("message should identify the invalid upgrade, got %q", we.Error())
 			}
 		})
 	}


### PR DESCRIPTION
> **Stacked on #297** (`fix/handshake-status-classification`) — it needs #297's three-valued `retryPolicy`, because on `main` alone `wsHandshakeRejected` still means *never retry*, and widening the net there would make a misconfigured 200 **permanent** rather than polled. Review #297 first; the diff below is the delta.

## The review is right, and it caught something I looked at and waved through

While adversarially reviewing #297 I explicitly considered the 2xx case and talked myself out of it — *"a 200-to-Upgrade is vanishingly rare vs 401/429, and tight-retrying it is not harmful (it's the status quo)"*. That reasoning does not survive contact with the rest of #297: the same argument would have justified leaving `404` on the tight cadence, and #297 moved `404`. Keeping a status **band** while claiming to classify by *what fixes the failure* was inconsistent, and the reviewer found the seam.

## The premise, verified rather than assumed

The whole review rests on "resp is still non-nil". I probed the vendored **v1.8.15** directly and inspected `resp`:

| server behaviour | `err != nil` | response |
|---|---|---|
| 200 OK | yes | **non-nil**, status 200 |
| 204 No Content | yes | **non-nil**, status 204 |
| 302 redirect | yes | **non-nil**, status 302 |
| 401 | yes | **non-nil**, status 401 |
| 500 / 503 | yes | **non-nil**, status 500 / 503 |
| 101, bad `Sec-WebSocket-Accept` | yes | **non-nil**, status **101** |
| 101, missing `Upgrade` header | yes | **non-nil**, status **101** |
| 101, unrequested subprotocol | yes | **non-nil**, status **101** |

All nine were being classified `wsUnreachable` → tight per-minute retry. Confirmed by a second probe that ran them through `pushNTNConfigUpdate` itself.

So the band silently missed three real, deterministic misconfigurations — a plain **200** from an HTTP server on the wrong port, a **204** from a proxy that swallowed the `Upgrade`, and a **malformed 101** — and hammered each of them once a minute, forever.

## Change

Classification keys on the response being **present**, not on a band. A definitive answer means the endpoint is reachable and is either refusing us or is not a WebSocket server, which the next minute cannot change → bounded self-heal poll. Transient exceptions: `5xx`, and `408`/`425` (RFC 9110 §15.5.9, RFC 8470 §5.2).

A malformed 101 now carries the library's own reason, which names the offending header — flattening that to `dial failed` threw away the entire diagnostic.

### One carve-out that is mine, not the reviewer's

`501 Not Implemented` and `505 HTTP Version Not Supported` are excluded from the 5xx exception. They say the server is **incapable** of the request, not that it is momentarily struggling — so banding them as transient would re-introduce the exact mistake this PR fixes, one boundary to the right. This fell out of asking whether the new rule was actually *principled* or just a better-placed band.

### Not adopted

**A distinct typed reason for 401/403.** It changes no behaviour (both already take the same poll), the HTTP status is already in the condition message, and it cuts against #296's deliberate unification of credential-failure reasons. Declined as surface without effect.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2`: **0 issues**; `gofmt` clean.
- `go test ./internal/controller/... ./pkg/...`: 8 packages ok.
- **Mutation-verified**, each reverting only itself and reddening only its own cases:
  - restore the `3xx/4xx` band → `200`, `204` and the malformed-101 cases fail
  - drop the 5xx exception → **only** `500` and `503` fail
  - fold `501`/`505` back into 5xx → **only** those two fail

New coverage: `200`/`204`/`501`/`505` rows in the status table, plus `TestPushNTNConfigUpdate_Malformed101IsRejectedNotUnreachable` driving three distinct invalid upgrades through a hijacking test server.

Sources: [coder/websocket #316](https://github.com/coder/websocket/issues/316) (non-101 handshake error shape), [coder/websocket #461](https://github.com/coder/websocket/issues/461).
