### PR TITLE
fix(ntncellconfig): gate plaintext remoteControl pushes with the endpoint allow-list too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The `remoteControl` endpoint allow-list now gates plaintext pushes too, not only credentialed ones.**
+  `--remote-control-allowed-endpoint-hosts` previously refused only a *credentialed* (`remoteControl.tls`)
+  push to a non-allowlisted host (closing bearer exfiltration); a *plaintext* `ws://` push escaped it, so
+  a principal who can write an `NTNCellConfig` but has narrower egress than the operator could aim one at
+  an internal host and use the operator as an **SSRF relay**. The check now runs for every push (still
+  before any Secret is read, so no "Secret is valid" oracle) and the flag/error/field-doc wording drops
+  the credential-only framing. An empty (default) allow-list still permits all, so only a deployment that
+  sets the flag *and* plaintext-pushes to an unlisted host is affected — the intended tightening. This is
+  the host-level app-layer complement the egress NetworkPolicy entry below points to (they act at
+  different layers), and is distinct from the `credentialRefPolicy` admission policy, which gates the
+  *credential reference* at admission rather than the *destination* at runtime. See ADR-0009 Amendment (2). #251
+
+- **A `remoteControl.tls` token that is not a valid HTTP header value is now rejected as a credential
+  error instead of tight-looping as a network failure.** A Secret holds arbitrary bytes, so a token
+  carrying a CR/LF/NUL — most often a trailing newline from `kubectl create secret
+  --from-file`/`--from-literal` — made `net/http` reject the `Authorization: Bearer` header at dial time;
+  that was misclassified as a transient gNB unreachability (`ProviderPushFailed`, 1-min retry) with a
+  status that misreported a network fault. The token is now validated with
+  `httpguts.ValidHeaderFieldValue` (net/http's own check) and bounded to 8 KiB; a bad one takes the
+  uniform `RemoteControlCredentialUnavailable` reason and slow self-heal like every other bad credential
+  — a *distinct* reason would have re-opened the oracle closed elsewhere in this section — and the token
+  is never logged. #322
+
 - **The kustomize base now ships an opt-in default-deny egress NetworkPolicy for the operator (#299).**
   The Helm chart already restricts operator egress via `networkPolicy.enable`, but the kustomize base
   (`config/network-policy/`) only had the metrics *ingress* rule, so a non-Helm deployment had no

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -167,13 +167,13 @@ func main() {
 			"CelesTrak access should leave this empty.")
 	var remoteControlAllowedHosts string
 	flag.StringVar(&remoteControlAllowedHosts, "remote-control-allowed-endpoint-hosts", "",
-		"Comma-separated list of hostnames a CREDENTIALED NTNCellConfig "+
-			"spec.provider.remoteControl (remoteControl.tls set) may push to. Empty (default) "+
-			"permits any endpoint (opt-in). When set, a credentialed push to a host not on the "+
-			"list is refused BEFORE the credential leaves the operator — an interim confused-deputy "+
-			"boundary (#251) so a principal who can write NTNCellConfig but not read the referenced "+
-			"Secret cannot aim a labelled credential at an arbitrary host. Plaintext pushes "+
-			"(no remoteControl.tls) are never gated.")
+		"Comma-separated list of hostnames any NTNCellConfig "+
+			"spec.provider.remoteControl may push to — credentialed (remoteControl.tls set) or "+
+			"plaintext alike. Empty (default) permits any endpoint (opt-in). When set, a push to a "+
+			"host not on the list is refused BEFORE the credential (if any) leaves the operator — an "+
+			"interim confused-deputy / SSRF boundary (#251) so a principal who can write NTNCellConfig "+
+			"but has narrower egress than the operator cannot aim a labelled credential at an arbitrary "+
+			"host, nor use the operator as a plaintext relay to an internal one.")
 	// Default to the Zap PRODUCTION config (JSON encoder, info level, sampling,
 	// error-level stacktraces) rather than the kubebuilder scaffold's Development
 	// default (console, warning stacktraces, no sampling), so a deployed operator

--- a/docs/adr/0009-remote-control-credential-confused-deputy.md
+++ b/docs/adr/0009-remote-control-credential-confused-deputy.md
@@ -1,6 +1,6 @@
 # ADR 0009 — Confused-deputy boundary for remoteControl.tls credential reads
 
-- Status: **Accepted**, **amended 2026-07-31** — see [Amendment](#amendment-2026-07-31--the-deferral-rationale-was-wrong). The interim endpoint allow-list stands; the deferral of the full per-CR authorization does **not**.
+- Status: **Accepted**, **amended 2026-07-31 (twice)** — see [Amendment (1)](#amendment-2026-07-31--the-deferral-rationale-was-wrong) and [Amendment (2)](#amendment-2026-07-31-2--the-endpoint-allow-list-now-gates-plaintext-destinations-too). The interim endpoint allow-list stands (and now gates plaintext destinations too); the deferral of the full per-CR authorization does **not**.
 - Date: 2026-07-31
 - Deciders: @thc1006
 - Relates to: #219 (label/type opt-in gate), #251 (this confused-deputy follow-up), the N-12 runtime TLS/bearer/mTLS push. Builds on the existing SSRF allow-list (`--prometheus-allowed-endpoint-hosts`, `--ephemeris-allowed-private-hosts`) and `pkg/netutil.EndpointAllowlist`.
@@ -45,7 +45,7 @@ Two-part, matching the actual (same-namespace, low-adoption) shape of the proble
 
 ## Testing
 
-`TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist` pins all four arms: a credentialed push to a non-allowlisted endpoint is refused (`RemoteControlConfigInvalid`, `errRemoteControlEndpointNotAllowed`) **and the provider is never called** (the credential does not leave the operator) — the refused case provisions **no** Secret, so getting the endpoint error (rather than credential-unavailable) proves the endpoint is checked before the Secret read (no oracle); an allowlisted credentialed push proceeds; an empty allow-list permits any endpoint (opt-in); and a plaintext push is never gated. Mutation-verified by neutering the `rc.TLS != nil` check (the attacker-endpoint case then pushes).
+`TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist` pins all five arms: a credentialed push to a non-allowlisted endpoint is refused (`RemoteControlConfigInvalid`, `errRemoteControlEndpointNotAllowed`) **and the provider is never called** (the credential does not leave the operator) — the refused case provisions **no** Secret, so getting the endpoint error (rather than credential-unavailable) proves the endpoint is checked before the Secret read (no oracle); an allowlisted credentialed push proceeds; an empty allow-list permits any endpoint (opt-in); a **plaintext** push to a non-allowlisted endpoint is **also refused** (no SSRF relay through the operator); and an allowlisted plaintext push proceeds. Mutation-verified by neutering the allow-list `Check` (both attacker-endpoint cases then push).
 
 ---
 
@@ -88,3 +88,13 @@ Checked end-to-end against a live Kubernetes **1.36.3** cluster using the artifa
 - **Objects already stored** are not re-validated; the policy applies on their next write.
 - **A privileged writer acting for someone else** — a GitOps controller or CI identity with broad rights — passes the check, because the authorized principal is whoever submits the object. This is inherent to authorization-at-admission and would be equally true of a webhook; where tenants submit through such a pipeline, the pipeline is the trust boundary.
 - The `patch`-without-`get` labelling vector from #219 is unchanged: this gates *who may reference* a labelled Secret, not who may label one.
+
+---
+
+## Amendment 2026-07-31 (2) — the endpoint allow-list now gates plaintext destinations too
+
+The original Decision scoped `--remote-control-allowed-endpoint-hosts` to *credentialed* pushes on a "nothing to exfiltrate" rationale, leaving plaintext `ws://` pushes ungated. That conflated two orthogonal axes. The endpoint allow-list constrains the **destination** — where the operator connects — which, as the Revised decision notes, is *orthogonal to who may reference the credential*. A missing credential does not make an arbitrary destination safe: a principal who can write an `NTNCellConfig` but has narrower egress than the operator can aim a **plaintext** push at an internal host and use the operator as an **SSRF relay**, no credential required.
+
+The allow-list now runs for **every** push (still before any Secret is read; still opt-in — an empty list permits all, so no existing deployment changes on upgrade). The error, flag help, and field doc drop the credential-only framing.
+
+**This does not contradict the `credentialRefPolicy` result in Amendment (1)** ("plaintext CR — created, correctly ungated"). That row is about **admission** of the *credential reference*: a plaintext CR has no `secretName`, so the credential-ref policy correctly does not block its creation. The endpoint allow-list acts later, at **runtime**, on the *destination*. The two are complementary and operate on different axes at different times — admission gates *who may reference a credential*; the allow-list gates *where any push may go*. Both compose with the opt-in egress NetworkPolicy (#317 / #299), which confines the operator at the network layer but is port-based by default and so does not confine *hosts* on its own; the app-layer allow-list adds host-level destination confinement for operators who set it.

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -66,10 +66,10 @@ type NTNCellConfigReconciler struct {
 	Recorder                events.EventRecorder
 	Providers               map[string]provider.NTNProvider
 	MaxConcurrentReconciles int
-	// RemoteControlAllowedHosts gates the endpoint a CREDENTIALED remoteControl.tls push may target
-	// (#251 confused-deputy containment). Empty = permit-all (opt-in), so existing deployments are
-	// unaffected; when set, a credentialed push to a host not on the list is refused before the
-	// credential is sent. Plaintext pushes are never gated. Interim boundary — see ADR-0009.
+	// RemoteControlAllowedHosts gates the endpoint ANY remoteControl push may target — credentialed
+	// (remoteControl.tls) or plaintext (#251 confused-deputy / SSRF containment). Empty = permit-all
+	// (opt-in), so existing deployments are unaffected; when set, a push to a host not on the list is
+	// refused before any credential is sent. Interim boundary — see ADR-0009.
 	RemoteControlAllowedHosts netutil.EndpointAllowlist
 }
 
@@ -828,21 +828,22 @@ func (r *NTNCellConfigReconciler) pushRuntimeEphemeris(
 			update.SatSwitch = spec.NTN.SatSwitchWithResync
 		}
 	}
-	// Confused-deputy containment (#251): when a credential is attached, the destination must be on the
-	// admin allow-list. Checked BEFORE the Secret is read, so a non-allowlisted endpoint is refused
-	// without touching the credential — no needless Secret read, and (unlike a post-resolve check) no
-	// "Secret is valid" oracle: the refusal is identical whether or not the Secret resolves. The endpoint
-	// is CR-author-controlled, so without this a principal who can write NTNCellConfig but not read the
-	// Secret could aim a labelled credential at an attacker host and exfiltrate it. Empty allow-list =
-	// opt-in (Check permits all); plaintext pushes (no rc.TLS) are never gated (nothing to exfiltrate).
-	// See ADR-0009. The synthetic https:// prefix lets EndpointAllowlist.Check parse the host:port
-	// endpoint (the CRD forbids a scheme in the field).
-	if rc := spec.Provider.RemoteControl; rc.TLS != nil {
-		if err := r.RemoteControlAllowedHosts.Check("https://" + rc.Endpoint); err != nil {
-			logf.FromContext(ctx).Error(err, "refusing to send a remoteControl.tls credential to an "+
-				"endpoint outside --remote-control-allowed-endpoint-hosts", "cell", cc.Name, "endpoint", rc.Endpoint)
-			return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlEndpointNotAllowed, errRemoteControlEndpointNotAllowed)
-		}
+	// Endpoint egress containment (#251, ADR-0009): the destination host must be on the admin
+	// allow-list. Checked BEFORE the Secret is read, so a non-allowlisted endpoint is refused without
+	// touching any credential — no needless Secret read, and (unlike a post-resolve check) no "Secret
+	// is valid" oracle: the refusal is identical whether or not a Secret resolves. This gates EVERY
+	// push — plaintext ws:// as well as credentialed wss:// — because the endpoint is CR-author-set:
+	// without it a principal who can write NTNCellConfig but has narrower egress than the operator
+	// could aim a credentialed push at an attacker host to exfiltrate a labelled credential, or a
+	// plaintext push at an internal host to use the operator as an SSRF relay. Empty allow-list =
+	// opt-in (Check permits all); it composes with, not replaces, the egress NetworkPolicy. The
+	// synthetic https:// prefix lets EndpointAllowlist.Check parse the host:port (the CRD forbids a
+	// scheme in the field).
+	endpoint := spec.Provider.RemoteControl.Endpoint
+	if err := r.RemoteControlAllowedHosts.Check("https://" + endpoint); err != nil {
+		logf.FromContext(ctx).Error(err, "refusing to push to an endpoint outside "+
+			"--remote-control-allowed-endpoint-hosts", "cell", cc.Name, "endpoint", endpoint)
+		return false, marker, newEphemerisPushError(ephemerisReasonRemoteControlEndpointNotAllowed, errRemoteControlEndpointNotAllowed)
 	}
 	// Resolve opt-in transport security (wss:// + shared secret / mTLS) from the
 	// referenced Secret; nil TLSConfig keeps the plaintext ws:// behavior (N-12).
@@ -915,11 +916,12 @@ const (
 // but not read Secrets probe Secret existence and type (an oracle).
 var errRemoteControlCredentialUnavailable = errors.New("referenced remote-control credential is unavailable or not authorized")
 
-// errRemoteControlEndpointNotAllowed tags a credentialed push whose endpoint is outside the operator's
-// --remote-control-allowed-endpoint-hosts allow-list (#251). Unlike the credential-unavailable message
-// this is NOT a Secret oracle — the endpoint is CR-author-set and already known to the writer — so it
-// names the endpoint. It is deterministic (config), so it self-heals on a spec/flag change, not a retry.
-var errRemoteControlEndpointNotAllowed = errors.New("remoteControl.tls endpoint is not in the operator's remote-control allow-list")
+// errRemoteControlEndpointNotAllowed tags a push whose endpoint is outside the operator's
+// --remote-control-allowed-endpoint-hosts allow-list (#251) — credentialed or plaintext alike. Unlike
+// the credential-unavailable message this is NOT a Secret oracle — the endpoint is CR-author-set and
+// already known to the writer — so it names the endpoint. It is deterministic (config), so it self-heals
+// on a spec/flag change, not a retry.
+var errRemoteControlEndpointNotAllowed = errors.New("remoteControl endpoint is not in the operator's remote-control allow-list")
 
 // maxRemoteControlTokenBytes bounds the bearer token so the "Authorization: Bearer <token>"
 // header stays well under any HTTP header-size limit and far below the 1 MiB Secret cap.

--- a/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
+++ b/internal/controller/ntncellconfig_rc_endpoint_allowlist_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/thc1006/ntn-operators/pkg/provider"
 )
 
-// TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist pins the #251 confused-deputy interim
-// boundary (ADR-0009): a CREDENTIALED remoteControl.tls push is refused BEFORE the credential is sent
-// when its endpoint host is outside --remote-control-allowed-endpoint-hosts. An empty allow-list permits
-// any endpoint (opt-in), and a plaintext push (no credential to exfiltrate) is never gated. Mutation:
-// drop the `tlsConfig != nil` allow-list check and the "attacker endpoint" case pushes (the mock is
-// called), failing the "must NOT be sent" assertion.
+// TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist pins the #251 / ADR-0009 endpoint
+// egress boundary: EVERY push — credentialed remoteControl.tls or plaintext — is refused BEFORE the
+// Secret is read when its endpoint host is outside --remote-control-allowed-endpoint-hosts (a
+// credentialed one would exfiltrate a labelled credential; a plaintext one would relay through the
+// operator to an internal host). An empty allow-list permits any endpoint (opt-in). Mutation: drop the
+// allow-list Check and the "attacker endpoint" cases push (the mock is called), failing the assertions.
 func TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
@@ -110,13 +110,23 @@ func TestPushEphemerisUpdateIfNeeded_RemoteControlEndpointAllowlist(t *testing.T
 		}
 	})
 
-	t.Run("plaintext push is never gated by the allow-list", func(t *testing.T) {
+	t.Run("plaintext push to a non-allowlisted endpoint is ALSO refused (SSRF relay)", func(t *testing.T) {
 		err, pushed := run(t, "gnb.allowed.svc", "attacker.evil.example:8001", false, false)
+		if err == nil || !errors.Is(err, errRemoteControlEndpointNotAllowed) {
+			t.Fatalf("a plaintext push to a non-allowlisted host must be refused, got %v", err)
+		}
+		if pushed {
+			t.Fatal("the operator must NOT relay a plaintext push to a non-allowlisted endpoint")
+		}
+	})
+
+	t.Run("plaintext push to an allowlisted endpoint proceeds", func(t *testing.T) {
+		err, pushed := run(t, "gnb.allowed.svc", "gnb.allowed.svc:8001", false, false)
 		if err != nil {
-			t.Fatalf("a plaintext push must not be gated, got %v", err)
+			t.Fatalf("an allowlisted plaintext push must proceed, got %v", err)
 		}
 		if !pushed {
-			t.Fatal("a plaintext push must proceed regardless of the allow-list")
+			t.Fatal("an allowlisted plaintext push must reach the provider")
 		}
 	})
 }


### PR DESCRIPTION
## What
`--remote-control-allowed-endpoint-hosts` gated only **credentialed** (`remoteControl.tls`) pushes, closing bearer exfiltration. A **plaintext** `ws://` push escaped it, so a principal who can write an `NTNCellConfig` but has narrower egress than the operator could aim one at an internal host and use the operator as an **SSRF relay**. The allow-list now runs for **every** push — still before any Secret read (no "Secret is valid" oracle), still opt-in (empty permits all).

## Why this fits the recently-landed layers (not redundant, not contradictory)
- **vs #317 (opt-in egress NetworkPolicy):** #317's own CHANGELOG entry names this allow-list as "the complementary control" for bounding where the operator dials. #317 is network-layer and **port-based by default** (does not confine *hosts*); this adds host-level destination confinement. They compose.
- **vs #309 (opt-in `credentialRefPolicy` admission policy):** #309's ADR amendment verified "plaintext CR — created, correctly ungated", but that is about **admission of the credential *reference*** (a plaintext CR has no `secretName`). This gate acts later, at **runtime**, on the **destination** — an orthogonal axis, as the ADR itself states. ADR-0009 gets a second amendment spelling this out.

## Scope
Generalizes the flag help / error / reason+field doc to drop the credential-only framing; adds a "plaintext to non-allowlisted is refused" arm and an "allowlisted plaintext proceeds" arm (5 arms total). **Mutation-verified**: neutering the `Check` makes both attacker arms push. Non-breaking — only a deployment that sets the flag *and* plaintext-pushes to an unlisted host is affected. Also backfills the CHANGELOG entry for #322 (token validation), which merged without one.

Rebased onto current main (incl. #323). `gofmt`/full controller+pkg suites/whole-repo `golangci-lint` clean.