### PR TITLE
docs(remote-control): deployable TLS-termination sample for the credentialed push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A deployable TLS-termination sample for the credentialed runtime push, and the guide that was
+  missing.** The operator can speak `wss://` with a bearer token and mutual TLS, but OCUDU's
+  `remote_control` server is plaintext and unauthenticated — so the feature only works behind a
+  proxy, and the repository shipped **no sample using `remoteControl` at all** and no proxy/sidecar
+  pattern anywhere in `config/`, `docs/` or `dist/`. Adds
+  `config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml`, a deployable nginx sidecar
+  (`config/samples/remote-control-tls/`) that terminates TLS in the gNB's own pod so the plaintext
+  port never leaves it, and `docs/remote-control-tls.md` covering the Secret key contract, the SAN
+  requirement, how to read the proxy's `101`/`400`/`401` as a diagnostic, and the credential-rotation
+  recovery behaviour. Verified end to end on Kubernetes 1.36.3 with the operator running in-cluster:
+  mTLS refused a dial without a client certificate, the bearer was genuinely transmitted and checked,
+  and a well-formed `ntn_config_update` carrying SGP4-propagated ECEF from a live CelesTrak fetch
+  reached the plaintext backend. The NetworkPolicy interaction is documented but explicitly flagged
+  as unverified — the dev cluster runs Flannel, which does not implement NetworkPolicy.
+
 - **`ntn_operators_config_apply_ready` — the config-apply half of #216, which shipped only the
   push half.** `ntn_operators_config_apply_errors_total` is incremented **only** by an
   `ApplyCellConfig` failure, so three other ways the apply can be broken incremented it **zero**

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - ntn_v1alpha1_groundstationlifecycle.yaml
 - ntn_v1alpha1_groundstationlifecycle_hsinchu.yaml
 - ntn_v1alpha1_ntncellconfig.yaml
+- ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml
 - ntn_v1alpha1_ntnslice.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml
+++ b/config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml
@@ -1,0 +1,49 @@
+# Runtime NTN push over wss:// with mTLS + a bearer token.
+#
+# OCUDU's remote_control server is PLAINTEXT and unauthenticated, so this only makes
+# sense with a TLS-terminating proxy in front of it. See
+# config/samples/remote-control-tls/ for a deployable sidecar and
+# docs/remote-control-tls.md for the whole picture.
+apiVersion: ntn.operators.dev/v1alpha1
+kind: NTNCellConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: ntn-operators
+    app.kubernetes.io/managed-by: kustomize
+  name: ntn-cell-remotecontrol-tls
+spec:
+  provider:
+    type: ocudu
+    # namespace is enforced to match metadata.namespace for security
+    remoteControl:
+      # The TLS front door, NOT OCUDU's plaintext port. The certificate's SAN must
+      # cover this host: the operator derives ServerName from it unless tls.serverName
+      # overrides. Keep this on the admin allow-list
+      # (--remote-control-allowed-endpoint-hosts) when you run one.
+      endpoint: "gnb-proxy.ntn-system.svc:8443"
+      tls:
+        # "tls"  — verify the server, send the bearer token.
+        # "mtls" — additionally present a client certificate.
+        mode: mtls
+        # Secret in THIS namespace. Its owner must opt it in with
+        #   ntn.operators.dev/remote-control-credential: "true"
+        # Keys: ca.crt (required whenever token is set), token, and for mode=mtls
+        # tls.crt + tls.key. See docs/remote-control-tls.md.
+        secretName: gnb-remote-control-cred
+  # Runtime push targets a cell by plmn+nci, so cellID is required with remoteControl.
+  cellID:
+    plmn: "00101"
+    nci: 6733824
+  # The propagated state vector actually pushed comes from this SatelliteEphemeris,
+  # not from spec.ntn.ephemerisECEF (that is the ConfigMap bootstrap value).
+  ephemerisRef: oneweb-constellation
+  ephemerisNoradID: 25544
+  ntn:
+    cellSpecificKoffset: 100
+    ephemerisECEF:
+      posX: 1000000
+      posY: 2000000
+      posZ: 3000000
+      velX: 0
+      velY: 0
+      velZ: 0

--- a/config/samples/remote-control-tls/gnb-with-tls-sidecar.yaml
+++ b/config/samples/remote-control-tls/gnb-with-tls-sidecar.yaml
@@ -1,0 +1,102 @@
+# A TLS-terminating sidecar in front of OCUDU's plaintext remote_control server.
+#
+# This is the deployment shape the credentialed runtime push assumes: OCUDU listens
+# PLAINTEXT and unauthenticated, so the wss:// + bearer + mTLS the operator speaks has
+# to be terminated by something. Putting that something in the SAME POD keeps the
+# plaintext port on the pod's loopback, where nothing else in the cluster can reach it.
+#
+# Verified end to end on Kubernetes 1.36.3: the operator dialled wss://, nginx enforced
+# the client certificate and the bearer, and a real ntn_config_update frame arrived at
+# the plaintext backend. See docs/remote-control-tls.md.
+#
+# Substitute your OCUDU gNB image and its remote_control port for the `gnb` container.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gnb-proxy-conf
+  labels:
+    app.kubernetes.io/name: ntn-operators
+data:
+  nginx.conf: |
+    events {}
+    http {
+      # Only forward the Upgrade header when the client actually asked for one.
+      map $http_upgrade $conn { default upgrade; '' close; }
+      server {
+        listen 8443 ssl;
+        ssl_certificate     /certs/tls.crt;
+        ssl_certificate_key /certs/tls.key;
+        # mTLS: require a client certificate issued by the same CA the operator trusts.
+        # Drop these two lines (and use tls.mode "tls") if you only want a bearer token.
+        ssl_client_certificate /certs/ca.crt;
+        ssl_verify_client on;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        location / {
+          # Enforce the bearer rather than passing it through: without this the token
+          # is transmitted but never checked, which is not authentication.
+          # Read it from a file in production; inline here to keep the sample readable.
+          if ($http_authorization != "Bearer REPLACE_WITH_TOKEN") { return 401; }
+          proxy_pass http://127.0.0.1:8001;   # OCUDU remote_control, pod-local only
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection $conn;
+          proxy_set_header Host $host;
+          # The operator bounds the whole exchange at 5s; keep this comfortably above it.
+          proxy_read_timeout 60s;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gnb
+  labels:
+    app.kubernetes.io/name: ntn-operators
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: gnb }
+  template:
+    metadata:
+      labels: { app: gnb }
+    spec:
+      containers:
+        # Your OCUDU gNB. remote_control stays PLAINTEXT and is never exposed by a
+        # Service — only the sidecar below can reach it, over the pod's loopback.
+        - name: gnb
+          image: REPLACE_WITH_OCUDU_GNB_IMAGE
+          ports:
+            - containerPort: 8001
+              name: remote-ctl
+        - name: proxy
+          image: nginx:1.29-alpine
+          ports:
+            - containerPort: 8443
+              name: wss
+          volumeMounts:
+            - { name: conf,  mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf }
+            - { name: certs, mountPath: /certs, readOnly: true }
+      volumes:
+        - name: conf
+          configMap: { name: gnb-proxy-conf }
+        # Server certificate for the sidecar. Its SAN must cover the Service DNS name
+        # used in NTNCellConfig .spec.provider.remoteControl.endpoint.
+        - name: certs
+          secret: { secretName: gnb-proxy-tls }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnb-proxy
+  labels:
+    app.kubernetes.io/name: ntn-operators
+spec:
+  selector: { app: gnb }
+  # Only the TLS port is published. The plaintext remote_control port is deliberately
+  # absent: a Service on 8001 would hand every pod in the cluster an unauthenticated
+  # path straight to the gNB.
+  ports:
+    - name: wss
+      port: 8443
+      targetPort: 8443

--- a/docs/remote-control-tls.md
+++ b/docs/remote-control-tls.md
@@ -1,0 +1,127 @@
+# Securing the runtime NTN push (`remoteControl.tls`)
+
+OCUDU's `remote_control` WebSocket server is **plaintext and unauthenticated**. The
+operator's runtime push (`ntn_config_update`) can speak `wss://` with a bearer token and
+mutual TLS — but only if something in front of the gNB terminates that TLS. This page is
+the missing half: what to deploy, what the Secret must contain, and how to tell whether it
+is working.
+
+If you do not configure `remoteControl.tls`, the operator dials plain `ws://`. That is only
+safe when the endpoint is pod-local (a sidecar) or otherwise unreachable from the rest of
+the cluster.
+
+## Shape
+
+```
+NTNCellConfig.spec.provider.remoteControl.endpoint
+        │  wss://  + Authorization: Bearer  + client certificate
+        ▼
+   nginx sidecar :8443   ── terminates TLS, verifies the client cert, checks the bearer
+        │  ws://127.0.0.1:8001   (pod loopback — no Service, not routable)
+        ▼
+   OCUDU remote_control  ── plaintext, unauthenticated, as shipped
+```
+
+Keeping the proxy in the **same pod** is the point: the plaintext port never leaves the
+pod's network namespace, so there is no unauthenticated path to the gNB for anything else
+in the cluster to find.
+
+Deployable manifests: [`config/samples/remote-control-tls/gnb-with-tls-sidecar.yaml`](../config/samples/remote-control-tls/gnb-with-tls-sidecar.yaml).
+Matching CR: [`config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml`](../config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml).
+
+## The credential Secret
+
+Lives in the **NTNCellConfig's own namespace** and must be opted in by its owner:
+
+```bash
+kubectl -n <ns> create secret generic gnb-remote-control-cred \
+  --from-file=ca.crt=ca.crt \        # CA that signed the sidecar's server certificate
+  --from-file=tls.crt=client.crt \   # mode=mtls only
+  --from-file=tls.key=client.key \   # mode=mtls only
+  --from-literal=token='<bearer>'    # optional shared secret
+
+kubectl -n <ns> label secret gnb-remote-control-cred \
+  ntn.operators.dev/remote-control-credential=true
+```
+
+| Key | When | Notes |
+|---|---|---|
+| `ca.crt` | required whenever `token` is set | Pins the destination. Without it the token would be sent to whatever the **public** roots vouch for, and `endpoint` is caller-controlled. |
+| `token` | optional | Sent as `Authorization: Bearer`, only ever over TLS. |
+| `tls.crt` / `tls.key` | `mode: mtls` | Client certificate the sidecar verifies. |
+
+The label is an **opt-in by the Secret's owner**, not an authorization boundary: any
+NTNCellConfig in the namespace may reference any labelled Secret. See
+[ADR-0009](adr/0009-remote-control-credential-confused-deputy.md) for the boundary, the
+admin endpoint allow-list (`--remote-control-allowed-endpoint-hosts`) and the opt-in
+admission policy (`credentialRefPolicy.enable`).
+
+## Certificates
+
+The sidecar's server certificate SAN **must cover the endpoint host**. The operator derives
+`ServerName` from `endpoint` unless `tls.serverName` overrides it, so a certificate issued
+for the pod IP or a bare name will fail verification.
+
+```bash
+# SAN for a Service-addressed sidecar
+subjectAltName = DNS:gnb-proxy.<ns>.svc, DNS:gnb-proxy.<ns>.svc.cluster.local
+```
+
+Give the client certificate `extendedKeyUsage = clientAuth`, or nginx's
+`ssl_verify_client` will reject it.
+
+## Verifying it works
+
+```bash
+# 1. The push succeeded
+kubectl -n <ns> get ntncellconfig <name> \
+  -o jsonpath='{range .status.conditions[?(@.type=="EphemerisPushed")]}{.status} {.reason} {.message}{"\n"}{end}'
+# → True Pushed norad=… epoch=… digest=…
+
+# 2. The proxy saw a real upgrade, not a rejection
+kubectl -n <ns> logs deploy/gnb -c proxy | grep -oE '"GET / HTTP/1.1" [0-9]{3}'
+# → 101   upgrade accepted
+# → 400   no client certificate (mTLS rejected it)
+# → 401   bearer missing or wrong
+```
+
+A `401` here means the operator reached the proxy and was refused — the credential is
+wrong, not the route. A `400` means `mode` is not `mtls`, or the client certificate is
+missing/untrusted.
+
+## Recovery after rotating the credential
+
+The operator reads the Secret **uncached** on every real push, but it does **not watch
+Secrets**. Editing the Secret therefore triggers nothing by itself. A cell whose push is
+failing recovers on its own low-frequency poll; a cell that is *succeeding* picks up a
+rotated credential on its next real push, which the referenced SatelliteEphemeris drives on
+its ~3-minute propagation heartbeat.
+
+Measured on a live 1.36.3 cluster: with the bearer deliberately broken and then repaired,
+the cell recovered **166 s** after the Secret was fixed — the ephemeris heartbeat, not a
+per-cell retry. Issue #298 records why that bound is accepted rather than closed with a
+Secret watch.
+
+## Egress
+
+If you enable the operator's NetworkPolicy (`networkPolicy.enable`), put the **proxy's**
+port in `networkPolicy.gnbPorts` — not OCUDU's plaintext port, which the operator never
+dials in this shape. The default is `[8001]`, so a sidecar on `8443` is silently
+unreachable until you change it.
+
+> Not verified here: this repository's own dev cluster runs Flannel, which does not
+> implement NetworkPolicy, so policy objects are accepted and never enforced. Confirm the
+> rule on a cluster with a policy-capable CNI (Calico, Cilium, Antrea) before relying on it.
+
+## What has been verified
+
+End to end on Kubernetes 1.36.3, with the operator running in-cluster from this
+repository's image:
+
+- mTLS enforced — a dial without a client certificate is refused (`400`)
+- the bearer is genuinely transmitted and checked — without it, `401`
+- the handshake upgrades (`101`) and reaches the plaintext backend
+- a well-formed `ntn_config_update` arrives, carrying SGP4-propagated ECEF from a real
+  CelesTrak fetch (ISS: |r| ≈ 6.80e6 m, |v| ≈ 7.34 km/s)
+- the operator resumes pushing after a restart
+- breaking and repairing the bearer produces the recovery behaviour described above


### PR DESCRIPTION
Closes the completeness gap a review named: the credentialed runtime push is implemented and unit-tested, but **nothing in the repository shows how to deploy it**, and I confirmed that by searching rather than assuming — `config/samples/` had **zero** samples using `remoteControl`, and there was no proxy/sidecar pattern anywhere in `config/`, `docs/` or `dist/`.

That matters because OCUDU's `remote_control` server is **plaintext and unauthenticated**. `wss://` + bearer + mTLS only exists if an operator puts something in front of it — and we never said what.

## What this adds

- **`config/samples/ntn_v1alpha1_ntncellconfig_remotecontrol_tls.yaml`** — the CR, `mode: mtls`.
- **`config/samples/remote-control-tls/gnb-with-tls-sidecar.yaml`** — an nginx sidecar in the gNB's **own pod**, so the plaintext port stays on pod loopback with no Service. A Service on `8001` would hand every pod in the cluster an unauthenticated path straight to the gNB, which is why the sample publishes only the TLS port.
- **`docs/remote-control-tls.md`** — the Secret key contract, the SAN requirement (the operator derives `ServerName` from `endpoint`), how to read the proxy's `101`/`400`/`401` as a diagnostic, and rotation-recovery behaviour.

The sidecar **enforces** the bearer instead of passing it through. Transmitting a token nobody checks is not authentication, and a sample that did that would teach the wrong thing.

## Verified on a real cluster, not in a unit test

Kubernetes **1.36.3**, operator running **in-cluster** from this repository's image, real CelesTrak fetch:

| | |
|---|---|
| no client certificate | **400** — mTLS enforced |
| no bearer | **401** — bearer enforced |
| both | **101**, and the frame reaches the plaintext backend |

The frame that arrived at the plaintext gNB behind the proxy:

```json
{"cmd":"ntn_config_update","cells":[{"plmn":"00101","nci":6733824,
 "epoch_timestamp":1785465233385,"ntn_ul_sync_validity_duration":5,
 "ephemeris_info":{"ecef":{"position_x":3790772.7,"position_y":2490937.8,
 "position_z":-5065680.1,"velocity_vx":-1992.12,"velocity_vy":6818.52,"velocity_vz":1869.84}}}]}
```

Those are real numbers, not fixtures: |r| ≈ 6.80e6 m (≈430 km altitude) and |v| ≈ 7.34 km/s — the ISS's actual orbit, straight through CelesTrak → parse → SGP4 → push. The operator also resumed pushing after a restart.

## A measured number, written into the doc

Breaking the bearer in the Secret and repairing it: the cell recovered **166 s** after the fix. Not 60 s (transient requeue), not 300 s (slow poll) — the referenced SatelliteEphemeris's **~3-minute propagation heartbeat**. The cell performs no retry of its own; recovery is entirely coupled to another CR's heartbeat. That is the bound #298 records as accepted, now confirmed on hardware rather than argued from code.

## What I did NOT verify, and say so in the doc

**NetworkPolicy.** The doc explains that `networkPolicy.gnbPorts` must name the *proxy's* port (default `[8001]`, so a sidecar on `8443` is silently unreachable) — but it carries an explicit warning that this is unverified here. This dev cluster runs **Flannel, which does not implement NetworkPolicy**: I applied a deny-all egress policy to a probe pod and it still reached the proxy. Claiming the rule works would have been unfounded, so the doc tells readers to confirm it on a policy-capable CNI.

(My first diagnosis of that was wrong — I said "no CNI installed" after grepping only `kube-system` and running `ls /etc/cni/net.d/` without `sudo` on a root-only directory. Flannel was there all along; the real reason is that Flannel has no policy engine.)

## Checks

- Both samples pass a **server-side dry-run** against the real CRDs and their CEL rules; the whole `config/samples` kustomization still renders and validates.
- The sample nginx config passes `nginx -t` against `nginx:1.29-alpine` with real certificates mounted.
- Every relative link in the doc resolves to a file that exists.
- Docs and samples only — no Go, no CRD, no chart change.

Test namespaces, CRDs, Helm release and locally-built images were all removed from the cluster afterwards.
