### PR TITLE
fix(ntncellconfig): reject a remoteControl.tls token that is not a valid HTTP header value

### DIFF
--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/net/http/httpguts"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -82,8 +83,9 @@ const (
 	ephemerisReasonEphemerisStale       = "EphemerisStale"
 	// ephemerisReasonRemoteControlCredential is the UNIFORM CR-facing reason for EVERY
 	// remoteControl.tls resolution failure — Secret missing, unreadable, wrong type, unlabelled,
-	// or malformed cert. It deliberately does NOT distinguish "missing/unreadable" from
-	// "present-but-invalid": a split reason (or a split retry cadence, which the per-failure
+	// malformed cert, or a token that is not a valid HTTP header value. It deliberately does NOT
+	// distinguish "missing/unreadable" from "present-but-invalid": a split reason (or a split retry
+	// cadence, which the per-failure
 	// EphemerisPushErrorsTotal would leak via its increment rate) would let a principal who can
 	// write the NTNCellConfig but not read Secrets probe Secret existence and type (an oracle).
 	ephemerisReasonRemoteControlCredential = "RemoteControlCredentialUnavailable"
@@ -822,7 +824,7 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 	tlsConfig, authToken, tlsErr := r.resolveRemoteControlTLS(ctx, eph.Namespace, spec.Provider.RemoteControl)
 	if tlsErr != nil {
 		// A deterministic credential/config error (wrong Secret type, missing opt-in label,
-		// malformed cert) does not clear on retry — only on a Secret or spec edit. The spec is
+		// malformed cert/token) does not clear on retry — only on a Secret or spec edit. The spec is
 		// watched, but the Secret is NOT (the controller watches only NTNCellConfig +
 		// SatelliteEphemeris, and secrets are get-only), so a Secret fix does not re-trigger
 		// reconcile. It therefore gets a low-frequency bounded self-heal requeue
@@ -883,7 +885,7 @@ const (
 
 // errRemoteControlCredentialUnavailable is the UNIFORM, CR-facing message for any
 // remoteControl.tls resolution failure. The specific cause (Secret missing / wrong
-// type / unlabelled / malformed cert) is logged for the operator but never surfaced
+// type / unlabelled / malformed cert / malformed token) is logged for the operator but never surfaced
 // on the CR condition/event: it would otherwise let a principal who can write the CR
 // but not read Secrets probe Secret existence and type (an oracle).
 var errRemoteControlCredentialUnavailable = errors.New("referenced remote-control credential is unavailable or not authorized")
@@ -893,6 +895,11 @@ var errRemoteControlCredentialUnavailable = errors.New("referenced remote-contro
 // this is NOT a Secret oracle — the endpoint is CR-author-set and already known to the writer — so it
 // names the endpoint. It is deterministic (config), so it self-heals on a spec/flag change, not a retry.
 var errRemoteControlEndpointNotAllowed = errors.New("remoteControl.tls endpoint is not in the operator's remote-control allow-list")
+
+// maxRemoteControlTokenBytes bounds the bearer token so the "Authorization: Bearer <token>"
+// header stays well under any HTTP header-size limit and far below the 1 MiB Secret cap.
+// 8 KiB is generous for any real shared secret or JWT.
+const maxRemoteControlTokenBytes = 8 * 1024
 
 // resolveRemoteControlTLS builds the TLS config and bearer token for the runtime
 // push from the Secret referenced by remoteControl.tls. It reads the Secret from
@@ -970,8 +977,24 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 		}
 		cfg.Certificates = []tls.Certificate{pair}
 	}
-	// Optional shared secret, sent as Authorization: Bearer (only over the TLS conn).
-	return cfg, string(secret.Data["token"]), nil
+	// Optional shared secret, sent as "Authorization: Bearer <token>" (only over the TLS conn).
+	// A Secret holds arbitrary bytes; a token carrying a CR/LF/NUL — most often a trailing newline
+	// from `kubectl create secret --from-file` — makes net/http reject the header at dial time,
+	// which today misclassifies a credential-format error as a transient gNB unreachability and
+	// tight-retries it. Reject it here so it takes the SAME uniform credential reason and slow
+	// self-heal as every other bad credential (the caller logs this error; it never names the token).
+	token := string(secret.Data["token"])
+	if token != "" {
+		if len(token) > maxRemoteControlTokenBytes {
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: token is %d bytes, over the %d-byte limit",
+				t.SecretName, len(token), maxRemoteControlTokenBytes)
+		}
+		if !httpguts.ValidHeaderFieldValue("Bearer " + token) {
+			return nil, "", fmt.Errorf("remoteControl.tls secret %q: token is not a valid HTTP header value "+
+				"(a control byte such as CR/LF/NUL — e.g. a trailing newline?)", t.SecretName)
+		}
+	}
+	return cfg, token, nil
 }
 
 // uniquePropagatedNorads counts distinct NORAD IDs among the states. Used to fail closed when a cell

--- a/internal/controller/ntncellconfig_tls_test.go
+++ b/internal/controller/ntncellconfig_tls_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -26,6 +27,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -238,6 +240,76 @@ func TestResolveRemoteControlTLS(t *testing.T) {
 		_, tok, err := r.resolveRemoteControlTLS(ctx, ns, rc)
 		if err == nil || tok != "" {
 			t.Fatal("a bootstrap-token Secret must never be usable as a remote-control credential")
+		}
+	})
+}
+
+// TestResolveRemoteControlTLS_TokenValidation covers the bearer-token guard: a Secret holds arbitrary
+// bytes, so a token with a control byte (most often a trailing newline from `kubectl create secret
+// --from-file`) or one near the 1 MiB Secret cap must be rejected at resolve time — taking the uniform
+// credential reason rather than misclassifying as a transient gNB failure at dial time — and the error
+// must never contain the token bytes.
+func TestResolveRemoteControlTLS_TokenValidation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	const ns = "ns1"
+	ctx := context.Background()
+	// A labelled Opaque Secret carrying only the token; ca.crt is omitted (system roots), which does
+	// not affect the token check.
+	newRWithToken := func(token []byte) *NTNCellConfigReconciler {
+		sec := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns,
+				Labels: map[string]string{remoteControlCredentialLabel: "true"}},
+			Data: map[string][]byte{"token": token},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(sec).Build()
+		return &NTNCellConfigReconciler{Client: c, APIReader: c}
+	}
+	rc := &ntnv1alpha1.RemoteControlRef{Endpoint: "h:1",
+		TLS: &ntnv1alpha1.RemoteControlTLS{Mode: "tls", SecretName: "s"}}
+
+	for _, tc := range []struct {
+		name  string
+		token []byte
+	}{
+		{"trailing newline", []byte("s3cr3t\n")},
+		{"embedded CRLF", []byte("s3\r\ncr3t")},
+		{"embedded NUL", []byte("s3\x00cr3t")},
+	} {
+		t.Run("token with "+tc.name+" → rejected without leaking it", func(t *testing.T) {
+			_, tok, err := newRWithToken(tc.token).resolveRemoteControlTLS(ctx, ns, rc)
+			if err == nil {
+				t.Fatal("a token that is not a valid HTTP header value must be rejected")
+			}
+			if tok != "" {
+				t.Fatalf("no token may be returned on rejection, got %q", tok)
+			}
+			if strings.Contains(err.Error(), string(tc.token)) || strings.Contains(err.Error(), "cr3t") {
+				t.Errorf("error must not leak the token bytes: %v", err)
+			}
+		})
+	}
+
+	t.Run("oversized token → rejected", func(t *testing.T) {
+		big := bytes.Repeat([]byte("a"), maxRemoteControlTokenBytes+1)
+		if _, tok, err := newRWithToken(big).resolveRemoteControlTLS(ctx, ns, rc); err == nil || tok != "" {
+			t.Fatalf("a token over %d bytes must be rejected, got tok=%q err=%v", maxRemoteControlTokenBytes, tok, err)
+		}
+	})
+
+	t.Run("valid token with base64/JWT special chars, exactly at the cap, passes", func(t *testing.T) {
+		// '.', '-', '_', '+', '/', '=' are valid header bytes, and the cap is exclusive (> cap rejects,
+		// == cap passes), so a token of exactly maxRemoteControlTokenBytes valid bytes stays.
+		valid := []byte("ab.cd-ef_gh+ij/kl=")
+		valid = append(valid, bytes.Repeat([]byte("x"), maxRemoteControlTokenBytes-len(valid))...)
+		_, tok, err := newRWithToken(valid).resolveRemoteControlTLS(ctx, ns, rc)
+		if err != nil || len(tok) != maxRemoteControlTokenBytes {
+			t.Fatalf("a valid token at the cap must pass, got len=%d err=%v", len(tok), err)
 		}
 	})
 }


### PR DESCRIPTION
## The bug (verified end-to-end)
A Kubernetes Secret holds arbitrary bytes. `resolveRemoteControlTLS` returned `string(secret.Data["token"])` verbatim, and the ws client sends it as `Authorization: Bearer <token>` (wsclient.go:331, only when non-empty). A token carrying a **CR/LF/NUL** — most commonly a **trailing newline** from `kubectl create secret --from-file` / `--from-literal` — makes Go's `http.Transport` reject the header *at dial time* (`net/http: invalid header field value`). That dial error is then classified as a transient gNB unreachability (`ProviderPushFailed`) and **tight-retried every minute**, with a status that misreports a network fault rather than a malformed credential, and it never takes the credential self-heal cadence.

## The fix
Validate the token in `resolveRemoteControlTLS` with **`httpguts.ValidHeaderFieldValue`** — the exact validator `net/http` itself uses, so there is zero drift between what we accept and what the transport will send — and bound it to **8 KiB** (keeps the header well under any header-size limit and far below the 1 MiB Secret cap).

## Why NOT a distinct `…CredentialInvalid` reason (deliberate divergence from the review)
On failure the function returns an error like every other credential-resolution failure, so the existing caller folds it into the **uniform `RemoteControlCredentialUnavailable`** reason + message + slow self-heal requeue. A *distinct* "invalid-token" reason would reintroduce the Secret existence/type **oracle** that #296 closed (it would let a principal who can write the CR but not read Secrets distinguish "Secret exists + labelled + malformed token" from "missing"). Folding into the uniform reason also **closes the accidental oracle that exists today** (malformed → `ProviderPushFailed`/1-min is already distinguishable from missing → 5-min). The error never contains the token bytes.

## Tests
`TestResolveRemoteControlTLS_TokenValidation`: trailing-newline / embedded-CRLF / embedded-NUL are rejected **without leaking the token**, an oversized token is rejected, and a valid base64/JWT-charset token *exactly at the cap* passes. **Mutation-verified**: neutering both guards makes all four fail (the oversized case flows the giant token through with `err=<nil>`). Extracted into its own function so `TestResolveRemoteControlTLS` stays under the gocyclo limit. `gofmt`/`go vet`/full controller+pkg suites/whole-repo `golangci-lint` all clean.