### PR TITLE
fix(provider): classify a lost create race, repair labels, widen the name hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Losing the ConfigMap create race is now classified instead of surfacing as a generic apply
+  failure.** `ApplyCellConfig` reads the ConfigMap with the uncached reader and creates it when the
+  read says NotFound. If anything else takes that name in between, the `Create` returned
+  `AlreadyExists`, which the reconciler reported as a plain `ApplyFailed` — a misleading condition
+  plus a Warning event that only self-corrected a requeue interval later. It now re-reads the object
+  that won the race and classifies it: ours to adopt and converge, or foreign and reported as
+  `ErrConfigMapNotOwned` → `OwnershipConflict`, which is what the situation actually is.
+
+- **The operator's management labels are repaired on a ConfigMap it owns.** The no-op guard compared
+  only `geo_ntn.yml` and the koffset annotation, and the update path never re-set the labels — so a
+  ConfigMap whose `app.kubernetes.io/managed-by` and `app.kubernetes.io/component` labels had been
+  stripped was reported successfully applied and never fixed. That matters beyond `kubectl get -l`:
+  those labels are how a ConfigMap is recognized as the operator's own once its owner reference is
+  gone, so a stripped label would quietly make a future pre-atomic-ref leftover unreclaimable. The
+  labels are now part of the compared desired state and are restored on write. The #204-G3 no-op is
+  preserved: a fully-correct ConfigMap is still not rewritten on the fan-out cadence.
+
 - **A legacy unowned ConfigMap is no longer leaked when the CR is deleted before its first
   reconcile.** #210 reclaims pre-atomic-reference artifacts — a ConfigMap carrying the operator's
   management labels and its `geo_ntn.yml` key but no owner reference, left behind when an older
@@ -512,6 +529,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#220 C4).
 
 ### Upgrade notes
+
+- **The ConfigMap name of an NTNCellConfig whose name exceeds ~243 characters changes.** The
+  disambiguating hash suffix appended to an over-long name widened from 32 bits (8 hex chars) to
+  128 bits (32 hex chars): a collision puts the losing CR into a permanent `OwnershipConflict`, and
+  a 32-bit truncated digest can be searched offline in seconds, so a principal able to create an
+  NTNCellConfig could aim a long name at another CR's ConfigMap. Names short enough to fit whole —
+  effectively all of them — are **unchanged**. For a CR long enough to be truncated, the operator
+  creates a ConfigMap under the new name on first reconcile after the upgrade; the old one keeps its
+  controller owner reference and is garbage-collected with the CR, but anything mounting it **by
+  name** (a gNB Pod spec) must be repointed. Check with
+  `kubectl get ntncellconfig -A -o name | awk 'length($0) > 250'` before upgrading.
 
 - **A satellite whose element set is stale beyond `maxEpochAge` now holds NTNSlice on terrestrial**
   instead of failing over to it — previously NTNSlice could steer traffic onto a satellite whose stale

--- a/pkg/provider/ocudu/provider.go
+++ b/pkg/provider/ocudu/provider.go
@@ -48,16 +48,23 @@ const configDataKey = "geo_ntn.yml"
 // maxK8sNameLen is the maximum length for a Kubernetes object name.
 const maxK8sNameLen = 253
 
+// configMapNameHashBytes is the width of the disambiguating hash suffix appended when a CR
+// name is too long to fit whole. 128 bits, not the 32 bits this used to take: a collision
+// puts the losing CR into a permanent OwnershipConflict, and a 32-bit truncated digest is
+// searchable offline in seconds, so a principal able to create an NTNCellConfig could aim a
+// long name at another CR's ConfigMap. 128 bits removes that as a construction problem.
+const configMapNameHashBytes = 16
+
 // ConfigMapNameFor returns the ConfigMap name for a given NTNCellConfig CR name.
-// If the resulting name exceeds K8s limits, it is truncated with a 8-char hash
-// suffix to prevent collisions between different long CR names.
+// If the resulting name exceeds K8s limits, it is truncated and disambiguated with a
+// hash suffix so different long CR names cannot land on the same ConfigMap.
 func ConfigMapNameFor(crName string) string {
 	name := ConfigMapPrefix + crName
 	if len(name) > maxK8sNameLen {
 		h := sha256.Sum256([]byte(name))
-		suffix := hex.EncodeToString(h[:4]) // 8 hex chars
-		// Truncate to leave room for "-" + 8-char hash
-		truncLen := maxK8sNameLen - 9 // 253 - 9 = 244
+		suffix := hex.EncodeToString(h[:configMapNameHashBytes])
+		// Leave room for "-" + the hex-encoded suffix.
+		truncLen := maxK8sNameLen - 1 - len(suffix)
 		name = strings.TrimRight(name[:truncLen], "-.") + "-" + suffix
 	}
 	return name
@@ -224,12 +231,23 @@ func (p *Provider) ApplyCellConfig(
 		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
 			return fmt.Errorf("setting controller reference: %w", err)
 		}
-		if err := p.client.Create(ctx, cm); err != nil {
+		err := p.client.Create(ctx, cm)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("creating ConfigMap: %w", err)
 		}
-		return nil
-	}
-	if err != nil {
+		// Lost the create race: something else made this name between our Get and our
+		// Create. The object exists now, so classify it — ours to update/adopt, or foreign
+		// (ErrConfigMapNotOwned, which the reconciler surfaces as OwnershipConflict).
+		// Returning the raw AlreadyExists instead would open a misleading ApplyFailed
+		// episode — Warning event included — that only self-corrects a requeue later.
+		cm = &corev1.ConfigMap{}
+		if err := p.reader().Get(ctx, key, cm); err != nil {
+			return fmt.Errorf("re-reading ConfigMap after losing the create race: %w", err)
+		}
+	} else if err != nil {
 		return fmt.Errorf("getting ConfigMap: %w", err)
 	}
 
@@ -252,13 +270,18 @@ func (p *Provider) ApplyCellConfig(
 	}
 	desiredData := string(yamlData)
 	desiredKoffset := strconv.Itoa(spec.NTN.CellSpecificKoffset)
-	// No-op when the stored ConfigMap already carries the desired content AND we already
+	// No-op when the stored ConfigMap already carries the desired state AND we already
 	// owned it: GenerateConfig is a deterministic function of the (static) CR spec, so a
 	// SatelliteEphemeris fan-out reconcile that changed nothing must not rewrite a
 	// byte-identical ConfigMap — an unconditional Update bumps resourceVersion and churns
 	// every watcher on the ~3-minute re-propagation cadence (#204-G3). A just-adopted CM
 	// (alreadyOwned == false) always writes, so the owner reference persists.
-	if alreadyOwned &&
+	//
+	// The management labels are part of that desired state, not just a create-time stamp:
+	// they are how a ConfigMap is recognized as ours once an owner reference is gone
+	// (isAdoptableLeftover), so a stripped label would quietly make a future leftover
+	// unreclaimable — and they are how an operator selects these objects with kubectl.
+	if alreadyOwned && isOperatorManaged(cm) &&
 		cm.Data[configDataKey] == desiredData &&
 		cm.Annotations["ntn.operators.dev/koffset"] == desiredKoffset {
 		return nil
@@ -267,6 +290,11 @@ func (p *Provider) ApplyCellConfig(
 		cm.Data = make(map[string]string)
 	}
 	cm.Data[configDataKey] = desiredData
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	cm.Labels[managedByLabel] = managedByValue
+	cm.Labels[componentLabel] = componentValue
 	if cm.Annotations == nil {
 		cm.Annotations = make(map[string]string)
 	}

--- a/pkg/provider/ocudu/provider_apply_race_test.go
+++ b/pkg/provider/ocudu/provider_apply_race_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ocudu
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/thc1006/ntn-operators/pkg/provider"
+)
+
+// raceProvider builds a Provider whose FIRST Get reports NotFound even though seeded already
+// exists — the exact window ApplyCellConfig races against: it reads (uncached) NotFound,
+// decides to Create, and something else wins the name in between. Every later Get is real, so
+// the recovery path sees the object that actually landed.
+func raceProvider(t *testing.T, seeded *corev1.ConfigMap) *Provider {
+	t.Helper()
+	firstGet := true
+	c := fake.NewClientBuilder().
+		WithScheme(ownerScheme(t)).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ntn-system"}}, seeded).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context, c client.WithWatch, key client.ObjectKey,
+				obj client.Object, opts ...client.GetOption,
+			) error {
+				if _, isCM := obj.(*corev1.ConfigMap); isCM && firstGet {
+					firstGet = false
+					return apierrors.NewNotFound(corev1.Resource("configmaps"), key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+	return NewProvider(c)
+}
+
+// Losing the create race must be CLASSIFIED, not surfaced as a raw AlreadyExists. A foreign
+// object that wins the name is an ownership conflict — the reconciler turns that into an
+// OwnershipConflict condition. Returning AlreadyExists instead opened a misleading ApplyFailed
+// episode (Warning event included) that only self-corrected a requeue interval later.
+func TestApplyCellConfig_CreateRace_ForeignWinner(t *testing.T) {
+	ctx := context.Background()
+	p := raceProvider(t, seedConfigMap(t, false, nil)) // unlabeled → not ours
+
+	err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), geoSpec(), ownerScheme(t))
+	if !errors.Is(err, provider.ErrConfigMapNotOwned) {
+		t.Fatalf("a foreign object winning the create race must be ErrConfigMapNotOwned, got %v", err)
+	}
+	if apierrors.IsAlreadyExists(err) {
+		t.Error("the raw AlreadyExists must not escape: it reads as a transient ApplyFailed, not an ownership conflict")
+	}
+
+	// And it must be left alone.
+	var cm corev1.ConfigMap
+	if err := p.client.Get(ctx, types.NamespacedName{
+		Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system",
+	}, &cm); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if cm.Data["geo_ntn.yml"] != "seed" {
+		t.Error("a foreign ConfigMap must not be overwritten after a lost create race")
+	}
+}
+
+// The other half: when the object that won the race IS ours (a pre-atomic-ref leftover), the
+// recovery path must adopt it and converge, with no error at all.
+func TestApplyCellConfig_CreateRace_AdoptableWinner(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerFor("cell-a")
+	p := raceProvider(t, seedConfigMap(t, true, nil)) // labeled + geo_ntn.yml, unowned
+
+	if err := p.ApplyCellConfig(ctx, owner, geoSpec(), ownerScheme(t)); err != nil {
+		t.Fatalf("losing the race to our own leftover must converge, got %v", err)
+	}
+	var cm corev1.ConfigMap
+	if err := p.client.Get(ctx, types.NamespacedName{
+		Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system",
+	}, &cm); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !metav1.IsControlledBy(&cm, owner) {
+		t.Error("the winner should have been adopted (controller ref set)")
+	}
+	if cm.Data["geo_ntn.yml"] == "seed" {
+		t.Error("an adopted ConfigMap must be rewritten with the generated config")
+	}
+}
+
+// The management labels are desired state, not a create-time stamp. They are how a ConfigMap
+// is recognized as ours once an owner reference is gone (isAdoptableLeftover), so a stripped
+// label silently makes a future leftover unreclaimable — and it breaks `kubectl get -l`.
+// The no-op guard compared only data + koffset, so a label-stripped ConfigMap whose content
+// already matched was reported applied and never repaired.
+func TestApplyCellConfig_RestoresStrippedManagementLabels(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider(t)
+	owner := ownerFor("cell-a")
+	spec := geoSpec()
+	key := types.NamespacedName{Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Someone strips the labels; data and koffset stay exactly as applied.
+	var cm corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &cm); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	delete(cm.Labels, managedByLabel)
+	delete(cm.Labels, componentLabel)
+	if err := p.client.Update(ctx, &cm); err != nil {
+		t.Fatalf("strip labels: %v", err)
+	}
+
+	if err := p.ApplyCellConfig(ctx, owner, spec, ownerScheme(t)); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	var got corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &got); err != nil {
+		t.Fatalf("get after re-apply: %v", err)
+	}
+	if !isOperatorManaged(&got) {
+		t.Fatalf("stripped management labels must be restored; got %v", got.Labels)
+	}
+}
+
+// Restoring labels must not cost the #204-G3 no-op: a fully-correct ConfigMap still must not
+// be rewritten on the ~3-minute fan-out cadence.
+func TestApplyCellConfig_LabelCheckKeepsTheNoOp(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider(t)
+	spec := geoSpec()
+	key := types.NamespacedName{Name: ConfigMapNameFor("cell-a"), Namespace: "ntn-system"}
+
+	if err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	var before corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &before); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if err := p.ApplyCellConfig(ctx, ownerFor("cell-a"), spec, ownerScheme(t)); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	var after corev1.ConfigMap
+	if err := p.client.Get(ctx, key, &after); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if before.ResourceVersion != after.ResourceVersion {
+		t.Fatalf("an identical re-apply must stay a no-op (#204-G3): resourceVersion %q -> %q",
+			before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+// A truncated name's disambiguating suffix must be wide enough that a collision cannot be
+// CONSTRUCTED. The loser of a collision sits in a permanent OwnershipConflict, and a 32-bit
+// truncated digest is searchable offline in seconds, so a principal able to create an
+// NTNCellConfig could aim a long name at another CR's ConfigMap.
+func TestConfigMapNameFor_SuffixIsWideEnoughToResistConstruction(t *testing.T) {
+	const minSuffixBits = 80 // the floor; the implementation uses 128
+	if got := configMapNameHashBytes * 8; got < minSuffixBits {
+		t.Fatalf("hash suffix is %d bits, want at least %d — a narrower digest is offline-searchable", got, minSuffixBits)
+	}
+
+	long := strings.Repeat("a", 250)
+	name := ConfigMapNameFor(long)
+	if len(name) > maxK8sNameLen {
+		t.Errorf("name length %d exceeds %d", len(name), maxK8sNameLen)
+	}
+	suffix := name[strings.LastIndex(name, "-")+1:]
+	if len(suffix) != configMapNameHashBytes*2 {
+		t.Errorf("suffix %q is %d hex chars, want %d", suffix, len(suffix), configMapNameHashBytes*2)
+	}
+
+	// Deterministic, and two long names that differ only past the truncation point must not
+	// collapse onto the same ConfigMap.
+	if ConfigMapNameFor(long) != name {
+		t.Error("ConfigMapNameFor must be deterministic")
+	}
+	other := strings.Repeat("a", 249) + "b"
+	if ConfigMapNameFor(other) == name {
+		t.Error("two distinct long CR names must not map to the same ConfigMap name")
+	}
+}


### PR DESCRIPTION
> **Replaces #304**, which was auto-closed rather than merged: it was stacked on `fix/finalizer-legacy-configmap-cleanup`, and when that branch merged as #301 and was deleted, GitHub marked #304 `CONFLICTING/DIRTY` and closed it. **None of its content reached `main`** — verified by grepping `main` for all three changes, which are absent. Same branch, now rebased onto `main` and re-targeted; the review below is unchanged.
>
> Re-verified against `main @ 393a613`: `go build`, `go vet`, and `./internal/controller/... ./pkg/...` → 8 packages ok, 0 failures.

---

> **Stacked on #301** (`fix/finalizer-legacy-configmap-cleanup`). All three findings sit in the `ApplyCellConfig` code that #301 restructures, so this branches off it rather than racing it. Review #301 first; the diff below is the delta.

Three findings from a review of the `ApplyCellConfig` path. All three verdicts below are mine, not the reviewer's — each was checked against the code before being accepted.

## 1. `NotFound` → `AlreadyExists` was misclassified — **adopted**

`ApplyCellConfig` reads with the uncached reader (`mgr.GetAPIReader()` is wired in `cmd/main.go`, so this is a genuine race and not a stale-cache artifact) and creates when the read says NotFound. If anything takes that name in between, `Create` returns `AlreadyExists`, which came back as a generic error → `ApplyFailed` condition **plus an episode-gated Warning event**, self-correcting only a requeue interval later.

Given how much this repo invests in episode-gated events (WO-20), a spurious episode is real noise, and the object is right there to be classified. It now re-reads the winner: ours → adopt and converge; foreign → `ErrConfigMapNotOwned` → `OwnershipConflict`, which is what the situation actually is.

## 2. Management labels were never repaired — **adopted**

The no-op guard compared only `geo_ntn.yml` and the koffset annotation, and — separately — the update path never re-set the labels either. So a ConfigMap the operator owns whose `app.kubernetes.io/managed-by` / `component` labels had been stripped was reported successfully applied and never repaired, on **both** paths.

This is more than cosmetic. Those labels are how a ConfigMap is recognized as the operator's own once its owner reference is gone (`isAdoptableLeftover`), so a stripped label quietly makes a future pre-atomic-ref leftover unreclaimable — the exact leak #301 exists to close. Labels join the compared desired state and are restored on write.

`TestApplyCellConfig_LabelCheckKeepsTheNoOp` pins that this does **not** cost the #204-G3 no-op: a fully-correct ConfigMap is still not rewritten on the ~3-minute fan-out cadence.

## 3. 32-bit hash suffix on truncated names — **adopted, with an upgrade note**

`ConfigMapNameFor` appended `sha256[:4]` — 32 bits — when `"ocudu-ntn-" + crName` exceeds 253 chars. A collision leaves the losing CR in a **permanent** `OwnershipConflict`, and a 32-bit truncated digest is searchable offline in seconds, so a principal able to create an NTNCellConfig could aim a long name at another CR's ConfigMap. Widened to 128 bits.

**This is the one change with a migration cost, so it is called out honestly.** It alters the ConfigMap name for any CR whose name exceeds ~243 characters. Such names are legal but vanishingly rare, and the trigger threshold is stated rather than glossed: names short enough to fit whole are unchanged. For an affected CR the operator creates a ConfigMap under the new name; the old one keeps its controller owner reference and is GC'd with the CR, but anything mounting it **by name** (a gNB Pod spec) must be repointed. The CHANGELOG upgrade note includes a pre-flight check:

```
kubectl get ntncellconfig -A -o name | awk 'length($0) > 250'
```

If you would rather not take a name change at all, say so and I will drop finding 3 — findings 1 and 2 are independent of it.

## Verification

- `go build`, `go vet`, `golangci-lint v2.12.2`: **0 issues**; `gofmt` clean.
- `go test ./internal/controller/... ./pkg/...` green (envtest 1.36.2).
- The create race is exercised with a `fake` client interceptor whose **first** `Get` returns NotFound while the object already exists — reproducing the exact window rather than asserting on a mock.
- **Mutation-verified independently**, each reverting only its own fix:
  - revert the `AlreadyExists` recovery → `must be ErrConfigMapNotOwned, got creating ConfigMap: ... already exists`
  - drop `isOperatorManaged` from the no-op guard → `stripped management labels must be restored; got map[]`, while the no-op test stays green, proving the guard still guards
  - narrow the suffix back to 4 bytes → `hash suffix is 32 bits, want at least 80`

