### PR TITLE
docs(adr): ADR-0011 — owner-issued grant for remoteControl.tls credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADR-0010 — an owner-issued grant for `remoteControl.tls` credentials (Proposed).** Records the
+  design for a `RemoteControlCredentialGrant` CRD created by the Secret's owner, naming which
+  NTNCellConfig may use the credential, against which endpoint, in which auth mode. It exists because
+  three gaps on `main` share one shape — the Secret's owner cannot express, revocably, what their
+  credential is for: #309's admission policy is evaluated only at write time so withdrawing RBAC does
+  not re-evaluate existing CRs; #300's endpoint allow-list is admin-global, so any labelled Secret can
+  be paired with any allow-listed endpoint; and Secrets are `get`-only by design, so a withdrawal of
+  consent is invisible until the next real push. The ADR **partly supersedes ADR-0009**, whose
+  recommendation to prefer a SubjectAccessReview over a grant CRD does not survive the revocability
+  and endpoint-binding requirements — a SAR is a point-in-time check on a write and cannot express a
+  destination. #309 is explicitly kept as the cheap default tier; the grant is opt-in behind
+  `--require-credential-grant`. The ADR is candid that it does **not** close #298: rotating a Secret's
+  *contents* fires no watch, so that path keeps the ~3-minute bound.
+
 - **A deployable TLS-termination sample for the credentialed runtime push, and the guide that was
   missing.** The operator can speak `wss://` with a bearer token and mutual TLS, but OCUDU's
   `remote_control` server is plaintext and unauthenticated — so the feature only works behind a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **ADR-0010 — an owner-issued grant for `remoteControl.tls` credentials (Proposed).** Records the
+- **ADR-0011 — an owner-issued grant for `remoteControl.tls` credentials (Proposed).** Records the
   design for a `RemoteControlCredentialGrant` CRD created by the Secret's owner, naming which
   NTNCellConfig may use the credential, against which endpoint, in which auth mode. It exists because
   three gaps on `main` share one shape — the Secret's owner cannot express, revocably, what their

--- a/docs/adr/0009-remote-control-credential-confused-deputy.md
+++ b/docs/adr/0009-remote-control-credential-confused-deputy.md
@@ -3,7 +3,7 @@
 - Status: **Accepted**, **amended 2026-07-31 (twice)** — see [Amendment (1)](#amendment-2026-07-31--the-deferral-rationale-was-wrong) and [Amendment (2)](#amendment-2026-07-31-2--the-endpoint-allow-list-now-gates-plaintext-destinations-too). The interim endpoint allow-list stands (and now gates plaintext destinations too); the deferral of the full per-CR authorization does **not**.
 - Date: 2026-07-31
 - Deciders: @thc1006
-- ⚠ **Partly superseded by [ADR-0010](0010-remote-control-credential-grant.md)**: the *Rationale* bullet preferring a SubjectAccessReview at admission **over** a ReferenceGrant-style CRD no longer holds once revocability and endpoint binding are required — a SAR is a point-in-time check on a write and cannot express a destination. The interim endpoint allow-list and the shipped admission policy (#309) both stand; ADR-0010 adds an owner-issued grant as the opt-in stronger tier.
+- ⚠ **Partly superseded by [ADR-0011](0011-remote-control-credential-grant.md)**: the *Rationale* bullet preferring a SubjectAccessReview at admission **over** a ReferenceGrant-style CRD no longer holds once revocability and endpoint binding are required — a SAR is a point-in-time check on a write and cannot express a destination. The interim endpoint allow-list and the shipped admission policy (#309) both stand; ADR-0011 adds an owner-issued grant as the opt-in stronger tier.
 - Relates to: #219 (label/type opt-in gate), #251 (this confused-deputy follow-up), the N-12 runtime TLS/bearer/mTLS push. Builds on the existing SSRF allow-list (`--prometheus-allowed-endpoint-hosts`, `--ephemeris-allowed-private-hosts`) and `pkg/netutil.EndpointAllowlist`.
 
 ## Context
@@ -18,6 +18,18 @@ This is a **confused deputy**: the operator lends its Secret-read privilege on b
 The #219 mitigation — the Secret owner must label it `ntn.operators.dev/remote-control-credential: true`, and API-credential Secret types are refused — reduces *which* Secrets can be targeted but is **not an authorization boundary**: the label is namespace-scoped, so **any** NTNCellConfig in the namespace may use **any** labelled Secret, and it does not bind the *endpoint*. The code comment on `RemoteControlTLS.secretName` already states this; #251 tracks the real fix.
 
 ## Decision
+
+**Net current state (2026-07-31)** — read this first; the original two-part decision and the two amendments below are the history that produced it. Three tiers, weakest-to-strongest, all composing:
+
+1. **Admin endpoint allow-list** (`--remote-control-allowed-endpoint-hosts`) — shipped; gates the *destination* of **every** push (credentialed and plaintext, per Amendment 2), before any Secret is read; opt-in (empty = permit-all).
+2. **Credential-reference admission policy** (#309 VAP, `credentialRefPolicy.enable`, default off) — the cheap default authorization tier: the principal referencing a Secret must be able to `get` it, checked at admission through the VAP `authorizer` library, **no webhook** — which retires this ADR's original "a SAR needs webhook infrastructure we lack" reasoning.
+3. **Owner-issued grant** ([ADR-0011](0011-remote-control-credential-grant.md), opt-in behind `--require-credential-grant`) — the strong tier the original decision deferred: revocable, binding a credential to a specific (CR, endpoint, mode). The per-CR authorization model now lives there.
+
+**Superseded** by the above: the original bullet 2's preference for *SubjectAccessReview-at-admission over a grant CRD*, and its framing of full per-CR authorization as merely "deferred." A SAR is a point-in-time write check that cannot express revocation or a destination; ADR-0011 supplies both. The threat model, the same-namespace framing, and tier 1 all still stand.
+
+---
+
+### Original two-part decision (2026-07-31 — superseded in part; see Net current state)
 
 Two-part, matching the actual (same-namespace, low-adoption) shape of the problem:
 

--- a/docs/adr/0009-remote-control-credential-confused-deputy.md
+++ b/docs/adr/0009-remote-control-credential-confused-deputy.md
@@ -3,6 +3,7 @@
 - Status: **Accepted**, **amended 2026-07-31 (twice)** — see [Amendment (1)](#amendment-2026-07-31--the-deferral-rationale-was-wrong) and [Amendment (2)](#amendment-2026-07-31-2--the-endpoint-allow-list-now-gates-plaintext-destinations-too). The interim endpoint allow-list stands (and now gates plaintext destinations too); the deferral of the full per-CR authorization does **not**.
 - Date: 2026-07-31
 - Deciders: @thc1006
+- ⚠ **Partly superseded by [ADR-0010](0010-remote-control-credential-grant.md)**: the *Rationale* bullet preferring a SubjectAccessReview at admission **over** a ReferenceGrant-style CRD no longer holds once revocability and endpoint binding are required — a SAR is a point-in-time check on a write and cannot express a destination. The interim endpoint allow-list and the shipped admission policy (#309) both stand; ADR-0010 adds an owner-issued grant as the opt-in stronger tier.
 - Relates to: #219 (label/type opt-in gate), #251 (this confused-deputy follow-up), the N-12 runtime TLS/bearer/mTLS push. Builds on the existing SSRF allow-list (`--prometheus-allowed-endpoint-hosts`, `--ephemeris-allowed-private-hosts`) and `pkg/netutil.EndpointAllowlist`.
 
 ## Context

--- a/docs/adr/0010-remote-control-credential-grant.md
+++ b/docs/adr/0010-remote-control-credential-grant.md
@@ -1,0 +1,205 @@
+# ADR 0010 — An owner-issued grant for `remoteControl.tls` credentials
+
+- Status: **Proposed**
+- Date: 2026-07-31
+- Deciders: @thc1006
+- Supersedes: the **"prefer SubjectAccessReview at admission over a ReferenceGrant-style CRD"** recommendation in [ADR-0009](0009-remote-control-credential-confused-deputy.md) — see *Relationship to ADR-0009*. The interim endpoint allow-list and the shipped admission policy both stand.
+- Relates to: #219 (label/type opt-in), #251 (confused deputy), #298 (rotation is bounded by the ~3m epoch cadence), #300 (admin endpoint allow-list), #309 (opt-in `ValidatingAdmissionPolicy`), #329/#332 (the credentialed-push E2E baseline this work extends).
+- ⚠ **Numbering**: a concurrent PR also proposed an ADR-0010 (secure-by-default transport). This decision keeps **0010** because it already carries ADR-0009's forward pointer; the transport decision becomes **ADR-0011**. The two are independent: transport versioning decides *how* we connect, this decides *who may consent to a credential being used*.
+- ⚠ **Depends on ADR-0011 for one field**: `allowedModes` must use the SAME enum as the transport API, and the grant must ship in whichever API version that lands in. This ADR does not pre-decide that — see *Open dependency*.
+
+## Context
+
+Three gaps remain on `main` after #219, #251/#300, #296, #297, #309 and #313. They look separate but have one shape: **the Secret's owner cannot express, revocably, what their credential may be used for.**
+
+**1. There is no way to withdraw consent after the fact.** #309 ships a `ValidatingAdmissionPolicy` requiring whoever writes an `NTNCellConfig` to hold `get` on the referenced Secret. That is a real boundary, but it is evaluated **at admission only** — ADR-0009's own amendment says *"Objects already stored are not re-validated; the policy applies on their next write."*
+
+To be precise about what a grant does and does not fix, because an earlier draft of this ADR was not: a grant **does not make the original author's RBAC revocable**. Nothing re-runs that SubjectAccessReview, nothing tracks the author's identity, and removing their RBAC still invalidates nothing automatically. What a grant adds is a *different* capability — a **durable, credential-side consent object that the credential's administrator can withdraw**, without needing any rights over the consuming CR. Implementers should not read this as a requirement to track CR-creator identity.
+
+**2. A credential is not bound to a destination.** `--remote-control-allowed-endpoint-hosts` (#300) is an **admin-global** list. Verified on `main`: there is no per-Secret endpoint binding anywhere in the tree. Any labelled Secret may therefore be paired with any allow-listed endpoint. A gNB operator who publishes a credential for *their* gNB cannot stop it being pointed at a different, equally allow-listed one.
+
+**3. Withdrawal is not observed promptly, and is not reported at all.** Secrets are `get`-only, deliberately (an informer would need cluster-wide `list`/`watch` — see #298). So withdrawing consent is not acted on until the next real push. Measured on a live 1.36.3 cluster: a broken credential recovered **166 s** after being fixed, driven by the referenced `SatelliteEphemeris`'s ~3-minute propagation heartbeat, not by any per-cell retry.
+
+**Correcting an earlier draft of this ADR**, which claimed this window is *"unbounded if that producer stalls"* — that contradicts #298, which this same author wrote. It is not unbounded: the currency gates run **before** the dedup early-return (#221 finding 1, pinned by `TestPushRuntime_SameMarkerBecomesStale_Blocked`), so a stalled producer trips `EphemerisStale` within `propagationEpochLead` and the push fails closed. And while dedup holds, `resolveRemoteControlTLS` is never called — **no credential is presented at all**. So the honest statement of the gap is narrower and worth stating exactly:
+
+- a withdrawn consent stops the **next** push, up to ~3 minutes later, not immediately;
+- until then the CR still reports `EphemerisPushed=True`, which is stale with respect to consent;
+- there is no mechanism at all for the credential side to *cause* that re-evaluation.
+
+This is a consent-propagation and reporting gap. It is **not** an ongoing credential-exposure window, and this ADR should not be used to argue that it is.
+
+A failing push is already handled: `RemoteEndpointRejected`, `RemoteControlCredentialUnavailable` and `RemoteControlEndpointNotAllowed` all self-heal on the 5-minute poll. The gap is the **healthy** cell, where the dedup early-return sits ahead of `resolveRemoteControlTLS`, so nothing re-reads the credential at all.
+
+## Decision
+
+Introduce a namespaced CRD — working name **`RemoteControlCredentialGrant`** — created **by the Secret's owner, in the Secret's namespace**, that states which `NTNCellConfig` may use the credential, against which endpoint, in which mode.
+
+```yaml
+apiVersion: ntn.operators.dev/v1alpha1
+kind: RemoteControlCredentialGrant
+metadata:
+  name: gnb-cred-for-cell-a
+  namespace: ran-team
+spec:
+  secretRef:
+    name: gnb-remote-control-cred
+  # Which CRs may reference it. Name is required; uid pins it against name reuse
+  # after a delete/recreate.
+  allowedConfigs:
+    - name: cell-a
+      uid: 6f1c…            # optional
+  # Which destinations that credential may be presented to. Exact host:port; the
+  # admin allow-list (#300) remains the outer bound, this is the inner one.
+  allowedEndpoints:
+    - "gnb-proxy.ran-team.svc:8443"
+  # Which authentication modes may use it.
+  allowedModes: ["mtls"]
+  # Optional: the owner bumps this when they rotate the Secret's contents. See
+  # "What this does NOT solve".
+  credentialRevision: "2"
+```
+
+Three consequences follow from it being an **object** rather than a check:
+
+- **Revocable.** Deleting the grant, or narrowing it, withdraws consent. The Secret's owner acts on their own object; they need no rights over the consuming CR.
+- **Watchable.** The controller watches grants and enqueues the `NTNCellConfig`s they name (a field index on `spec.secretRef.name`, mirroring the existing `spec.ephemerisRef` index). Revocation therefore triggers a reconcile instead of waiting for an unrelated heartbeat — closing gap 3 for the consent half.
+- **Binding.** `allowedEndpoints` and `allowedModes` make gap 2 a property of the credential rather than of the cluster.
+
+### Where the check runs — the part that makes the properties true
+
+A grant watch alone does **not** deliver revocation, and an earlier draft of this ADR implied it did. `pushRuntimeEphemeris` currently runs `isEphemerisPushUpToDate` (line ~114) **before** `resolveRemoteControlTLS` (line ~163). So the sequence for a healthy cell is:
+
+1. the grant is deleted or narrowed → the watch enqueues the `NTNCellConfig`;
+2. the ephemeris marker has not changed and the generation has not changed;
+3. **dedup returns early** — and the grant is never looked at.
+
+Deleting a grant, narrowing it, or bumping `credentialRevision` would all be silently ignored until the next epoch. The decision must therefore say where authorization is evaluated, not just that grants are watched.
+
+**Decision: grant authorization is evaluated BEFORE the dedup early-return, and its outcome participates in the dedup key.**
+
+```
+freshness / currency gates          (unchanged, still first)
+→ match the grant  ────────────────  cheap: CR-local fields vs a cached grant. No Secret read.
+→ dedup on (ephemerisMarker, authzDigest)
+→ resolve the Secret               (unchanged: only past dedup)
+→ dial / push
+```
+
+`authzDigest` is derived from the **matched grant's** UID + `resourceVersion` (which changes on any edit, including `credentialRevision`), plus the tuple that was matched. Persisted next to the existing push marker. This keeps the cheap path cheap — a steady-state reconcile still reads no Secret and still writes nothing — while making "the grant changed" a first-class reason to re-push, exactly as "the epoch changed" already is.
+
+Rejected alternative: fold the grant into the existing ephemeris push marker. That marker is load-bearing for gNB-restart recovery and the #230 crash-idempotency argument, and #298 already rejects conflating "what the gNB holds" with "how we authenticated" for the same reason.
+
+**Required tests** (extending the #332 fixture rather than building a new one):
+
+| Case | Expected |
+|---|---|
+| healthy cell → delete the only matching grant, **no** new ephemeris epoch | condition goes False promptly, without waiting ~3 min |
+| narrow `allowedEndpoints` / `allowedModes` so the tuple no longer matches | refused promptly |
+| bump `credentialRevision` only | dedup bypassed, Secret re-read, push re-issued |
+| edit an unrelated grant | **no** re-push (the digest must not be over-broad) |
+| two matching grants, delete one | still permitted |
+
+### Watch → enqueue mapping
+
+Indexing grants by `spec.secretRef.name` answers "which grants reference this Secret", which is **not** the question the event handler has to answer. The mapping is explicit:
+
+- **Add/Update**: enqueue the union of `allowedConfigs` in the **old** and **new** objects, so a config removed from the list is re-evaluated and loses access.
+- **Delete**: enqueue every `allowedConfigs` entry of the deleted object.
+- Entries are namespace-local (the grant lives in the Secret's namespace, which is the CR's namespace).
+
+A second index of `NTNCellConfig` by its referenced Secret name is **not** required for this mapping and is not added.
+
+### Multiple grants: one grant must match the whole tuple
+
+**A single grant must match Secret + config + endpoint + mode.** Permissions are **not** assembled across grants: a grant allowing endpoint A and another allowing `mtls` must not combine into "A over mtls". Deleting any one grant revokes exactly what that grant permitted; access survives only if some *other single* grant still matches the complete tuple.
+
+Gateway API's `ReferenceGrant` is additive/OR across grants, but each grant there authorises one complete (from, to) pair — the OR is over whole permissions, not over fields. This keeps that property while refusing field-level assembly, which is the failure mode where two individually-harmless grants add up to one nobody intended.
+
+### Identity: what is pinned, and what is not
+
+- `allowedConfigs[].uid` — **optional**. Present ⇒ delete/recreate under the same name does **not** inherit the grant.
+- `spec.secretRef` — **name-bound, no UID**, and this is deliberate: the CR references its Secret by name too, so pinning the grant harder than the reference it authorises would make routine Secret rotation-by-recreate fail while the CR happily kept pointing at the new object. The consequence is stated rather than hidden: **deleting a Secret and recreating it under the same name inherits the existing grant.** Both recreate cases get a test.
+- `spec.secretRef` is **immutable** after creation. Repointing a grant at a different Secret is a new consent decision and must be a new object.
+
+### Who may write a grant
+
+"Created by the Secret's owner" is a story, not a boundary — Kubernetes has no notion of Secret ownership, only verbs. Anyone with `create`/`patch` on the grant resource could otherwise issue one, which would hollow out the whole design. Enforcement is therefore part of this decision, not an afterthought:
+
+1. A **grant-specific `ValidatingAdmissionPolicy`** requiring the principal writing the grant to hold `get` on the exact Secret in `spec.secretRef` — the same `authorizer` mechanism #309 already uses, applied to the grant instead of the CR.
+2. **Separate RBAC**: the shipped `ntncellconfig-editor-role` must **not** confer grant write.
+3. `--require-credential-grant` refuses to start unless (1) is installed, so the enforcement mode cannot be enabled while its own gate is missing.
+
+Note this is a distinct policy from #309's, which checks the *NTNCellConfig* writer and is default-off. Neither implies the other.
+
+### Schema bounds
+
+Decided here because they change the merge semantics and the compatibility surface, not merely the implementation:
+
+| Field | Rule |
+|---|---|
+| `allowedConfigs` | `MinItems: 1`, `MaxItems: 32`, `listType: map` keyed on `name` |
+| `allowedEndpoints` | `MinItems: 1`, `MaxItems: 16`, `listType: set`, each `MaxLength: 261` |
+| `allowedModes` | `MinItems: 1`, enum from the transport API, `listType: set` |
+| empty list | **impossible** — `MinItems: 1` everywhere. An empty list must never read as "allow all" |
+| wildcards | **not supported** in any field, in this version |
+| `credentialRevision` | optional opaque string, `MaxLength: 64` |
+
+### Endpoint matching is canonicalised, once
+
+`allowedEndpoints` is an exact `host:port` match **after canonicalisation**, and the same canonicaliser is used by admission validation, the controller's match, and the tests — a rule that differs between the three is a rule that will eventually authorise something nobody approved:
+
+- host lower-cased; a single trailing dot stripped;
+- a short Service name is **not** equal to its FQDN — write what the CR writes;
+- IPv6 in its canonical compressed form; IPv4-mapped IPv6 normalised to the IPv4 form;
+- the port is **mandatory** and compared.
+
+This is deliberately stricter than `pkg/netutil.EndpointAllowlist`, which compares a lower-cased hostname and ignores the port. That one is an admin's outer bound on egress; this is an owner's inner bound on a specific credential, and the two are not interchangeable.
+
+### Open dependency
+
+`allowedModes` must draw from the same enum as the transport work (ADR-0011), and the grant must ship in whichever API version that lands in. This ADR **does not** assume that version. Sequencing — grant first, transport first, or together — is settled with ADR-0011 before either implementation starts.
+
+### Enforcement is admin-gated and default-off
+
+A new flag, `--require-credential-grant` (default `false`). While it is off, grants are advisory and nothing changes. When an admin turns it on, a `remoteControl.tls` push is refused unless a grant permits the (Secret, CR, endpoint, mode) tuple.
+
+The alternative — "enforce whenever a grant exists for that Secret" — is **rejected**: an attacker simply does not create one, and the feature would silently do nothing exactly when it matters.
+
+Refusal reuses `RemoteControlCredentialUnavailable`, the uniform reason from #296, so the existing 5-minute self-heal applies and no new Secret oracle is opened.
+
+## Relationship to ADR-0009
+
+ADR-0009 recommended **SAR at admission** over a grant CRD, on the grounds that this is a same-namespace problem, that the feature is a minority deployment, and that *"applying its owner-opt-in-object machinery to a same-namespace reference is heavier than the problem warrants."*
+
+That reasoning was sound **for the requirement as stated there** — deciding who may create the reference. It does not survive two requirements that were not on the table:
+
+- **Revocability.** A SAR is a point-in-time check on a write. ADR-0009's amendment records that limitation itself. A grant is state, so withdrawing it is observable.
+- **Endpoint binding.** A SAR answers "may this principal read this Secret?". It cannot express "…and only to reach *that* gNB". Nothing in the SAR model can.
+
+So a grant is not a heavier way to do the same job — it does **three** jobs, and the per-object cost is amortised across all three. That is what changes the calculus, not a disagreement with ADR-0009's original analysis.
+
+**#309 is not replaced.** It stays as the cheap default: no CRD, no controller, one declarative policy, and it stops the confused deputy at the moment of writing. The grant is the stronger, opt-in tier for multi-tenant namespaces. They compose — admission decides who may *create* the reference, the grant decides whether it may *continue* to be used, and #300's allow-list remains the admin's outer bound on destinations.
+
+## What this does NOT solve
+
+- **Rotating a Secret's *contents*.** Editing `token` or `tls.key` does not touch the grant, so it fires no watch. That path stays at the ~3-minute bound recorded in #298. The optional `credentialRevision` field is the escape hatch — an owner who bumps it on rotation converts a content change into a watched change — but it is opt-in and depends on the owner remembering. It is **not** a substitute for a Secret watch, and this ADR should not be read as closing #298.
+- **A `patch`-capable principal.** Someone who can patch objects in the Secret's namespace can write a grant they should not. The grant moves consent to the Secret's own namespace, which is where it belongs, but namespace RBAC is still the ceiling.
+- **Anything about the gNB's own authorization.** A grant governs what the operator will present, not what the gNB accepts.
+
+## Consequences
+
+- A fifth CRD: `make manifests bundle nephio-sync` keeps **four** copies in sync, plus `docs/api-reference.md`, chart RBAC, and samples.
+- The controller gains `list`/`watch` on the new CRD — but **not** on Secrets. That is the point: consent becomes watchable without widening Secret access, which is exactly the trade #298 rejected the informer for.
+- Cardinality is per (Secret, consumer) rather than per CR; in the expected deployment that is a small number.
+- The grant is only meaningful when the operator can be trusted to enforce it. It is a boundary against *CR authors*, not against a compromised operator, which already holds `secrets get`.
+
+## Alternatives considered
+
+- **Keep SAR-only (#309 as shipped).** Rejected as the end state: it cannot revoke and cannot bind an endpoint. Kept as the default tier.
+- **Gateway API `ReferenceGrant` itself.** Its schema is namespace/kind-scoped for the cross-namespace case; it has no place to express an endpoint or an auth mode, which are two of the three jobs here.
+- **Put `allowedEndpoints` on the Secret as annotations.** No schema, no validation, no status, and a `patch`-only principal can edit annotations on a Secret they cannot read — the same weakness #219 already documents for the opt-in label.
+- **A cluster-scoped grant.** Rejected: consent belongs next to the credential, and a cluster-scoped object would need its own authorization story.
+
+## Follow-up, tracked separately
+
+The credentialed-push E2E baseline is no longer hypothetical: #329 tracked it and **#332** shipped it, with four arms driving a real `ntn_config_update` frame through a TLS proxy to a plaintext backend. The revoke/narrow/revision tests above extend that fixture rather than standing up a second one.

--- a/docs/adr/0011-remote-control-credential-grant.md
+++ b/docs/adr/0011-remote-control-credential-grant.md
@@ -1,12 +1,12 @@
-# ADR 0010 — An owner-issued grant for `remoteControl.tls` credentials
+# ADR 0011 — An owner-issued grant for `remoteControl.tls` credentials
 
 - Status: **Proposed**
 - Date: 2026-07-31
 - Deciders: @thc1006
 - Supersedes: the **"prefer SubjectAccessReview at admission over a ReferenceGrant-style CRD"** recommendation in [ADR-0009](0009-remote-control-credential-confused-deputy.md) — see *Relationship to ADR-0009*. The interim endpoint allow-list and the shipped admission policy both stand.
 - Relates to: #219 (label/type opt-in), #251 (confused deputy), #298 (rotation is bounded by the ~3m epoch cadence), #300 (admin endpoint allow-list), #309 (opt-in `ValidatingAdmissionPolicy`), #329/#332 (the credentialed-push E2E baseline this work extends).
-- ⚠ **Numbering**: a concurrent PR also proposed an ADR-0010 (secure-by-default transport). This decision keeps **0010** because it already carries ADR-0009's forward pointer; the transport decision becomes **ADR-0011**. The two are independent: transport versioning decides *how* we connect, this decides *who may consent to a credential being used*.
-- ⚠ **Depends on ADR-0011 for one field**: `allowedModes` must use the SAME enum as the transport API, and the grant must ship in whichever API version that lands in. This ADR does not pre-decide that — see *Open dependency*.
+- ⚠ **Numbering**: this grant decision is **ADR-0011**; the concurrent secure-by-default transport decision takes **ADR-0010** (layering: 0009 confused-deputy threat model → 0010 transport mode + API versioning → 0011 continuous per-credential authorization). The two are independent: transport versioning decides *how* we connect, this decides *who may consent to a credential being used*.
+- ⚠ **Depends on ADR-0010 for one field**: `allowedModes` must use the SAME enum as the transport API, and the grant must ship in whichever API version that lands in. This ADR does not pre-decide that — see *Open dependency*.
 
 ## Context
 
@@ -157,7 +157,7 @@ This is deliberately stricter than `pkg/netutil.EndpointAllowlist`, which compar
 
 ### Open dependency
 
-`allowedModes` must draw from the same enum as the transport work (ADR-0011), and the grant must ship in whichever API version that lands in. This ADR **does not** assume that version. Sequencing — grant first, transport first, or together — is settled with ADR-0011 before either implementation starts.
+`allowedModes` must draw from the same enum as the transport work (ADR-0010), and the grant must ship in whichever API version that lands in. This ADR **does not** assume that version. Sequencing — grant first, transport first, or together — is settled with ADR-0010 before either implementation starts.
 
 ### Enforcement is admin-gated and default-off
 


### PR DESCRIPTION
**Proposed** — no CRD, controller or flag ships here. This records a design and corrects part of an earlier one.

## Why now

Three gaps remain on `main` after #219, #251/#300, #296, #297, #309 and #313. I checked each against `main @ 93c47f3` rather than assuming. They look separate but share one shape: **the Secret's owner cannot express, revocably, what their credential may be used for.**

| Gap | State on `main` |
|---|---|
| Authorization is not revocable | #309's `ValidatingAdmissionPolicy` is evaluated **at admission only** — ADR-0009's own amendment says stored objects are not re-validated. Withdrawing an author's RBAC does not re-evaluate the CRs they already created. |
| A credential is not bound to a destination | `--remote-control-allowed-endpoint-hosts` is **admin-global**. Grepped the tree: **zero** per-Secret endpoint binding. Any labelled Secret can be paired with any allow-listed endpoint. |
| Revocation is invisible | Secrets are `get`-only by design (an informer needs cluster-wide `list`/`watch`, rejected in #298). Withdrawn consent is unseen until the next real push — **measured at 166 s** on a live 1.36.3 cluster, driven by the referenced `SatelliteEphemeris`'s heartbeat, not by any per-cell retry. |

A *failing* push is already fine — `RemoteEndpointRejected`, `RemoteControlCredentialUnavailable` and `RemoteControlEndpointNotAllowed` all self-heal on the 5-minute poll. The gap is the **healthy** cell, where the dedup early-return sits ahead of `resolveRemoteControlTLS`, so nothing re-reads the credential at all.

## The design

`RemoteControlCredentialGrant`, namespaced, created **by the Secret's owner in the Secret's namespace**: `secretRef`, `allowedConfigs` (name + optional uid), `allowedEndpoints`, `allowedModes`.

Being an **object** rather than a check is what buys all three properties at once — it can be **deleted** (revocable), it can be **watched and field-indexed** so revocation enqueues the affected `NTNCellConfig`s instead of waiting on an unrelated heartbeat, and it has **somewhere to put** an endpoint and a mode.

Enforcement is admin-gated and **default-off** behind `--require-credential-grant`. The tempting "enforce whenever a grant exists for that Secret" variant is rejected in the ADR: an attacker simply would not create one, so the feature would do nothing precisely when it matters.

## It corrects ADR-0009, and says which part

ADR-0009 recommended SAR-at-admission **over** a grant CRD, calling the latter *"heavier than the problem warrants"*. That was sound **for the requirement as stated there** — deciding who may create the reference. It does not survive two requirements that were not on the table:

- **Revocability** — a SAR is a point-in-time check on a write. ADR-0009's amendment records this limitation itself.
- **Endpoint binding** — a SAR answers "may this principal read this Secret?" and can never express "…and only to reach *that* gNB".

So a grant is not a heavier way to do the same job; it does **three** jobs, which is what changes the calculus. ADR-0009 now carries a forward pointer in its header so nobody lands on it and acts on the superseded bullet.

**#309 is explicitly not replaced.** It stays the cheap default tier — no CRD, no controller, one declarative policy — and stops the confused deputy at write time. The grant is the opt-in stronger tier for multi-tenant namespaces. #300's allow-list remains the admin's outer bound on destinations.

## What the ADR refuses to claim

- **It does not close #298.** Rotating a Secret's *contents* touches no grant and fires no watch, so that path keeps the ~3-minute bound. The optional `credentialRevision` field is an opt-in escape hatch that depends on the owner remembering to bump it — not a Secret watch, and the ADR says so.
- A `patch`-capable principal in the Secret's namespace can still write a grant they should not; namespace RBAC remains the ceiling.
- A grant governs what the operator will present, not what the gNB accepts.

## Cost, stated up front

A fifth CRD means `make manifests bundle nephio-sync` across **four** copies plus `docs/api-reference.md`, chart RBAC and samples. The controller gains `list`/`watch` on the new CRD but **not** on Secrets — that is the point: consent becomes watchable without widening Secret access, which is the trade #298 rejected an informer for.

## Follow-up, deliberately not bundled

Automated E2E for the credentialed push. The chain is verified manually and shipped as a sample (#326), but **no test in `test/e2e/` exercises wss/mTLS**, so a regression would ship green. Tracked separately — it is independent of this design decision.
