### PR TITLE
ci(test-chart): close false-green gaps + hardening

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -55,25 +55,48 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN: this job only reads the repo (checkout, build, Kind, Helm).
+permissions:
+  contents: read
+
 jobs:
   test-chart:
     name: Helm lint + deploy
     runs-on: ubuntu-24.04
+    # Cap a hung Kind/Docker/Helm/API-poll so the job fails fast rather than drifting to GitHub's 6h ceiling.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs PR-modifiable Makefile/scripts/Go tests; do not leave the checkout token on disk.
+          persist-credentials: false
 
-      # Fail fast (before the heavy Go/Kind setup) if the OLM bundle CRDs
-      # have drifted from config/crd/bases/. Mirrors nephio-verify-sync;
-      # catches the gap that shipped a stale bundle CRD before #147.
-      - name: Verify OLM bundle CRDs are in sync (drift check)
-        run: make bundle-verify-sync
-
+      # Set Go up FIRST so every `make` below uses the pinned toolchain from go.mod. Otherwise the
+      # Makefile's parse-time `$(shell go env ...)` runs against the runner's system Go and can trigger a
+      # toolchain download before setup-go warms its cache.
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+
+      # Fail fast (before the heavy Kind setup) if the OLM bundle CRDs have drifted from
+      # config/crd/bases/. Mirrors nephio-verify-sync; catches the stale-bundle-CRD gap from before #147.
+      - name: Verify OLM bundle CRDs are in sync (drift check)
+        run: make bundle-verify-sync
+
+      # BIDIRECTIONAL generated-artifact verification: regenerate everything, then fail if the tree is
+      # dirty. bundle-verify-sync above only checks source->bundle; this also catches a bundle CRD with no
+      # source (stale/renamed), a source CRD with no chart template (sync-chart-crds.sh is now fail-closed),
+      # and any stale api/DeepCopy or chart CRD — `make bundle` removes stale bundle CRDs so `git diff`
+      # sees the removal. Verified locally that the generators leave a clean tree.
+      - name: Verify generated artifacts are committed (no drift)
+        run: |
+          set -euo pipefail
+          make manifests generate bundle
+          git diff --exit-code -- api config/crd bundle/manifests dist/chart/templates/crd \
+            || { echo "FAIL: generated artifacts are stale — run 'make manifests generate bundle' and commit"; exit 1; }
 
       - name: Install Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
@@ -86,21 +109,22 @@ jobs:
       # Build the manager on the host so the compile reuses setup-go's persistent build cache
       # (~/.cache/go-build, keyed on go.sum and shared across jobs) — a warm cache turns the ~60s
       # in-container recompile into a few seconds. Go 1.20+ ships no precompiled stdlib, so an
-      # in-container build (make docker-build) has a cold cache every run; the Dockerfile path is still
-      # exercised by the E2E job. CGO_ENABLED=0 keeps it static (runs in distroless); the arch is left
-      # native (= runner = Kind node); ./cmd/ is the package ko ships at release → a functionally
-      # identical binary.
+      # in-container build (make docker-build) has a cold cache every run. CGO_ENABLED=0 keeps it static
+      # (runs in distroless); the arch is left native (= runner = Kind node); ./cmd/ is the exact package
+      # ko ships at release, so this is a functionally identical binary in the same distroless base.
       - name: Build manager binary (host Go cache)
         run: |
           mkdir -p /tmp/img
           CGO_ENABLED=0 GOOS=linux go build -o /tmp/img/manager ./cmd/
 
-      # Package the static binary into the same distroless runtime the Dockerfile ships (keep in sync
-      # with Dockerfile's final stage). A /tmp context sidesteps .dockerignore, which excludes bin/.
+      # Package the static binary into the distroless runtime PRODUCTION actually ships. Production images
+      # are built by ko (release.yml; base = .ko.yaml defaultBaseImage), NOT by the repo Dockerfile, so this
+      # base is pinned to the SAME digest as .ko.yaml and Dockerfile — a bump moves all three together and
+      # the HA suite tests the runtime that ships. A /tmp context sidesteps .dockerignore, which excludes bin/.
       - name: Package + load image into Kind
         run: |
           cat > /tmp/img/Dockerfile <<'EOF'
-          FROM gcr.io/distroless/static:nonroot
+          FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
           WORKDIR /
           COPY manager /manager
           USER 65532:65532
@@ -112,14 +136,26 @@ jobs:
       - name: Install Helm
         run: make install-helm
 
-      - name: Lint Helm Chart
-        run: ./bin/helm lint ./dist/chart
+      - name: Lint Helm Chart (declared minimum + a current Kubernetes)
+        run: |
+          set -euo pipefail
+          # Lint against the chart's declared MINIMUM (Chart.yaml kubeVersion ">=1.31.0-0"): the Kind node
+          # uses a much newer default, so a template using an API/field newer than 1.31 would ship green.
+          ./bin/helm lint ./dist/chart --kube-version 1.31.0
+          ./bin/helm lint ./dist/chart --kube-version 1.34.0
 
       - name: Verify chart HA invariants (PDB replicas gate + shutdown grace)
         run: |
           set -euo pipefail
           H=./bin/helm
-          count() { $H template t ./dist/chart --set manager.replicas="$1" --set podDisruptionBudget.enable=true | grep -c '^kind: PodDisruptionBudget' || true; }
+          # Render each replica variant once; a helm failure aborts (set -e) rather than being swallowed
+          # by `|| true`, and only grep's no-match (exit 1) is tolerated — so a broken render cannot read
+          # as "0 PDBs" and pass the replicas=1 assertion.
+          count() {
+            local rendered
+            rendered=$("$H" template t ./dist/chart --set manager.replicas="$1" --set podDisruptionBudget.enable=true) || return 1
+            grep -c '^kind: PodDisruptionBudget$' <<<"$rendered" || :
+          }
           [ "$(count 1)" = "0" ] || { echo "FAIL: replicas=1 must render 0 PDBs (a minAvailable:1 PDB over 1 replica deadlocks node drains)"; exit 1; }
           [ "$(count 2)" = "1" ] || { echo "FAIL: replicas=2 must render 1 PDB"; exit 1; }
           [ "$(count 3)" = "1" ] || { echo "FAIL: replicas=3 must render 1 PDB"; exit 1; }
@@ -147,16 +183,26 @@ jobs:
         run: |
           set -euo pipefail
           H=./bin/helm
-          off=$($H template t ./dist/chart | grep -c '^kind: ValidatingAdmissionPolicy' || true)
+          # Default render must contain NO policy. Render first so a helm failure aborts here, instead of
+          # being swallowed by `|| true` and misread as "0 policies = correctly off"; only grep's no-match
+          # (exit 1) is tolerated.
+          default_render=$("$H" template t ./dist/chart)
+          off=$(grep -c '^kind: ValidatingAdmissionPolicy' <<<"$default_render" || :)
           [ "$off" = "0" ] || { echo "FAIL: credentialRefPolicy must be opt-in; default render produced $off policies"; exit 1; }
-          on=$($H template t ./dist/chart --set credentialRefPolicy.enable=true \
+          on=$("$H" template t ./dist/chart --set credentialRefPolicy.enable=true \
                  -s templates/admission/credential-ref-policy.yaml)
-          echo "$on" | grep -q 'kind: ValidatingAdmissionPolicy$' || { echo "FAIL: policy not rendered when enabled"; exit 1; }
-          echo "$on" | grep -q 'kind: ValidatingAdmissionPolicyBinding$' || { echo "FAIL: binding not rendered when enabled"; exit 1; }
-          echo "$on" | grep -q "authorizer.group('').resource('secrets')" || { echo "FAIL: the authorizer check is missing — the policy would authorize nothing"; exit 1; }
-          echo "$on" | grep -q "check('get').allowed()" || { echo "FAIL: the authorizer check does not assert 'get' is allowed"; exit 1; }
-          echo "$on" | grep -q 'failurePolicy: Fail' || { echo "FAIL: failurePolicy must default to Fail"; exit 1; }
-          echo "credential-ref policy OK (off by default; authorizer check present when enabled)"
+          # (a) the live API server must ACCEPT the enabled policy (server-side dry-run) — this proves the CEL
+          # compiles and the schema/binding are valid on this Kubernetes, not merely that the text is present.
+          # The NetworkPolicy step already dry-runs; the admission policy IS the #251/ADR-0009 boundary and must too.
+          printf '%s\n' "$on" | kubectl apply --dry-run=server -f - -o name
+          # (b) semantic assertions on the CEL boundary — a render that dropped the authorizer check would look
+          # installed while authorizing nothing.
+          grep -q 'kind: ValidatingAdmissionPolicy$' <<<"$on" || { echo "FAIL: policy not rendered when enabled"; exit 1; }
+          grep -q 'kind: ValidatingAdmissionPolicyBinding$' <<<"$on" || { echo "FAIL: binding not rendered when enabled"; exit 1; }
+          grep -q "authorizer.group('').resource('secrets')" <<<"$on" || { echo "FAIL: the authorizer check is missing — the policy would authorize nothing"; exit 1; }
+          grep -q "check('get').allowed()" <<<"$on" || { echo "FAIL: the authorizer check does not assert 'get' is allowed"; exit 1; }
+          grep -q 'failurePolicy: Fail' <<<"$on" || { echo "FAIL: failurePolicy must default to Fail"; exit 1; }
+          echo "credential-ref policy OK (off by default; API-server-accepted + authorizer check present when enabled)"
 
       # #230 item 1: the active-passive HA topology the design relies on was never asserted structurally.
       # A drift that dropped the soft anti-affinity, changed the default replica count, misaligned the PDB
@@ -167,6 +213,9 @@ jobs:
       - name: Verify chart HA topology + self-test the checker (negative controls)
         run: |
           set -euo pipefail
+          # verify_ha_topology.py imports PyYAML. ubuntu runners ship it, but make the dependency explicit:
+          # use the preinstalled copy, else install a pinned one, rather than silently relying on the image.
+          python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'pyyaml==6.0.2'
           ./bin/helm template t ./dist/chart -n ntn-system --set podDisruptionBudget.enable=true > /tmp/ha_topology.yaml
           python3 hack/verify_ha_topology.py /tmp/ha_topology.yaml
           python3 hack/verify_ha_topology_selftest.py /tmp/ha_topology.yaml
@@ -179,8 +228,10 @@ jobs:
         run: |
           set -euo pipefail
           H=./bin/helm
-          # (a) default (enable=false) renders NO NetworkPolicy.
-          off=$($H template t ./dist/chart -n default | grep -c '^kind: NetworkPolicy' || true)
+          # (a) default (enable=false) renders NO NetworkPolicy. Render first so a helm failure aborts
+          # instead of being swallowed by `|| true` and misread as "0 NetworkPolicy = correctly off".
+          default_render=$("$H" template t ./dist/chart -n default)
+          off=$(grep -c '^kind: NetworkPolicy' <<<"$default_render" || :)
           [ "$off" = "0" ] || { echo "FAIL: networkPolicy.enable=false must render 0 NetworkPolicy, got $off"; exit 1; }
           # (b) enable=true renders the policy; the live API server normalizes it (server-side dry-run) to
           # JSON, then jq asserts the required rules SCOPED TO .spec.egress. Scoping to .spec.egress (not a
@@ -199,12 +250,19 @@ jobs:
           echo "$obj" | jq -e '
             .kind == "NetworkPolicy"
             and (.spec.policyTypes | index("Egress"))
-            and ([ .spec.egress[]? | select((.to // []) | length == 0) | .ports[]? | "\(.port)/\(.protocol // "TCP")" ] as $p
-                 | ($p | index("53/TCP")) and ($p | index("53/UDP"))
-                 and ($p | index("443/TCP")) and ($p | index("9090/TCP")) and ($p | index("8001/TCP")))
+            # The podSelector must actually select the manager pods: a typo (e.g. control-plane: typoo) is
+            # accepted by the API server yet the policy protects ZERO pods — a silent isolation bypass.
+            and (.spec.podSelector.matchLabels["control-plane"] == "controller-manager")
+            and (.spec.podSelector.matchLabels["app.kubernetes.io/name"] == "ntn-operators")
+            # EXACT set (not subset) of the "to"-less (all-destinations) egress ports. A subset check would
+            # let an added 22/2375/10250 through; the exact set also catches a dropped required port. A rule
+            # scoped to some ipBlock CIDR does NOT count — .to must be empty (broad) for apiserver/CelesTrak/
+            # Space-Track/Prometheus/gNB reachability.
+            and ([ .spec.egress[]? | select((.to // []) | length == 0) | .ports[]? | "\(.port)/\(.protocol // "TCP")" ] | unique
+                  == (["53/TCP","53/UDP","443/TCP","9090/TCP","8001/TCP"] | unique))
           ' >/dev/null \
-            || { echo "FAIL: .spec.egress must allow DNS 53 TCP+UDP, 443/TCP, 9090/TCP, 8001/TCP to ALL destinations (a 'to'-less rule)"; echo "$obj" | jq '.spec.egress'; exit 1; }
-          echo "NetworkPolicy egress assertion OK (server-normalized, 'to'-less .spec.egress: 53 TCP+UDP, 443/9090/8001 TCP)"
+            || { echo "FAIL: NetworkPolicy must select the manager (control-plane=controller-manager, app.kubernetes.io/name=ntn-operators) and its 'to'-less .spec.egress must be EXACTLY {53/TCP,53/UDP,443/TCP,9090/TCP,8001/TCP}"; echo "$obj" | jq '{podSelector: .spec.podSelector, egress: .spec.egress}'; exit 1; }
+          echo "NetworkPolicy assertion OK (server-normalized; manager selector + exact 'to'-less egress set 53 TCP+UDP, 443/9090/8001 TCP)"
 
       - name: Deploy manager via Helm
         # ha-ci-values.yaml adds the celestrak-mock host to --ephemeris-allowed-private-hosts so
@@ -253,14 +311,61 @@ jobs:
           if grep -Eq 'no tests to run|no test files' /tmp/ha_e2e.out; then
             echo "FALSE GREEN: go test -tags=e2e_ha ran no tests"; exit 1
           fi
-          # DERIVE the TestHA* set from the compiled binary so a NEW HA test or a rename is auto-covered (not
-          # just a hardcoded list), require at least the current four, then assert each actually PASSED. A
-          # build-tag typo makes the list empty -> caught by the floor.
+          # DERIVE the TestHA* set from the compiled binary so a NEW HA test or a rename is auto-covered, then
+          # assert each derived test actually PASSED (the trailing space stops a prefix like TestHAGraceful
+          # from matching TestHAGracefulFailover). A build-tag typo makes the list empty -> caught below.
           mapfile -t HATESTS < <(go test -tags=e2e_ha ./test/e2e/ -list '^TestHA' 2>/dev/null | grep '^TestHA' || true)
-          if [ "${#HATESTS[@]}" -lt 4 ]; then
-            echo "FALSE GREEN: expected >= 4 TestHA* tests, found ${#HATESTS[@]} (build-tag/rename regression?)"; exit 1
-          fi
           for tc in "${HATESTS[@]}"; do
             grep -Eq "^--- PASS: ${tc} " /tmp/ha_e2e.out || { echo "FALSE GREEN: ${tc} did not run+PASS"; exit 1; }
           done
-          echo "verified: all ${#HATESTS[@]} TestHA* ran and passed"
+          # The derived list only proves whatever CURRENTLY compiles passed; it cannot notice that a
+          # known-critical test was DELETED (a shorter list still passes). Pin the acceptance contract: these
+          # five MUST each run+PASS. Deleting/renaming/skipping one fails here instead of silently going green.
+          # (Also subsumes the old '>= 4' floor: five present-and-passing means at least five ran.)
+          REQUIRED_HATESTS=(
+            TestHAGracefulFailover
+            TestHAUngracefulFailover
+            TestHAPDBEviction
+            TestHACacheSyncRolloutGate
+            TestHAOutageContinuityAcrossFailover
+          )
+          for tc in "${REQUIRED_HATESTS[@]}"; do
+            grep -Eq "^--- PASS: ${tc} " /tmp/ha_e2e.out \
+              || { echo "FALSE GREEN: required acceptance test ${tc} did not run+PASS (deleted/renamed/skipped?)"; exit 1; }
+          done
+          echo "verified: all ${#HATESTS[@]} TestHA* ran and passed (incl. the ${#REQUIRED_HATESTS[@]} required acceptance tests)"
+
+      # On failure, dump cluster state so an HA failure (CrashLoop, probe, lease, PDB selector, rollout
+      # stall, image pull, RBAC denial, informer sync, mock nginx) is diagnosable from the run itself
+      # instead of needing a re-run. set +e so a failing collector never masks the real failure.
+      - name: Collect failure diagnostics
+        if: ${{ failure() }}
+        run: |
+          set +e
+          mkdir -p /tmp/diagnostics
+          kubectl get all,pdb,lease,networkpolicy,validatingadmissionpolicy,validatingadmissionpolicybinding \
+            -A -o wide > /tmp/diagnostics/resources.txt 2>&1
+          kubectl get events -A --sort-by=.lastTimestamp > /tmp/diagnostics/events.txt 2>&1
+          kubectl describe pods -n ntn-operators-system > /tmp/diagnostics/pods-describe.txt 2>&1
+          kubectl logs -n ntn-operators-system -l control-plane=controller-manager \
+            --all-containers --prefix --tail=-1 > /tmp/diagnostics/manager.log 2>&1
+          make helm-status > /tmp/diagnostics/helm-status.txt 2>&1
+          cp -f /tmp/ha_e2e.out /tmp/diagnostics/ 2>/dev/null
+          echo "===== manager.log (tail) ====="; tail -60 /tmp/diagnostics/manager.log
+          echo "===== events (tail) ====="; tail -40 /tmp/diagnostics/events.txt
+
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ha-failure-diagnostics
+          path: /tmp/diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Explicitly tear down the Kind cluster (name "kind" from `kind create cluster`) so a reused/self-hosted
+      # runner does not leak it and the post-run log stays clean. kind-action was install_only, so it manages
+      # no cluster of its own to delete.
+      - name: Delete Kind cluster
+        if: ${{ always() }}
+        run: kind delete cluster --name kind || true

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,3 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot
+# Base pinned by digest so `ko build` yields a reproducible runtime; keep in sync with the Dockerfile
+# FROM and test-chart.yml's HA heredoc — a digest bump moves all three together.
+defaultBaseImage: gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/hack/sync-chart-crds.sh
+++ b/hack/sync-chart-crds.sh
@@ -27,8 +27,10 @@ for src in "$SRC_DIR"/*.yaml; do
 	base=$(basename "$src" | sed -E 's/^ntn\.operators\.dev_(.+)\.yaml$/\1.ntn.operators.dev.yaml/')
 	dest="$DEST_DIR/$base"
 
-	# Only touch CRDs already present in the chart (don't introduce new ones here).
-	[ -f "$dest" ] || continue
+	# Fail closed: a source CRD with no chart template must NOT be silently skipped — that ships a chart
+	# Helm users cannot install the CRD from (the original `|| continue` hid exactly this). Add the
+	# template (an empty file is enough; this script fills it) before regenerating.
+	[ -f "$dest" ] || { echo "ERROR: no Helm chart template for CRD '$src' (expected '$dest'); create it before 'make manifests'" >&2; exit 1; }
 
 	awk '
 		BEGIN { wrapped = 0 }

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -1054,7 +1054,7 @@ func (e *haEnv) deployCelestrakMock(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "nginx",
-						Image: "nginx:1.27-alpine",
+						Image: "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
 						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80}},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name: "fixture", MountPath: "/usr/share/nginx/html/gp.json", SubPath: "gp.json", ReadOnly: true,


### PR DESCRIPTION
Adversarial review of the HA `test-chart.yml` workflow found several real **false-green** channels. Each fix was **mutation-verified locally** (a failing helm stub, a new CRD, a dirtied generated file, negative-control jq) against a real chart + a **live K8s 1.36.3** cluster.

### Round A — false-green gaps
- **`|| true` masked helm failures.** `off=$(helm … | grep -c … || true)` read a *broken* render as "0 = correctly off" for the credentialRefPolicy and NetworkPolicy default-off checks (and the PDB count). Now render first (helm failure aborts via `set -e`), tolerate only grep's no-match.
- **Generated-artifact drift.** `bundle-verify-sync` was source→bundle only, and `sync-chart-crds.sh` silently skipped a new CRD (`|| continue`). Made the sync **fail-closed** + added a bidirectional `make manifests generate bundle && git diff --exit-code` (catches stale/renamed/new CRDs). Verified the generators leave a clean tree.
- **HA acceptance drift.** Guard was `>= 4` while **five** `TestHA*` exist → deleting the fifth stayed green. Pinned the five as a required acceptance contract (each must run+PASS) atop the derived-list auto-coverage.
- **Admission policy was only string-grepped.** Added a **server-side dry-run** so the CEL compiles + schema/binding are accepted (verified on 1.36.3), matching the NetworkPolicy step.
- **NetworkPolicy could regress silently.** Added a **podSelector** assertion (a typo'd selector is API-accepted yet protects zero pods) + switched egress ports from subset to **exact set** (an added 22/2375/10250 now fails).

### Round B — hardening
`permissions: contents: read`, `persist-credentials: false`, 40m job timeout; on-failure diagnostics dump + SHA-pinned artifact; **digest-pin the distroless base** across `.ko.yaml` (the real production base via ko), `Dockerfile`, and the HA heredoc (and fixed the stale comment claiming E2E builds the Dockerfile — production is **ko**); digest-pin the HA mock nginx; `helm lint --kube-version 1.31.0`; explicit PyYAML dep; setup-go before the drift `make`; explicit Kind teardown.

### Deliberately NOT done
Narrowing `paths` (would block merges if this is a required check); the static/HA/nightly job split; a chart icon + `--strict` (icon is INFO, not escalated — a non-issue). The workflow's Kind/HA end-to-end only CI can run — that's this PR's own run.