### PR TITLE
docs(adr): record what #332 and #335 actually shipped

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,10 +26,10 @@ Governance is machine-checked:
 | [0006](0006-decouple-propagation-from-pass-prediction.md) | Decouple propagation heartbeat from pass prediction | accepted | — | #234 · impl #256 |
 | [0007](0007-durable-omm-cache.md) | Durable last-good OMM cache for restart and leader failover | accepted | — | hash-name migration follow-up |
 | [0008](0008-constellation-pool-availability.md) | Model satellite-path contact opportunity at constellation-pool level | accepted | — | slice-to-cell binding follow-up |
-| [0009](0009-remote-control-credential-boundary.md) | Layered authorization boundary for remote-control credentials | accepted | superseded-in-part by **0011** | #251, #299 |
+| [0009](0009-remote-control-credential-boundary.md) | Layered authorization boundary for remote-control credentials | accepted | superseded-in-part by **0011** | #251, #299 · wire-level E2E impl #332 |
 | [0010](0010-v1alpha2-secure-defaults-and-duration-validation.md) | v1alpha2 secure-by-default transport and duration admission validation | proposed | — | #214, #315, #311, #299 |
-| [0011](0011-remote-control-credential-grant.md) | Owner-issued grant for remote-control credentials | proposed | supersedes **0009** admission-only end state | #251, #298, #329 |
-| [0012](0012-ground-station-antenna-health-probe.md) | Evidence-based ground-station antenna health and readiness | proposed | supersedes node-exists→`AntennaReady=True` | #68 |
+| [0011](0011-remote-control-credential-grant.md) | Owner-issued grant for remote-control credentials | proposed | supersedes **0009** admission-only end state | #251, #298, #329 (closed by #332) |
+| [0012](0012-ground-station-antenna-health-probe.md) | Evidence-based ground-station antenna health and readiness | proposed | supersedes node-exists→`AntennaReady=True` | #68 · #335 removed the fabricated `True`; the probe itself is unimplemented |
 
 ## Reserved / gaps
 

--- a/docs/adr/REVIEW_FINDINGS.md
+++ b/docs/adr/REVIEW_FINDINGS.md
@@ -26,13 +26,23 @@
 - slice-to-cell/cell-group binding;
 - cell activation/deactivation;
 - true session continuity/UPF integration;
-- automated wss/mTLS E2E;
 - conversion webhook and v1alpha2 migration;
 - credential grant CRD/controller;
 - structured ground-station hardware agent;
 - policy-capable NetworkPolicy E2E;
 - six-digit NORAD regression coverage;
 - collision-resistant OMM cache migration.
+
+## Landed since this bundle was written
+
+- **Automated wss/mTLS E2E** — #332 covers the credentialed runtime push at the
+  wire level (bearer rejection, unpinned CA, mTLS enforcement, endpoint
+  allow-list) against a TLS-terminating proxy in front of a plaintext backend.
+  It does **not** cover NetworkPolicy enforcement, which stays listed above: the
+  chain being tested is not the same as every remote-control control being tested.
+- **Fabricated antenna readiness** — #335 changed `AntennaReady` from a node-exists
+  `True` to `Unknown/NoAntennaProbe`, which is the correction ADR 0012 requires.
+  The evidence-based agent contract itself remains unimplemented (#68).
 
 ## Claims deliberately not made
 


### PR DESCRIPTION
`make adr-lint` still green (11 ADRs).

## What this fixes

`docs/adr/REVIEW_FINDINGS.md` lists **automated wss/mTLS E2E** as a repository gap "intentionally left as tracked implementation work". That stopped being true when #332 merged (`4838694`, closing #329). A gap list naming work that is already on `main` is how the next agent rebuilds it.

`AGENTS.md` states the rule this violates from the other side:

> An `Accepted` ADR is not `Implemented`: record implementation PRs explicitly; never claim unmerged work has shipped.

The inverse — calling shipped work a gap — costs the same.

## Changes

| Where | Before | After |
|---|---|---|
| `REVIEW_FINDINGS.md` gap list | `automated wss/mTLS E2E;` | removed; new **Landed since this bundle was written** section |
| index, ADR 0009 | `#251, #299` | `… · wire-level E2E impl #332` |
| index, ADR 0011 | `#251, #298, #329` | `… #329 (closed by #332)` |
| index, ADR 0012 | `#68` | `#68 · #335 removed the fabricated True; the probe itself is unimplemented` |

## Both entries say what is NOT covered

That is the part a reader gets wrong.

- #332 does **not** exercise NetworkPolicy enforcement — Kind's default CNI and this project's Flannel dev cluster do not enforce it. So **policy-capable NetworkPolicy E2E stays on the gap list**; testing the credentialed chain is not testing every remote-control control.
- #335 only removed the node-exists `AntennaReady=True` in favour of `Unknown/NoAntennaProbe`. That is the correction ADR 0012 requires, but the evidence-based agent contract remains unimplemented (#68 still open).
