### PR TITLE
fix(test): repair flap-state call arity that broke main's go vet (merge-skew)

### DIFF
--- a/internal/controller/ntnslice_satread_test.go
+++ b/internal/controller/ntnslice_satread_test.go
@@ -182,7 +182,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 	key := client.ObjectKeyFromObject(nsObj)
 	// Seed a confirmation + recovery streak AND a dwell clock from an earlier reliable window.
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -192,7 +192,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset when satellite availability is unknown (H2), got %v", st.RecoveryObservedAt)
 	}
@@ -265,7 +265,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 
 	key := client.ObjectKeyFromObject(nsObj)
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -275,7 +275,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset on unreliable metrics with a known satellite (H2), got %v", st.RecoveryObservedAt)
 	}


### PR DESCRIPTION
## main is currently red — this unblocks it

`go vet ./...` **fails on `main`**, so every open PR's `Unit + envtest`, `Race detector`, and `E2E on Kind` (all of which compile the test package) go red regardless of the PR's own content:

```
vet: internal/controller/ntnslice_satread_test.go:189:3: not enough arguments in call to r.storeFlapState
  have (ObjectKey, UID, AntiFlapState)  want (NamespacedName, UID, int64, AntiFlapState)
```

## Root cause — a merge-skew

`storeFlapState` / `loadFlapState` gained a `generation int64` parameter (for generation-scoped anti-flap staleness), and the callers in that PR were updated. But the telemetry-gap coverage tests (#292, `ntnslice_satread_test.go`) were branched off an older `main` with the old signatures and merged with the stale 3-/2-arg calls. Each PR was green alone; merged `main` doesn't compile its tests. (`go build ./...` doesn't catch it — it skips `_test.go`; only `go vet`/`go test` compile them.)

## Fix

Pass `nsObj.Generation` at all four stale call sites (two `storeFlapState`, two `loadFlapState`), matching the store/load generation contract and the production callers (`ns.Generation`). Seeding and loading with the same generation keeps the anti-flap state honored, which is what those tests rely on.

## Verification

`go vet ./...` clean; full `internal/controller` envtest suite green (21.9s); `gofmt` clean.

Merge this before the other open PRs — their CI will keep failing until `main`'s tests compile again.