### PR TITLE
fix(test): restore the build — storeFlapState/loadFlapState gained a generation arg

### DIFF
--- a/internal/controller/ntnslice_satread_test.go
+++ b/internal/controller/ntnslice_satread_test.go
@@ -182,7 +182,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 	key := client.ObjectKeyFromObject(nsObj)
 	// Seed a confirmation + recovery streak AND a dwell clock from an earlier reliable window.
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -192,7 +192,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset when satellite availability is unknown (H2), got %v", st.RecoveryObservedAt)
 	}
@@ -265,7 +265,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 
 	key := client.ObjectKeyFromObject(nsObj)
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -275,7 +275,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset on unreliable metrics with a known satellite (H2), got %v", st.RecoveryObservedAt)
 	}


### PR DESCRIPTION
## 🔴 `main` does not `go vet` — this unblocks every open PR

```
internal/controller/ntnslice_satread_test.go:189:3:
  not enough arguments in call to r.storeFlapState
  have (client.ObjectKey, types.UID, slice.AntiFlapState)
  want (types.NamespacedName, types.UID, int64, slice.AntiFlapState)
```

Reproduced on `main @ 2264707` directly, not inferred from CI.

**Cause.** #307 added a `generation` parameter to `storeFlapState`/`loadFlapState`. #292 still calls the old 3-arg form at four sites. The two changes touch different lines, so **git merged #292 cleanly** and nothing complained until the compiler ran. #292's own CI was green because it last ran *before* the signature landed, and GitHub does not re-run a PR when `main` advances underneath it.

Same shape as #289/#291 → #293. I flagged this exact breakage on #292 before it merged; it landed anyway, so this is the follow-up rather than a new discovery.

**Blast radius:** every open PR is currently red on `Unit + envtest`, `Race detector` and `E2E on Kind` — for a file none of them touch. #301, #306 and #309 were green before `main` moved.

## The fix is not just "make it compile"

Four call sites, seeded with `nsObj.Generation`:

```go
r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{…})
st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
```

Passing *any* generation would have compiled — and quietly broken both tests. On a generation mismatch `loadFlapState` **itself** zeroes `ConsecutiveDegraded` and `RecoveryObservedAt`, which is precisely what `TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell` and `TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell` assert the *reconcile* does. A wrong value would have made them pass for the wrong reason, asserting the generation gate instead of the H2 unknown-satellite reset.

**Proven, not assumed:** with the `entry.generation != generation` branch in `loadFlapState` neutered, both tests still pass — so they are exercising the H2 reset, and the seeded generation matches what the reconciler observes.

## Verification

- `go vet ./...` clean on the fixed tree (it is **not** clean on `main`).
- `go test ./internal/controller/... ./pkg/...`: 8 packages ok (envtest 1.36.2).
- `golangci-lint v2.12.2`: **0 issues**.

## Worth a follow-up

Nothing in CI catches "this PR is stale against `main`". A scheduled or merge-queue re-run, or requiring branches to be up to date before merge, would have caught both this and the #296 case. Not bundled here — a red `main` should get the smallest possible fix.
