### PR TITLE
docs(security): point endpoint + credential docs at the real controls (#299, #251)

### DIFF
--- a/api/v1alpha1/ntncellconfig_types.go
+++ b/api/v1alpha1/ntncellconfig_types.go
@@ -91,6 +91,12 @@ type RemoteControlRef struct {
 	// 1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
 	// value. The pattern alone cannot bound the label/host length (a regex quantifier
 	// would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
+	//
+	// Shape validation does NOT restrict WHICH host the operator will dial; the endpoint is
+	// CR-author-controlled, so confining it is an admin egress control (SSRF), not a CRD rule.
+	// Set the operator flag --remote-control-allowed-endpoint-hosts to permit only sanctioned
+	// gNB hosts for the runtime push (empty = any, backward compatible), and pair it with the
+	// operator egress NetworkPolicy (config/network-policy/allow-egress-traffic.yaml). See #299.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=261
 	// +kubebuilder:validation:Pattern=`^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$`

--- a/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -860,6 +860,12 @@ spec:
                           1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
                           value. The pattern alone cannot bound the label/host length (a regex quantifier
                           would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
+
+                          Shape validation does NOT restrict WHICH host the operator will dial; the endpoint is
+                          CR-author-controlled, so confining it is an admin egress control (SSRF), not a CRD rule.
+                          Set the operator flag --remote-control-allowed-endpoint-hosts to permit only sanctioned
+                          gNB hosts for the runtime push (empty = any, backward compatible), and pair it with the
+                          operator egress NetworkPolicy (config/network-policy/allow-egress-traffic.yaml). See #299.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$

--- a/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntncellconfigs.yaml
@@ -860,6 +860,12 @@ spec:
                           1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
                           value. The pattern alone cannot bound the label/host length (a regex quantifier
                           would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
+
+                          Shape validation does NOT restrict WHICH host the operator will dial; the endpoint is
+                          CR-author-controlled, so confining it is an admin egress control (SSRF), not a CRD rule.
+                          Set the operator flag --remote-control-allowed-endpoint-hosts to permit only sanctioned
+                          gNB hosts for the runtime push (empty = any, backward compatible), and pair it with the
+                          operator egress NetworkPolicy (config/network-policy/allow-egress-traffic.yaml). See #299.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$

--- a/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntncellconfigs.ntn.operators.dev.yaml
@@ -863,6 +863,12 @@ spec:
                           1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
                           value. The pattern alone cannot bound the label/host length (a regex quantifier
                           would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
+
+                          Shape validation does NOT restrict WHICH host the operator will dial; the endpoint is
+                          CR-author-controlled, so confining it is an admin egress control (SSRF), not a CRD rule.
+                          Set the operator flag --remote-control-allowed-endpoint-hosts to permit only sanctioned
+                          gNB hosts for the runtime push (empty = any, backward compatible), and pair it with the
+                          operator egress NetworkPolicy (config/network-policy/allow-egress-traffic.yaml). See #299.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$

--- a/internal/controller/ntncellconfig_controller.go
+++ b/internal/controller/ntncellconfig_controller.go
@@ -968,21 +968,26 @@ func (r *NTNCellConfigReconciler) resolveRemoteControlTLS(
 	if err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: t.SecretName}, secret); err != nil {
 		return nil, "", fmt.Errorf("reading remoteControl.tls secret %q: %w", t.SecretName, err)
 	}
-	// SECURITY (partial confused-deputy MITIGATION, not an authorization boundary): the
-	// operator reads this Secret with its OWN cluster-wide secrets-get, on behalf of
-	// whoever authored the NTNCellConfig — who may not be able to read Secrets. Two gates
-	// raise the bar against a CR author pointing the operator at an arbitrary Secret and
-	// shipping its contents to a CR-controlled endpoint:
+	// SECURITY (confused deputy): the operator reads this Secret with its OWN cluster-wide
+	// secrets-get, on behalf of whoever authored the NTNCellConfig — who may not be able to
+	// read Secrets. The ENFORCED authorization boundary is the credentialRefPolicy
+	// ValidatingAdmissionPolicy (dist/chart, credentialRefPolicy.enable; ADR-0009, #251):
+	// when enabled the apiserver requires the CR's writer to hold `get` on the referenced
+	// Secret, so the writer cannot borrow a Secret it could not read itself. That policy is
+	// OPT-IN and OFF by default (enable=false), so out of the box the two gates below are a
+	// PARTIAL mitigation only — NOT an authorization boundary — raising the bar against a CR
+	// author pointing the operator at an arbitrary Secret and shipping its contents to a
+	// CR-controlled endpoint:
 	//   (1) refuse a Kubernetes API credential — a service-account or bootstrap token
 	//       Secret stores its apiserver token under the same "token" key we read;
 	//   (2) require the Secret's owner to opt it in via a label.
-	// Known LIMITS (a real per-CR/per-endpoint SubjectAccessReview or grant resource is a
-	// tracked follow-up): the opt-in is namespace-scoped — once labelled, ANY NTNCellConfig
-	// in the namespace may use the Secret; a principal with secrets `patch` but not `get`
-	// could add the label to a Secret it cannot read; and the type check does not stop an
-	// Opaque Secret from holding some other bearer token. Those limits are about WHICH Secret
-	// may be named; the CA-pinning gate further down bounds where its token may be SENT,
-	// which is what turns "named the wrong Secret" into something less than exfiltration.
+	// LIMITS of gates (1)/(2) — why they do not substitute for the policy: the label opt-in
+	// is namespace-scoped — once labelled, ANY NTNCellConfig in the namespace may use the
+	// Secret; a principal with secrets `patch` but not `get` could add the label to a Secret
+	// it cannot read; and the type check does not stop an Opaque Secret from holding some
+	// other bearer token. Those limits are about WHICH Secret may be named; the CA-pinning
+	// gate further down bounds where its token may be SENT, which is what turns "named the
+	// wrong Secret" into something less than exfiltration.
 	switch secret.Type {
 	case corev1.SecretTypeServiceAccountToken, secretTypeBootstrapToken:
 		return nil, "", fmt.Errorf("remoteControl.tls secret %q has type %q — a Kubernetes API credential must not be used as a gNB remote-control secret", t.SecretName, secret.Type)

--- a/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntncellconfigs-crd.yaml
@@ -860,6 +860,12 @@ spec:
                           1-63) — a permanent admission error beats a silent tight-requeue on a mistyped
                           value. The pattern alone cannot bound the label/host length (a regex quantifier
                           would, but the DNS-1123 label form makes that unreadable), so CEL carries it.
+
+                          Shape validation does NOT restrict WHICH host the operator will dial; the endpoint is
+                          CR-author-controlled, so confining it is an admin egress control (SSRF), not a CRD rule.
+                          Set the operator flag --remote-control-allowed-endpoint-hosts to permit only sanctioned
+                          gNB hosts for the runtime push (empty = any, backward compatible), and pair it with the
+                          operator egress NetworkPolicy (config/network-policy/allow-egress-traffic.yaml). See #299.
                         maxLength: 261
                         minLength: 1
                         pattern: ^(\[[0-9a-fA-F:]+\]|[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*):[0-9]{1,5}$


### PR DESCRIPTION
## What

Two documentation-accuracy fixes surfaced while verifying the acceptance criteria of #299 and #251. **No behavior change** — comment + field-godoc only (plus the CRD regeneration the godoc triggers).

### #299 (任意 endpoint SSRF) — acceptance #4

The `remoteControl.endpoint` field godoc documented only the shape validation (host:port, DNS-1123, CEL) and never pointed at the control that actually bounds *which* host the operator will dial. Added a note that confining the destination is an admin egress concern, naming the two enforced controls:

- `--remote-control-allowed-endpoint-hosts` app-layer allow-list (empty = any, backward compatible)
- the egress `NetworkPolicy` at `config/network-policy/allow-egress-traffic.yaml`

The godoc flows into all four CRD copies via `controller-gen` (`config/crd/bases`, `bundle/manifests`, `dist/chart/templates/crd`, `nephio/packages`).

**This closes the last open acceptance item for #299** (the allow-list, plaintext-relay gate, and egress policy already shipped in #300/#317/#324). #299 is closeable after this merges.

### #251 (remoteControl.tls confused deputy)

The `resolveRemoteControlTLS` SECURITY comment called itself *"a partial mitigation, not an authorization boundary"* and pointed only at a hypothetical future `SubjectAccessReview`. That is now stale and **understates what shipped**: the opt-in `credentialRefPolicy` ValidatingAdmissionPolicy (ADR-0009) IS the enforced boundary — it makes the apiserver require the CR's writer to hold `get` on the referenced Secret (`authorizer…namespace(request.namespace).name(…secretName).check('get')`).

Rewrote the comment to name that policy as the real boundary, **while staying honest** that it is opt-in and `enable: false` by default, so the two in-resolver gates (reject API-credential Secret types; require an owner opt-in label) remain a partial mitigation out of the box.

**#251 stays OPEN** — remaining work: an automated envtest exercising a restricted (secrets-`get`-less) user against the live policy, and the decision on whether to flip the default posture. This PR only corrects the misleading comment.

## Verification

- `go build ./...` + `go vet ./api/... ./internal/controller/...` clean
- `make manifests bundle nephio-sync` — all four CRD copies regenerated consistently (+6 lines each)
- Every factual claim in the new docs checked against the actual code: flag name + empty=permit-all (`pkg/netutil/allowlist.go:50`), NetworkPolicy path exists, and the VAP CEL scopes `get` to the referenced Secret (`dist/chart/templates/admission/credential-ref-policy.yaml:37-40`)
