### PR TITLE
ci(test-e2e): close false-greens + hardening + Dockerfile build perf

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -3,47 +3,36 @@ name: E2E Tests
 on:
   push:
     branches: [main]
-    paths:
+    # The E2E suite applies config/samples/*.yaml and builds the production Dockerfile in BeforeSuite,
+    # so those MUST trigger it. config/network-policy and config/prometheus were removed: they are
+    # commented out in config/default/kustomization.yaml, so `make deploy` never applies them — keeping
+    # them here was fake coverage (a change ran E2E but was not actually deployed/tested).
+    paths: &e2e_paths
       - 'internal/**'
       - 'pkg/**'
       - 'api/**'
       - 'cmd/**'
-      # config/** narrowed to subdirectories that actually affect
-      # controller behaviour. Skips config/samples/ (sample CRs) and
-      # config/grafana/ (dashboard JSON) which have zero impact on the
-      # reconciler — they used to trigger e2e on doc-only PRs and
-      # collide with CelesTrak network flake. If config/webhook/ or
-      # other controller-affecting subdirs land later, add them here.
       - 'config/crd/**'
       - 'config/default/**'
       - 'config/manager/**'
-      - 'config/network-policy/**'
-      - 'config/prometheus/**'
       - 'config/rbac/**'
+      - 'config/samples/**'
       - 'test/**'
       - 'hack/**'
+      - 'Dockerfile'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
+      # Kept broad on purpose: narrowing to test-e2e.yml would leave this check Pending (never triggered)
+      # on PRs that touch other workflow files, which blocks merge if it is a required status check.
       - '.github/workflows/**'
   pull_request:
-    paths:
-      - 'internal/**'
-      - 'pkg/**'
-      - 'api/**'
-      - 'cmd/**'
-      - 'config/crd/**'
-      - 'config/default/**'
-      - 'config/manager/**'
-      - 'config/network-policy/**'
-      - 'config/prometheus/**'
-      - 'config/rbac/**'
-      - 'test/**'
-      - 'hack/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
-      - '.github/workflows/**'
+    paths: *e2e_paths
+
+# Least-privilege GITHUB_TOKEN: this job only reads the repo.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,15 +42,41 @@ jobs:
   test-e2e:
     name: E2E on Kind
     runs-on: ubuntu-24.04
+    # Cap a hung Docker build / Kind / Ginkgo so the job fails fast rather than at GitHub's 6h ceiling.
+    timeout-minutes: 25
+    env:
+      KIND_CLUSTER: ntn-operators-test-e2e
+      # Guarantee BuildKit so the Dockerfile's `# syntax` directive + `--mount=type=cache` are honored
+      # (default on modern Docker, but make it explicit — without it the build fails on the cache mounts).
+      DOCKER_BUILDKIT: "1"
+      # cert-manager is NOT needed: webhooks and the cert-manager metrics-cert are commented out in
+      # config/default, and the metrics endpoint self-signs via controller-runtime. Skip the ~27s install.
+      CERT_MANAGER_INSTALL_SKIP: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs PR-modifiable Makefile/scripts/Go tests; do not leave the checkout token on disk.
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+
+      # `make test-e2e` runs `manifests generate fmt` first, so without this it would silently regenerate
+      # and reformat, then test the FIXED tree — a developer who forgot to commit DeepCopy/CRD/RBAC or ran
+      # unformatted code would still go green. Verify the committed tree here FIRST; the subsequent
+      # regenerate/format in `make test-e2e` is then a no-op and the suite tests exactly what is committed.
+      - name: Verify generated artifacts + formatting are committed
+        run: |
+          set -euo pipefail
+          make manifests generate
+          git diff --exit-code -- api config/crd config/rbac dist/chart/templates/crd \
+            || { echo "FAIL: generated artifacts are stale — run 'make manifests generate' and commit"; exit 1; }
+          unformatted=$(gofmt -l $(git ls-files '*.go'))
+          [ -z "$unformatted" ] || { printf 'FAIL: unformatted Go files:\n%s\n' "$unformatted"; exit 1; }
 
       - name: Install Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
@@ -70,3 +85,50 @@ jobs:
 
       - name: Run E2E tests
         run: make test-e2e
+
+      # Belt-and-suspenders vs a false green: `make test-e2e`'s -ginkgo.fail-on-pending / fail-on-empty
+      # catch pending or zero-spec runs, but a runtime Skip() would still pass go test. Assert the JSON
+      # report shows at least the current baseline of It specs and that EVERY one passed.
+      - name: Verify E2E specs actually ran and passed (no silent skips)
+        run: |
+          set -euo pipefail
+          report=/tmp/e2e-report.json
+          [ -f "$report" ] || { echo "FAIL: no Ginkgo JSON report at $report — the suite did not run"; exit 1; }
+          jq -e '
+            [ .[].SpecReports[]? | select(.LeafNodeType == "It") ] as $specs
+            | ($specs | length) >= 6 and ([ $specs[] | select(.State != "passed") ] | length) == 0
+          ' "$report" >/dev/null \
+            || { echo "FAIL: expected >= 6 It specs all passed (0 skipped/pending/failed):"; \
+                 jq '[ .[].SpecReports[]? | select(.LeafNodeType=="It") | .State ] | group_by(.) | map({(.[0]): length})' "$report"; \
+                 exit 1; }
+          echo "E2E spec guard OK: $(jq '[ .[].SpecReports[]? | select(.LeafNodeType=="It") ] | length' "$report") It specs, all passed"
+
+      # On failure, dump cluster state (the Ginkgo AfterEach diagnostics do not run for BeforeSuite/BeforeAll
+      # failures, pending/skipped specs, or after teardown) so a failure is diagnosable without a re-run.
+      - name: Collect failure diagnostics
+        if: ${{ failure() }}
+        run: |
+          set +e
+          mkdir -p /tmp/e2e-diagnostics
+          kubectl get all,cm,secret,lease,pdb,networkpolicy -A -o wide > /tmp/e2e-diagnostics/resources.txt 2>&1
+          kubectl get events -A --sort-by=.lastTimestamp > /tmp/e2e-diagnostics/events.txt 2>&1
+          kubectl describe pods -A > /tmp/e2e-diagnostics/pods.txt 2>&1
+          kubectl logs -n ntn-operators-system -l control-plane=controller-manager \
+            --all-containers --prefix --tail=-1 > /tmp/e2e-diagnostics/manager.log 2>&1
+          kind export logs /tmp/e2e-diagnostics/kind --name "$KIND_CLUSTER" 2>&1
+          echo "===== manager.log (tail) ====="; tail -60 /tmp/e2e-diagnostics/manager.log
+
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-failure-diagnostics
+          path: /tmp/e2e-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # `make test-e2e` tears the cluster down only on success (cleanup is a separate recipe line after the
+      # test); on a test failure or a cancel-in-progress it is skipped and the cluster leaks. Guarantee it.
+      - name: Ensure Kind cleanup
+        if: ${{ always() }}
+        run: kind delete cluster --name "$KIND_CLUSTER" 2>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
-# Build the manager binary
-FROM golang:1.26.5 AS builder
+# syntax=docker/dockerfile:1
+# Build the manager binary. Builder base pinned by digest for reproducibility.
+FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
+# Copy the Go Modules manifests first so a source-only change does not re-download deps.
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
-# Build
-# the GOARCH has no default value to allow the binary to be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+# Build. GOARCH is left empty by default so the binary matches the build host/platform. Dropped `go build
+# -a`: it force-rebuilds every package (including stdlib) on every build, defeating the Go build cache;
+# BuildKit cache mounts persist the module + build caches instead, and -trimpath keeps the output
+# reproducible. (Both improve build time WITHOUT bypassing the production Dockerfile — the E2E artifact.)
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 test-e2e: manifests generate fmt vet ## Run the e2e tests. Defaults to a Kind environment; set E2E_USE_EXISTING_CLUSTER=true (and MANAGER_IMAGE) to target an existing cluster instead.
 	@if [ -z "$$E2E_USE_EXISTING_CLUSTER" ]; then $(MAKE) setup-test-e2e; \
 	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind setup"; fi
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e -count=1 -timeout 15m ./test/e2e/ -v -ginkgo.v -ginkgo.fail-on-pending -ginkgo.fail-on-empty -ginkgo.json-report=/tmp/e2e-report.json
 	@if [ -z "$$E2E_USE_EXISTING_CLUSTER" ]; then $(MAKE) cleanup-test-e2e; \
 	else echo "E2E_USE_EXISTING_CLUSTER set — skipping Kind teardown"; fi
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -83,7 +83,8 @@ const celestrakMockHost = "celestrak-mock.default.svc.cluster.local"
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 // To run against a pre-existing cluster (e.g. kubeadm) with the manager
 // image already pushed to a registry the cluster can pull from, set:
-//   E2E_USE_EXISTING_CLUSTER=1 MANAGER_IMAGE=<your-registry>/ntn-operators:v0.0.1
+//
+//	E2E_USE_EXISTING_CLUSTER=1 MANAGER_IMAGE=<your-registry>/ntn-operators:v0.0.1
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting ntn-operators e2e test suite\n")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,7 +22,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -213,11 +212,6 @@ var _ = Describe("Manager", Ordered, func() {
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
 
-			By("getting the service account token")
-			token, err := serviceAccountToken()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token).NotTo(BeEmpty())
-
 			By("ensuring the controller pod is ready")
 			verifyControllerPodReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "pod", controllerPodName, "-n", namespace,
@@ -243,16 +237,16 @@ var _ = Describe("Manager", Ordered, func() {
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,
-				"--image=curlimages/curl:8.12.1",
+				"--image=curlimages/curl:8.12.1@sha256:94e9e444bcba979c2ea12e27ae39bee4cd10bc7041a472c4727a558e213744e6",
 				"--overrides",
 				fmt.Sprintf(`{
 					"spec": {
 						"containers": [{
 							"name": "curl",
-							"image": "curlimages/curl:8.12.1",
+							"image": "curlimages/curl:8.12.1@sha256:94e9e444bcba979c2ea12e27ae39bee4cd10bc7041a472c4727a558e213744e6",
 							"command": ["/bin/sh", "-c"],
 							"args": [
-								"for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
+								"TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token); for i in $(seq 1 30); do curl -v -k -H \"Authorization: Bearer ${TOKEN}\" https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
 							],
 							"securityContext": {
 								"readOnlyRootFilesystem": true,
@@ -269,7 +263,7 @@ var _ = Describe("Manager", Ordered, func() {
 						}],
 						"serviceAccountName": "%s"
 					}
-				}`, token, metricsServiceName, namespace, serviceAccountName))
+				}`, metricsServiceName, namespace, serviceAccountName))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
 
@@ -557,58 +551,9 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 })
 
-// serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
-	const tokenRequestRawString = `{
-		"apiVersion": "authentication.k8s.io/v1",
-		"kind": "TokenRequest"
-	}`
-
-	// Temporary file to store the token request
-	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
-	tokenRequestFile := filepath.Join("/tmp", secretName)
-	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
-	if err != nil {
-		return "", err
-	}
-
-	var out string
-	verifyTokenCreation := func(g Gomega) {
-		// Execute kubectl command to create the token
-		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
-			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
-			namespace,
-			serviceAccountName,
-		), "-f", tokenRequestFile)
-
-		output, err := cmd.CombinedOutput()
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// Parse the JSON output to extract the token
-		var token tokenRequest
-		err = json.Unmarshal(output, &token)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		out = token.Status.Token
-	}
-	Eventually(verifyTokenCreation).Should(Succeed())
-
-	return out, err
-}
-
 // getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
 func getMetricsOutput() (string, error) {
 	By("getting the curl-metrics logs")
 	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 	return utils.Run(cmd)
-}
-
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
-type tokenRequest struct {
-	Status struct {
-		Token string `json:"token"`
-	} `json:"status"`
 }


### PR DESCRIPTION
Adversarial review of the E2E workflow — verified against real files, a real chart + **K8s 1.36.3** cluster, and a real Docker build; each new guard was mutation-checked to actually fire.

### P0 false-greens
- **Samples + Dockerfile were untested triggers.** The suite applies `config/samples/*.yaml` (`e2e_test.go:307-342`) and builds the production `Dockerfile` in BeforeSuite, but none of `config/samples/**`, `Dockerfile`, `.dockerignore` were in `paths` → a broken sample/Dockerfile never ran E2E. Added them. Removed `config/network-policy/**` + `config/prometheus/**` (commented out in `config/default` → never deployed → fake coverage; no e2e test references them).
- **CI auto-fixed the tree before testing** (`make test-e2e: manifests generate fmt vet`). Added a pre-step that regenerates + `git diff --exit-code`s api/config/crd/config/rbac/chart CRDs and asserts `gofmt`-clean (which surfaced a tag-gated `e2e_suite_test.go` that `go fmt ./...` skips — fixed).
- **Ginkgo could pass with zero/pending/skipped specs.** Added `-count=1 -ginkgo.fail-on-pending -ginkgo.fail-on-empty -ginkgo.json-report` + a report guard asserting **≥6 It specs all passed** (mutation-verified: a skip → FAIL).
- **Kind leaked on failure/cancel** (teardown is a separate recipe line after `go test`). Added `if: always()` teardown + on-failure diagnostics (incl. `kind export logs`) as a SHA-pinned artifact.

### Hardening
`permissions: contents: read`; `persist-credentials: false`; 25m timeout; `CERT_MANAGER_INSTALL_SKIP=true` (~27s, cert-manager is unused). **Token hygiene:** the metrics test embedded the SA Bearer token in a `kubectl run --overrides` command that `utils.Run` logs; the curl pod already runs as the metrics-reader-bound SA, so it now reads its **projected in-pod token** — the token never reaches the command line. Pinned the curl mock by digest.

### Dockerfile build perf (production image = the E2E artifact; not bypassed)
Dropped `go build -a`, added BuildKit `--mount=type=cache` for module + build caches, `-trimpath`, pinned the golang builder by digest; `DOCKER_BUILDKIT=1`. Verified the image still builds + the manager runs.

### Deliberately NOT done
Cross-run `type=gha` Docker cache (buildx + runtime-token plumbing, unvalidatable locally, risks breaking the build — the `-a` removal is the main win); narrowing `.github/workflows/**` (would block merge if this is a required check — the adversarial review caught me nearly doing this); Kind node-image pin; existing-cluster destructive guard (not the Kind CI path). The Kind/HA E2E only CI can run — that's this PR's own run.