### PR TITLE
fix(test): repair anti-flap signature skew that broke main's test build

### DIFF
--- a/internal/controller/ntnslice_satread_test.go
+++ b/internal/controller/ntnslice_satread_test.go
@@ -182,7 +182,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 	key := client.ObjectKeyFromObject(nsObj)
 	// Seed a confirmation + recovery streak AND a dwell clock from an earlier reliable window.
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -192,7 +192,7 @@ func TestReconcile_UnknownSatellite_ResetsStreakKeepsDwell(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset when satellite availability is unknown (H2), got %v", st.RecoveryObservedAt)
 	}
@@ -265,7 +265,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 
 	key := client.ObjectKeyFromObject(nsObj)
 	dwell := fixedNow.Add(-30 * time.Second)
-	r.storeFlapState(key, nsObj.UID, slice.AntiFlapState{
+	r.storeFlapState(key, nsObj.UID, nsObj.Generation, slice.AntiFlapState{
 		RecoveryObservedAt:  fixedNow.Add(-200 * time.Second),
 		ConsecutiveDegraded: 2,
 		LastSwitchback:      dwell,
@@ -275,7 +275,7 @@ func TestReconcile_MetricsUnreliableSatelliteKnown_ResetsStreakKeepsDwell(t *tes
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	st := r.loadFlapState(key, nsObj.UID)
+	st := r.loadFlapState(key, nsObj.UID, nsObj.Generation)
 	if !st.RecoveryObservedAt.IsZero() {
 		t.Errorf("recovery clock must reset on unreliable metrics with a known satellite (H2), got %v", st.RecoveryObservedAt)
 	}


### PR DESCRIPTION
**P0 — main's `Unit + envtest` job is currently red.** The `internal/controller` test package does not compile on `origin/main` (`2264707`).

**Merge-skew root cause:** PR #292 (`test/telemetry-gap-reset-coverage`) added `ntnslice_satread_test.go` calling `storeFlapState`/`loadFlapState` with the **pre-`29b7dce`** signature, while the parallel anti-flap spec-generation-reset change (`29b7dce`) added a `generation int64` parameter and updated the controller call sites. Each PR was green in isolation; merged together the test package no longer compiles (git merge-tree only catches *textual* conflicts, not type skew).

**Fix:** pass `nsObj.Generation` at both seed sites, mirroring `Reconcile`'s `loadFlapState(key, ns.UID, ns.Generation)` (ntnslice_controller.go:439). The seeded anti-flap state round-trips (no spurious generation-change reset) and the telemetry-gap reset assertions still hold.

Verified locally: `go vet ./internal/controller/` compiles; the four affected `ResetsStreakKeepsDwell` tests pass. Test-only; no production code touched.