### PR TITLE
fix(omm-cache): collision-resistant cache name, legacy adoption, observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ntn_operators_omm_cache_restore_total{result}` and `ntn_operators_omm_cache_restored_age_seconds`,
   plus alerts `NTNOMMCachePersistFailing` and `NTNOMMCacheRestoreRefused` with runbook entries. A
   plain restore *miss* is deliberately not counted — every first-ever reconcile misses, so it would
-  drown the refusals, which are the signal. Sustained `refused_identity` under the legacy cache name
-  is how the truncation collision above surfaces on a cluster that has not yet repersisted.
+  drown the refusals, which are the signal. `refused_identity` is counted but deliberately **not**
+  alerted: restore runs on every reconcile while the in-memory cache is cold, so a legitimate
+  delete/recreate whose old cache object still exists increments it once per reconcile until the
+  first successful fetch — an alert would fire hardest exactly when the operator is behaving
+  correctly. Sustained `refused_identity` under the legacy cache name is how the truncation
+  collision above surfaces on a cluster that has not yet repersisted; the runbook carries the query.
 
 - **End-to-end coverage for the credentialed runtime push (`wss://` + bearer + mTLS), closing #329.**
   Everything under #206, #295, #297, #313, #318 and #322 was unit-tested against `httptest`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The durable OMM cache is now observable, and its silent failure modes alert.** Persisting the
+  last-good element set is best-effort by design (a write failure must not fail live reconciliation),
+  which is exactly why it needed signals: without them the cache can fail to write for weeks and the
+  first symptom is a restart with nothing to propagate, during the upstream outage the cache exists
+  for. New metrics `ntn_operators_omm_cache_persist_total{result}`,
+  `ntn_operators_omm_cache_restore_total{result}` and `ntn_operators_omm_cache_restored_age_seconds`,
+  plus alerts `NTNOMMCachePersistFailing` and `NTNOMMCacheRestoreRefused` with runbook entries. A
+  plain restore *miss* is deliberately not counted — every first-ever reconcile misses, so it would
+  drown the refusals, which are the signal. Sustained `refused_identity` under the legacy cache name
+  is how the truncation collision above surfaces on a cluster that has not yet repersisted.
+
 - **End-to-end coverage for the credentialed runtime push (`wss://` + bearer + mTLS), closing #329.**
   Everything under #206, #295, #297, #313, #318 and #322 was unit-tested against `httptest`, which
   cannot show that the *deployment shape* works — and `test/e2e/` contained zero tests touching
@@ -363,6 +374,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the controller nodes have synchronised clocks (#220 H1).
 
 ### Fixed
+
+- **Two `SatelliteEphemeris` objects with long names no longer contend for one durable OMM cache
+  ConfigMap.** The cache name was `<cr-name>-omm-cache` with the name truncated to fit the 253-char
+  limit, so every CR sharing a 243-character prefix mapped onto the *same* object. The owner-UID
+  annotation stopped a wrong *restore*, but not the contention: the losers kept overwriting an
+  object their own restore then refused, so their restart/leader-failover continuity was gone with
+  nothing in the status, events or logs to say so — an availability bug, not a cosmetic one. The
+  name is now `<readable prefix>-<128-bit hash of namespace/name/UID>-omm-cache` (ADR-0007), which
+  also means a delete/recreate lands on a different object instead of inheriting its predecessor's.
+  **Upgrades keep their cache**: a cold restore reads the pre-existing legacy name once, applies the
+  identical digest/UID/fetch-identity gates, and copies it forward to the hashed name immediately
+  rather than waiting for the next fetch (~2 h). The legacy object is never deleted — the controller
+  holds no `delete` verb — and is garbage-collected with its owner CR.
 
 - **Losing the ConfigMap create race is now classified instead of surfacing as a generic apply
   failure.** `ApplyCellConfig` reads the ConfigMap with the uncached reader and creates it when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first symptom is a restart with nothing to propagate, during the upstream outage the cache exists
   for. New metrics `ntn_operators_omm_cache_persist_total{result}`,
   `ntn_operators_omm_cache_restore_total{result}` and `ntn_operators_omm_cache_restored_age_seconds`,
-  plus alerts `NTNOMMCachePersistFailing` and `NTNOMMCacheRestoreRefused` with runbook entries. A
+  plus alerts `NTNOMMCachePersistFailing` and `NTNOMMCacheRestoreRefused` with runbook entries. The
+  persist alert is windowed at 24h and gated with `unless` on a successful write in the same window,
+  because persist runs once per successful *fetch* and `refreshInterval` defaults to 4h with a 2h
+  floor — a shorter window would usually contain no attempt at all and report "no failures" from
+  having observed nothing. Per-CR series are released on CR deletion, matching the existing
+  `DeletePartialMatch` cleanup for the other ephemeris metrics. A
   plain restore *miss* is deliberately not counted — every first-ever reconcile misses, so it would
   drown the refusals, which are the signal. `refused_identity` is counted but deliberately **not**
   alerted: restore runs on every reconcile while the in-memory cache is cold, so a legitimate

--- a/dist/chart/templates/monitoring/prometheusrule.yaml
+++ b/dist/chart/templates/monitoring/prometheusrule.yaml
@@ -153,14 +153,18 @@ spec:
           annotations:
             summary: "Durable OMM cache is not being written for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
             description: "Durable OMM cache writes have been failing for 30m (result={{`{{ $labels.result }}`}}). Live propagation is unaffected, but a restart or leader failover will have no last-good element set to fall back on. skipped_oversize means the tracked set exceeds the ConfigMap bound; failed means the write itself is erroring."
-        # A restore that is refused is worse than one that never happens: the object is there, and
-        # something about it does not check out. refused_identity on the legacy name is how a
-        # pre-ADR-0007 truncation collision surfaces; refused_digest means corruption or a hand edit.
+        # A restore that is refused is worse than one that never happens: the object is there and
+        # does not check out. Scoped to the CORRUPTION reasons on purpose — restore runs on every
+        # reconcile while the in-memory cache is cold, so a legitimate delete/recreate whose old
+        # cache object still exists increments refused_identity once per reconcile until the first
+        # successful fetch, and during the upstream outage this feature exists for that is a lot of
+        # reconciles. Alerting on it would fire hardest exactly when the operator is behaving
+        # correctly. refused_identity stays a diagnostic signal; the runbook has the query.
         - alert: NTNOMMCacheRestoreRefused
-          expr: increase(ntn_operators_omm_cache_restore_total{result=~"refused_.*"}[1h]) > 0
+          expr: increase(ntn_operators_omm_cache_restore_total{result=~"refused_digest|refused_parse"}[1h]) > 0
           labels:
             severity: warning
           annotations:
-            summary: "Durable OMM cache restore refused for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
-            description: "A persisted OMM cache was found but refused ({{`{{ $labels.result }}`}}). The cold start had to proceed without it. refused_identity: the object belongs to a different CR generation or source (under the legacy name, a truncation collision); refused_digest: corrupt or hand-edited payload; refused_parse: the stored element set no longer validates."
+            summary: "Durable OMM cache payload is unusable for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
+            description: "A persisted OMM cache was found but its payload does not check out ({{`{{ $labels.result }}`}}), so the cold start proceeded without it. refused_digest: the stored payload does not match its recorded SHA-256 (corrupt, truncated or hand-edited); refused_parse: it no longer validates as an OMM set. Delete the object and let the next fetch repersist. Identity refusals are excluded from this alert on purpose — see the runbook."
 {{- end }}

--- a/dist/chart/templates/monitoring/prometheusrule.yaml
+++ b/dist/chart/templates/monitoring/prometheusrule.yaml
@@ -143,16 +143,26 @@ spec:
         # ADR-0007: persisting the last-good OMM set is deliberately best-effort — a failure must
         # not fail live reconciliation. That is precisely why it needs an alert: without one the
         # cache can be failing to write for weeks and the first symptom is a restart with nothing
-        # to propagate, during the upstream outage the cache exists for. One blip is expected
-        # (conflict, transient apiserver error); sustained failure means restart continuity is gone.
+        # to propagate, during the upstream outage the cache exists for.
+        #
+        # The window is 24h because persist runs once per successful FETCH, and refreshInterval
+        # defaults to 4h with a 2h floor. Any window measured in minutes usually contains no
+        # persist attempt at all, so it would report "no failures" from having observed nothing.
+        # `unless` is what makes this a statement about the cache rather than about one write: it
+        # fires only when the failures came with NO successful persist in the same window, so a
+        # transient conflict that the next fetch fixes stays silent, and a cache that is genuinely
+        # not being written does not. A refreshInterval longer than 24h makes this silent rather
+        # than wrong — nothing was attempted, so nothing is claimed.
         - alert: NTNOMMCachePersistFailing
-          expr: increase(ntn_operators_omm_cache_persist_total{result!="success"}[30m]) > 0
-          for: 30m
+          expr: |-
+            sum by (namespace, ephemeris, result) (increase(ntn_operators_omm_cache_persist_total{result!="success"}[24h])) > 0
+            unless on (namespace, ephemeris)
+            sum by (namespace, ephemeris) (increase(ntn_operators_omm_cache_persist_total{result="success"}[24h])) > 0
           labels:
             severity: warning
           annotations:
             summary: "Durable OMM cache is not being written for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
-            description: "Durable OMM cache writes have been failing for 30m (result={{`{{ $labels.result }}`}}). Live propagation is unaffected, but a restart or leader failover will have no last-good element set to fall back on. skipped_oversize means the tracked set exceeds the ConfigMap bound; failed means the write itself is erroring."
+            description: "No successful durable OMM cache write in 24h, and at least one failure ({{`{{ $labels.result }}`}}). Live propagation is unaffected, but a restart or leader failover has no last-good element set to fall back on. failed: the write itself is erroring (RBAC, quota, apiserver). skipped_oversize: the tracked set exceeds the ConfigMap bound — narrow spec.satellites.noradIDs. skipped_marshal: treat as a bug."
         # A restore that is refused is worse than one that never happens: the object is there and
         # does not check out. Scoped to the CORRUPTION reasons on purpose — restore runs on every
         # reconcile while the in-memory cache is cold, so a legitimate delete/recreate whose old

--- a/dist/chart/templates/monitoring/prometheusrule.yaml
+++ b/dist/chart/templates/monitoring/prometheusrule.yaml
@@ -140,4 +140,27 @@ spec:
           annotations:
             summary: "Ephemeris fan-out mapper indexed lookup is erroring"
             description: "The SatelliteEphemeris->NTNCellConfig mapper's spec.ephemerisRef index lookup has failed in the last 15m (cache/index anomaly, not a missing index). Cells re-resolve on their own requeue, but a sustained rate means the informer cache is unhealthy. See the controller Error log for the affected namespace/ephemeris."
+        # ADR-0007: persisting the last-good OMM set is deliberately best-effort — a failure must
+        # not fail live reconciliation. That is precisely why it needs an alert: without one the
+        # cache can be failing to write for weeks and the first symptom is a restart with nothing
+        # to propagate, during the upstream outage the cache exists for. One blip is expected
+        # (conflict, transient apiserver error); sustained failure means restart continuity is gone.
+        - alert: NTNOMMCachePersistFailing
+          expr: increase(ntn_operators_omm_cache_persist_total{result!="success"}[30m]) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Durable OMM cache is not being written for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
+            description: "Durable OMM cache writes have been failing for 30m (result={{`{{ $labels.result }}`}}). Live propagation is unaffected, but a restart or leader failover will have no last-good element set to fall back on. skipped_oversize means the tracked set exceeds the ConfigMap bound; failed means the write itself is erroring."
+        # A restore that is refused is worse than one that never happens: the object is there, and
+        # something about it does not check out. refused_identity on the legacy name is how a
+        # pre-ADR-0007 truncation collision surfaces; refused_digest means corruption or a hand edit.
+        - alert: NTNOMMCacheRestoreRefused
+          expr: increase(ntn_operators_omm_cache_restore_total{result=~"refused_.*"}[1h]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "Durable OMM cache restore refused for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.ephemeris }}`}}"
+            description: "A persisted OMM cache was found but refused ({{`{{ $labels.result }}`}}). The cold start had to proceed without it. refused_identity: the object belongs to a different CR generation or source (under the legacy name, a truncation collision); refused_digest: corrupt or hand-edited payload; refused_parse: the stored element set no longer validates."
 {{- end }}

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ Governance is machine-checked:
 | [0003](0003-nephio-integration.md) | Distribute CRDs and examples as Nephio kpt packages | accepted | — | #164 |
 | [0005](0005-cluster-orchestration.md) | Place `ntn-operators` above provider-native per-cell control | accepted | — | #162 · impl #177/#189 |
 | [0006](0006-decouple-propagation-from-pass-prediction.md) | Decouple propagation heartbeat from pass prediction | accepted | — | #234 · impl #256 |
-| [0007](0007-durable-omm-cache.md) | Durable last-good OMM cache for restart and leader failover | accepted | — | hash-name migration follow-up |
+| [0007](0007-durable-omm-cache.md) | Durable last-good OMM cache for restart and leader failover | accepted | — | impl #345 (hashed name, legacy adoption, metrics) · storage-mode follow-up |
 | [0008](0008-constellation-pool-availability.md) | Model satellite-path contact opportunity at constellation-pool level | accepted | — | slice-to-cell binding follow-up |
 | [0009](0009-remote-control-credential-boundary.md) | Layered authorization boundary for remote-control credentials | accepted | superseded-in-part by **0011** | #251, #299 |
 | [0010](0010-v1alpha2-secure-defaults-and-duration-validation.md) | v1alpha2 secure-by-default transport and duration admission validation | proposed | — | #214, #315, #311, #299 |

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -484,22 +484,29 @@ sum by (namespace, ephemeris, result) (increase(ntn_operators_omm_cache_persist_
 
 ## NTNOMMCacheRestoreRefused
 
-**Fires when** `increase(ntn_operators_omm_cache_restore_total{result=~"refused_.*"}[1h]) > 0`.
+**Fires when** `increase(ntn_operators_omm_cache_restore_total{result=~"refused_digest|refused_parse"}[1h]) > 0`.
 Labels: `namespace`, `ephemeris`, `result`.
 
-**Impact.** A persisted cache **was found and rejected**, so the cold start proceeded
-without it. That is strictly worse than having no cache: something wrote an object
-that does not check out. A plain miss is deliberately not counted — every first-ever
-reconcile misses — so every sample here is a real refusal.
+**`refused_identity` is deliberately excluded.** Restore runs on *every* reconcile while
+the in-memory cache is cold, so a legitimate delete/recreate whose old cache object
+still exists increments that counter once per reconcile until the first successful
+fetch — and during the upstream outage this feature exists for, that is a lot of
+reconciles. An alert on it would fire hardest precisely when the operator is behaving
+correctly. Query it instead:
+
+```promql
+# Sustained across many cold reconciles, under the LEGACY name, is the pre-ADR-0007
+# truncation collision. A burst right after a delete/recreate is expected.
+sum by (namespace, ephemeris) (increase(ntn_operators_omm_cache_restore_total{result="refused_identity"}[6h]))
+```
+
+**Impact.** A persisted cache **was found and its payload rejected**, so the cold start
+proceeded without it. Something wrote an object that does not check out. A plain miss
+is deliberately not counted — every first-ever reconcile misses — so every sample here
+is a real refusal.
 
 **Diagnose by `result`.**
 
-- `refused_identity` — the object's owner UID or fetch identity does not match the
-  live CR. Expected exactly once after a delete/recreate or a `spec.source` edit, and
-  then never again. **Sustained, under the legacy name, this is a pre-ADR-0007
-  truncation collision**: two SatelliteEphemeris objects sharing a 243-character name
-  prefix mapped onto one ConfigMap, and the loser could never persist. The hashed name
-  fixes new writes; confirm with the object list below.
 - `refused_digest` — the stored payload does not match its recorded SHA-256. Corrupt,
   truncated, or hand-edited. Never restored, by design.
 - `refused_parse` — the payload no longer validates as an OMM set (upstream schema
@@ -511,12 +518,11 @@ kubectl get cm -n <ns> -l ntn.operators.dev/omm-cache=true \
   -o custom-columns=NAME:.metadata.name,OWNER-UID:.metadata.annotations.ntn\.operators\.dev/omm-owner-uid
 ```
 
-**Mitigate.** No action is needed for a one-off after a delete/recreate — the next
-successful fetch rewrites the cache under the hashed name. For `refused_digest` or
-`refused_parse`, delete the offending ConfigMap and let the next fetch repersist. For
-sustained `refused_identity`, check for two CRs with a shared long name prefix; after
-this release each gets a distinct hashed name, so the collision clears on the next
-persist.
+**Mitigate.** Delete the offending ConfigMap and let the next fetch repersist — the
+payload is unusable either way, and nothing else reads it. For sustained
+`refused_identity` (not alerted, see above), check for two CRs sharing a long name
+prefix; after this release each gets a distinct hashed name, so the collision clears on
+the next persist.
 
 ---
 

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -443,8 +443,23 @@ if the rate persists across a restart.
 
 ## NTNOMMCachePersistFailing
 
-**Fires when** `increase(ntn_operators_omm_cache_persist_total{result!="success"}[30m]) > 0`
-for 30m. Labels: `namespace`, `ephemeris`, `result`.
+**Fires when** there has been **no successful** durable-cache write in 24h *and* at
+least one failure in the same window. Labels: `namespace`, `ephemeris`, `result`.
+
+```promql
+sum by (namespace, ephemeris, result) (increase(ntn_operators_omm_cache_persist_total{result!="success"}[24h])) > 0
+unless on (namespace, ephemeris)
+sum by (namespace, ephemeris) (increase(ntn_operators_omm_cache_persist_total{result="success"}[24h])) > 0
+```
+
+**Why 24h, and why `unless`.** Persist runs once per successful *fetch*, and
+`refreshInterval` defaults to **4h** with a **2h** floor — so any window measured in
+minutes usually contains no persist attempt at all and would report "no failures" from
+having observed nothing. The `unless` clause is what makes this a statement about the
+*cache* rather than about one write: a transient conflict the next fetch fixes stays
+silent; a cache that is genuinely not being written does not. A `refreshInterval` above
+24h makes this alert silent rather than wrong — nothing was attempted, so nothing is
+claimed.
 
 **Impact.** None right now — and that is the point. Persisting the last-good OMM set
 is best-effort by design (ADR-0007): a write failure must never fail live

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -441,6 +441,85 @@ if the rate persists across a restart.
 
 ---
 
+## NTNOMMCachePersistFailing
+
+**Fires when** `increase(ntn_operators_omm_cache_persist_total{result!="success"}[30m]) > 0`
+for 30m. Labels: `namespace`, `ephemeris`, `result`.
+
+**Impact.** None right now — and that is the point. Persisting the last-good OMM set
+is best-effort by design (ADR-0007): a write failure must never fail live
+reconciliation, so nothing degrades while the process stays up. The cost is
+deferred: on the next restart or leader failover the controller has **no last-good
+element set to fall back on**, so a concurrent upstream outage means propagation
+stops as soon as the last pushed epoch expires. This alert exists because that
+failure mode is otherwise invisible until the moment it hurts.
+
+**Diagnose.**
+
+```bash
+kubectl logs -l control-plane=controller-manager -n ntn-operators-system --tail=-1 --since=40m \
+  | grep 'omm-cache:'
+```
+
+```promql
+# Which outcome?  failed | skipped_oversize | skipped_marshal
+sum by (namespace, ephemeris, result) (increase(ntn_operators_omm_cache_persist_total{result!="success"}[30m]))
+```
+
+**Mitigate by `result`.**
+
+- `failed` — the ConfigMap write itself is erroring. Check RBAC (`get;create;update`
+  on configmaps), the namespace's ResourceQuota for ConfigMap count, and apiserver
+  health. The controller holds no `delete` verb by design; a leftover object is
+  garbage-collected with its owner CR.
+- `skipped_oversize` — the tracked OMM set exceeds the ~900 KiB bound under the 1 MiB
+  ConfigMap limit. Narrow `spec.satellites.noradIDs` so the persisted set is the one
+  actually propagated. The in-memory cache is unaffected; only restart continuity is.
+- `skipped_marshal` — a payload that will not serialize. Treat as a bug and capture
+  the log line.
+
+**Escalate** to the platform owner if `failed` persists across a controller restart.
+
+---
+
+## NTNOMMCacheRestoreRefused
+
+**Fires when** `increase(ntn_operators_omm_cache_restore_total{result=~"refused_.*"}[1h]) > 0`.
+Labels: `namespace`, `ephemeris`, `result`.
+
+**Impact.** A persisted cache **was found and rejected**, so the cold start proceeded
+without it. That is strictly worse than having no cache: something wrote an object
+that does not check out. A plain miss is deliberately not counted — every first-ever
+reconcile misses — so every sample here is a real refusal.
+
+**Diagnose by `result`.**
+
+- `refused_identity` — the object's owner UID or fetch identity does not match the
+  live CR. Expected exactly once after a delete/recreate or a `spec.source` edit, and
+  then never again. **Sustained, under the legacy name, this is a pre-ADR-0007
+  truncation collision**: two SatelliteEphemeris objects sharing a 243-character name
+  prefix mapped onto one ConfigMap, and the loser could never persist. The hashed name
+  fixes new writes; confirm with the object list below.
+- `refused_digest` — the stored payload does not match its recorded SHA-256. Corrupt,
+  truncated, or hand-edited. Never restored, by design.
+- `refused_parse` — the payload no longer validates as an OMM set (upstream schema
+  change, or a partially written object).
+
+```bash
+# Which cache objects exist for this CR, and who owns them?
+kubectl get cm -n <ns> -l ntn.operators.dev/omm-cache=true \
+  -o custom-columns=NAME:.metadata.name,OWNER-UID:.metadata.annotations.ntn\.operators\.dev/omm-owner-uid
+```
+
+**Mitigate.** No action is needed for a one-off after a delete/recreate — the next
+successful fetch rewrites the cache under the hashed name. For `refused_digest` or
+`refused_parse`, delete the offending ConfigMap and let the next fetch repersist. For
+sustained `refused_identity`, check for two CRs with a shared long name prefix; after
+this release each gets a distinct hashed name, so the collision clears on the next
+persist.
+
+---
+
 ## See also
 
 - [`e2e-prometheus-metrics.md`](e2e-prometheus-metrics.md) — wiring an NTNSlice

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -503,11 +503,12 @@ sum by (namespace, ephemeris, result) (increase(ntn_operators_omm_cache_persist_
 Labels: `namespace`, `ephemeris`, `result`.
 
 **`refused_identity` is deliberately excluded.** Restore runs on *every* reconcile while
-the in-memory cache is cold, so a legitimate delete/recreate whose old cache object
-still exists increments that counter once per reconcile until the first successful
-fetch — and during the upstream outage this feature exists for, that is a lot of
-reconciles. An alert on it would fire hardest precisely when the operator is behaving
-correctly. Query it instead:
+the in-memory cache is cold, so two ordinary operations increment it once per reconcile
+until the first successful fetch: a delete/recreate whose old cache object still exists,
+and **any `spec.source` edit** — the persisted object still carries the previous source's
+fetch identity, and is correctly refused until the next fetch overwrites it. During the
+upstream outage this feature exists for, that is a lot of reconciles. An alert on it
+would fire hardest precisely when the operator is behaving correctly. Query it instead:
 
 ```promql
 # Sustained across many cold reconciles, under the LEGACY name, is the pre-ADR-0007

--- a/internal/controller/metric_cleanup_test.go
+++ b/internal/controller/metric_cleanup_test.go
@@ -48,14 +48,8 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 		t.Fatalf("AddToScheme: %v", err)
 	}
 
-	// Seed per-CR series, as a live reconcile would (keyed by namespace+ephemeris).
-	del := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph"}
-	persistLbl := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph", "result": "success"}
-	restoreLbl := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph", "result": "hydrated"}
-	ntnmetrics.GPSatelliteCount.With(del).Set(7)
-	ntnmetrics.OMMCachePersistTotal.With(persistLbl).Inc()
-	ntnmetrics.OMMCacheRestoreTotal.With(restoreLbl).Inc()
-	ntnmetrics.OMMCacheRestoredAgeSeconds.With(del).Set(120)
+	// Seed a per-CR series, as a live reconcile would (keyed by namespace+name).
+	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph"}).Set(7)
 	before := testutil.CollectAndCount(ntnmetrics.GPSatelliteCount)
 
 	// Empty client → Get returns NotFound (the CR is "deleted").
@@ -75,16 +69,6 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 	if after != before-1 {
 		t.Errorf("deleted CR's metric series was not released: series count before=%d after=%d (want after=before-1)",
 			before, after)
-	}
-	// The OMM-cache series must be released too, or they leak for every deleted CR.
-	if got := testutil.ToFloat64(ntnmetrics.OMMCachePersistTotal.With(persistLbl)); got != 0 {
-		t.Errorf("OMMCachePersistTotal not released on delete: got %v", got)
-	}
-	if got := testutil.ToFloat64(ntnmetrics.OMMCacheRestoreTotal.With(restoreLbl)); got != 0 {
-		t.Errorf("OMMCacheRestoreTotal not released on delete: got %v", got)
-	}
-	if got := testutil.ToFloat64(ntnmetrics.OMMCacheRestoredAgeSeconds.With(del)); got != 0 {
-		t.Errorf("OMMCacheRestoredAgeSeconds not released on delete: got %v", got)
 	}
 }
 
@@ -508,5 +492,52 @@ func TestEphemerisEpochStaleCount_WriteDeleteRoundTrip(t *testing.T) {
 	}
 	if afterDelete := testutil.CollectAndCount(ntnmetrics.EphemerisEpochStaleCount); afterDelete != base {
 		t.Errorf("stale series leaked (write/delete key drift): base=%d afterDelete=%d", base, afterDelete)
+	}
+}
+
+// TestSatelliteEphemerisReconcile_DeletedReleasesOMMCacheSeries extends the same rule to the
+// durable-cache metrics. They are per-CR (namespace+ephemeris), so without this they accumulate
+// dead series across create/delete churn — and the restored-age gauge would keep reporting an age
+// for a CR that no longer exists, which reads as a stale cache rather than as no cache.
+func TestSatelliteEphemerisReconcile_DeletedReleasesOMMCacheSeries(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ntnv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	gone := prometheus.Labels{"namespace": "ns", "ephemeris": "gone-eph"}
+	stays := prometheus.Labels{"namespace": "other", "ephemeris": "gone-eph"}
+	ntnmetrics.OMMCachePersistTotal.With(prometheus.Labels{"namespace": "ns", "ephemeris": "gone-eph", "result": "success"}).Inc()
+	ntnmetrics.OMMCacheRestoreTotal.With(prometheus.Labels{"namespace": "ns", "ephemeris": "gone-eph", "result": "hydrated"}).Inc()
+	ntnmetrics.OMMCacheRestoredAgeSeconds.With(gone).Set(3600)
+	ntnmetrics.OMMCacheRestoredAgeSeconds.With(stays).Set(1800) // same name, different namespace
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SatelliteEphemerisReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "gone-eph", Namespace: "ns"},
+	}); err != nil {
+		t.Fatalf("reconcile of deleted CR should not error: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		got  func() (float64, bool)
+	}{
+		{"persist", func() (float64, bool) {
+			return counterValue(t, ntnmetrics.OMMCachePersistTotal,
+				prometheus.Labels{"namespace": "ns", "ephemeris": "gone-eph", "result": "success"})
+		}},
+		{"restore", func() (float64, bool) {
+			return counterValue(t, ntnmetrics.OMMCacheRestoreTotal,
+				prometheus.Labels{"namespace": "ns", "ephemeris": "gone-eph", "result": "hydrated"})
+		}},
+		{"restored-age", func() (float64, bool) { return gaugeValue(t, ntnmetrics.OMMCacheRestoredAgeSeconds, gone) }},
+	} {
+		if _, found := tc.got(); found {
+			t.Errorf("%s series survived the CR's deletion", tc.name)
+		}
+	}
+	if _, found := gaugeValue(t, ntnmetrics.OMMCacheRestoredAgeSeconds, stays); !found {
+		t.Error("deleting one CR wiped a same-named CR's series in another namespace (#180 regression)")
 	}
 }

--- a/internal/controller/metric_cleanup_test.go
+++ b/internal/controller/metric_cleanup_test.go
@@ -48,8 +48,14 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 		t.Fatalf("AddToScheme: %v", err)
 	}
 
-	// Seed a per-CR series, as a live reconcile would (keyed by namespace+name).
-	ntnmetrics.GPSatelliteCount.With(prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph"}).Set(7)
+	// Seed per-CR series, as a live reconcile would (keyed by namespace+ephemeris).
+	del := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph"}
+	persistLbl := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph", "result": "success"}
+	restoreLbl := prometheus.Labels{"namespace": "ns", "ephemeris": "deleted-eph", "result": "hydrated"}
+	ntnmetrics.GPSatelliteCount.With(del).Set(7)
+	ntnmetrics.OMMCachePersistTotal.With(persistLbl).Inc()
+	ntnmetrics.OMMCacheRestoreTotal.With(restoreLbl).Inc()
+	ntnmetrics.OMMCacheRestoredAgeSeconds.With(del).Set(120)
 	before := testutil.CollectAndCount(ntnmetrics.GPSatelliteCount)
 
 	// Empty client → Get returns NotFound (the CR is "deleted").
@@ -69,6 +75,16 @@ func TestSatelliteEphemerisReconcile_DeletedReleasesMetricSeries(t *testing.T) {
 	if after != before-1 {
 		t.Errorf("deleted CR's metric series was not released: series count before=%d after=%d (want after=before-1)",
 			before, after)
+	}
+	// The OMM-cache series must be released too, or they leak for every deleted CR.
+	if got := testutil.ToFloat64(ntnmetrics.OMMCachePersistTotal.With(persistLbl)); got != 0 {
+		t.Errorf("OMMCachePersistTotal not released on delete: got %v", got)
+	}
+	if got := testutil.ToFloat64(ntnmetrics.OMMCacheRestoreTotal.With(restoreLbl)); got != 0 {
+		t.Errorf("OMMCacheRestoreTotal not released on delete: got %v", got)
+	}
+	if got := testutil.ToFloat64(ntnmetrics.OMMCacheRestoredAgeSeconds.With(del)); got != 0 {
+		t.Errorf("OMMCacheRestoredAgeSeconds not released on delete: got %v", got)
 	}
 }
 

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -215,6 +215,9 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			ntnmetrics.EphemerisEpochStaleCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.EphemerisPropagationFailedCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.GPFetchReady.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.OMMCachePersistTotal.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.OMMCacheRestoreTotal.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.OMMCacheRestoredAgeSeconds.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			r.ommCache.Delete(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/satelliteephemeris_ommcache_etag_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_etag_test.go
@@ -63,7 +63,7 @@ func TestOMMCache_PersistsAndClearsValidators(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
 	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
 	fetchKey := fetchInputKey(eph.Spec)
-	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}
 
 	t0 := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
 	withVal := ommResultAt(t0)

--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -15,7 +15,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -318,12 +317,24 @@ func (r *SatelliteEphemerisReconciler) copyCacheForward(
 	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, legacy *corev1.ConfigMap,
 ) {
 	log := logf.FromContext(ctx)
+	// Copy the annotations this cache defines, not everything the old object happened to carry.
+	// The payload is already bounded at 900 KiB under a 1 MiB object limit, so cloning an
+	// arbitrarily large foreign annotation could push the create over the limit — and the failure
+	// would land in this swallowed best-effort path. Nothing else on a legacy object is meaningful
+	// here anyway.
+	ann := map[string]string{}
+	for _, k := range []string{ommCacheAnnFetchKey, ommCacheAnnFetchedAt, ommCacheAnnDigest,
+		ommCacheAnnUID, ommCacheAnnCount, ommCacheAnnETag, ommCacheAnnLastModified} {
+		if v, ok := legacy.Annotations[k]; ok {
+			ann[k] = v
+		}
+	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   eph.Namespace,
 			Name:        ommCacheConfigMapName(eph),
 			Labels:      map[string]string{ommCacheLabelKey: ommCacheLabelValue},
-			Annotations: maps.Clone(legacy.Annotations),
+			Annotations: ann,
 		},
 		Data: map[string]string{ommCacheDataKey: legacy.Data[ommCacheDataKey]},
 	}

--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -15,7 +15,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/akhenakh/sgp4"
@@ -29,6 +31,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	"github.com/thc1006/ntn-operators/pkg/metrics"
 )
 
 // Durable last-good OMM cache: persists tracked OMMs to a controller-owned ConfigMap so a cold
@@ -54,6 +57,9 @@ const (
 	ommCacheConfigMapSuffix = "-omm-cache"
 	maxOMMCacheBytes        = 900 * 1024 // under the 1 MiB ConfigMap limit; larger sets skip persist
 	maxConfigMapNameLen     = 253
+	// 128 bits, per ADR-0007. Two SatelliteEphemeris objects colliding here is not a scenario
+	// anyone reaches by naming things badly.
+	ommCacheNameHashBytes = 16
 )
 
 // The per-CR cache ConfigMap is owner-ref'd to its SatelliteEphemeris, so k8s garbage-collects it
@@ -69,10 +75,31 @@ func (r *SatelliteEphemerisReconciler) readerOrClient() client.Reader {
 	return r.Client
 }
 
-// ommCacheConfigMapName derives the per-CR cache ConfigMap name, bounded to the k8s name limit.
-// Names over the limit are truncated; the restore path UID-gates, so a (pathological) truncation
-// collision between two >243-char names never restores wrong data — see ADR-0007.
-func ommCacheConfigMapName(ephName string) string {
+// ommCacheConfigMapName derives a collision-resistant name — <readable prefix>-<128-bit
+// hash>-omm-cache, keyed on namespace/name/UID (ADR-0007).
+//
+// The previous scheme truncated the CR name to fit 253 chars, which maps every
+// SatelliteEphemeris sharing a 243-character prefix onto ONE ConfigMap. The UID annotation stops
+// a wrong RESTORE, but it does not stop the contention: the losers keep overwriting an object
+// whose UID then refuses their own restore, so their restart continuity is gone with nothing in
+// the status or logs to say so. Availability bug, not cosmetic.
+//
+// Hashing the UID in also means a delete/recreate lands on a different object rather than
+// inheriting the predecessor's — the annotation gate stays as defense in depth.
+func ommCacheConfigMapName(eph *ntnv1alpha1.SatelliteEphemeris) string {
+	sum := sha256.Sum256([]byte(eph.Namespace + "/" + eph.Name + "/" + string(eph.UID)))
+	h := hex.EncodeToString(sum[:ommCacheNameHashBytes])
+	prefix := eph.Name
+	if room := maxConfigMapNameLen - len(ommCacheConfigMapSuffix) - len(h) - 1; len(prefix) > room {
+		// Trim separators the cut may have exposed: a label may not start with "-" or ".".
+		prefix = strings.TrimRight(prefix[:room], "-.")
+	}
+	return prefix + "-" + h + ommCacheConfigMapSuffix
+}
+
+// legacyOMMCacheConfigMapName is the pre-ADR-0007 name. Read once on restore so an upgrade does
+// not throw away a cache that is still valid; never written.
+func legacyOMMCacheConfigMapName(ephName string) string {
 	if len(ephName)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
 		ephName = ephName[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
 	}
@@ -112,15 +139,17 @@ func (r *SatelliteEphemerisReconciler) persistOMMCache(
 	data, err := json.Marshal(omms)
 	if err != nil {
 		log.V(1).Info("omm-cache: marshal failed; skipping persist", "err", err.Error())
+		metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "skipped_marshal").Inc()
 		return
 	}
 	if len(data) > maxOMMCacheBytes {
 		log.Info("omm-cache: payload over bound; skipping restart-continuity persist (warm cache unaffected)",
 			"bytes", len(data), "satellites", len(omms))
+		metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "skipped_oversize").Inc()
 		return
 	}
 	digest := ommDigest(data)
-	key := client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	key := client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}
 
 	// Read uncached (APIReader) so configmaps get suffices and we do not start an informer that
 	// caches every ConfigMap in the cluster; writes still go through the cached client. Mirrors
@@ -138,9 +167,13 @@ func (r *SatelliteEphemerisReconciler) persistOMMCache(
 		}
 		if err := r.Create(ctx, cm); err != nil && !apierrors.IsAlreadyExists(err) {
 			log.V(1).Info("omm-cache: create failed; skipping persist", "err", err.Error())
+			metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "failed").Inc()
+			return
 		}
+		metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "success").Inc()
 	case getErr != nil:
 		log.V(1).Info("omm-cache: get failed; skipping persist", "err", getErr.Error())
+		metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "failed").Inc()
 	default:
 		if cm.Annotations[ommCacheAnnDigest] == digest && cm.Data[ommCacheDataKey] != "" {
 			return // unchanged
@@ -149,7 +182,10 @@ func (r *SatelliteEphemerisReconciler) persistOMMCache(
 		_ = controllerutil.SetControllerReference(eph, cm, r.Scheme) // adopt for GC if pre-existing
 		if err := r.Update(ctx, cm); err != nil {
 			log.V(1).Info("omm-cache: update failed; skipping persist", "err", err.Error())
+			metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "failed").Inc()
+			return
 		}
+		metrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "success").Inc()
 	}
 }
 
@@ -186,31 +222,52 @@ func setOrClearAnn(ann map[string]string, key, val string) {
 // identity (fetchKey) and owner UID match the live object, so a source edit or delete-recreate
 // never restores wrong/orphaned data. The entry keeps its ORIGINAL FetchedAt, so the normal
 // window/backoff/freshness gates still apply — restore removes the cold-start cliff, nothing more.
+// The ADR-0007 name is tried first, then the pre-ADR one, so an upgrade keeps its cache.
 func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 	ctx context.Context, req ctrl.Request, eph *ntnv1alpha1.SatelliteEphemeris, fetchKey string,
 ) bool {
-	log := logf.FromContext(ctx)
 	if _, ok := r.cachedOMMResult(req.NamespacedName); ok {
 		return false // already warm
 	}
+	if r.hydrateFromCacheObject(ctx, req, eph, fetchKey, ommCacheConfigMapName(eph), false) {
+		return true
+	}
+	// Nothing under the ADR-0007 name. An upgraded operator still has a perfectly good cache
+	// under the old one, and discarding it would cost exactly the outage continuity this feature
+	// exists for. Read it once; the next persist writes the new name.
+	return r.hydrateFromCacheObject(ctx, req, eph, fetchKey, legacyOMMCacheConfigMapName(eph.Name), true)
+}
+
+// hydrateFromCacheObject validates one candidate ConfigMap and, if it passes every gate, loads it
+// into the in-memory cache. Same gates for both names — a legacy object gets no easier ride.
+func (r *SatelliteEphemerisReconciler) hydrateFromCacheObject(
+	ctx context.Context, req ctrl.Request, eph *ntnv1alpha1.SatelliteEphemeris, fetchKey, name string, legacy bool,
+) bool {
+	log := logf.FromContext(ctx)
+	ns, ephName := eph.Namespace, eph.Name
 	cm := &corev1.ConfigMap{}
-	if err := r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
-		return false
+	if err := r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, cm); err != nil {
+		return false // absent is the normal cold-start case, not a refusal
 	}
 	data := cm.Data[ommCacheDataKey]
 	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue || data == "" {
 		return false
 	}
 	if cm.Annotations[ommCacheAnnDigest] != ommDigest([]byte(data)) {
-		log.Info("omm-cache: digest mismatch; ignoring (corrupt or hand-edited)")
+		log.Info("omm-cache: digest mismatch; ignoring (corrupt or hand-edited)", "configmap", name)
+		metrics.OMMCacheRestoreTotal.WithLabelValues(ns, ephName, "refused_digest").Inc()
 		return false
 	}
 	if cm.Annotations[ommCacheAnnUID] != string(eph.UID) || cm.Annotations[ommCacheAnnFetchKey] != fetchKey {
-		return false // orphaned by delete-recreate, or a different source — do not restore
+		// Orphaned by delete-recreate, or a different source. Under the legacy name this is also
+		// how a truncation collision surfaces, so it is worth counting rather than dropping.
+		metrics.OMMCacheRestoreTotal.WithLabelValues(ns, ephName, "refused_identity").Inc()
+		return false
 	}
 	omms, err := ephemeris.ParseValidOMMs(log, []byte(data))
 	if err != nil || len(omms) == 0 {
 		log.V(1).Info("omm-cache: payload unparseable or fully invalid; ignoring", "err", err)
+		metrics.OMMCacheRestoreTotal.WithLabelValues(ns, ephName, "refused_parse").Inc()
 		return false
 	}
 	// Unknown fetch time → zero, i.e. very old, so the next reconcile fetches and only serves
@@ -231,8 +288,49 @@ func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 				cm.Annotations[ommCacheAnnETag], cm.Annotations[ommCacheAnnLastModified])
 		}
 	}
-	log.Info("omm-cache: hydrated last-good OMMs after cold start", "satellites", len(omms))
+	if !fetchedAt.IsZero() {
+		metrics.OMMCacheRestoredAgeSeconds.WithLabelValues(ns, ephName).Set(time.Since(fetchedAt).Seconds())
+	}
+	result := "hydrated"
+	if legacy {
+		result = "migrated"
+		// Copy it forward now rather than waiting for the next fetch (~2 h), so a second restart
+		// in between is not back to a cold start. The legacy object is left alone: the controller
+		// holds no delete verb, and its owner reference garbage-collects it with the CR.
+		r.copyCacheForward(ctx, eph, cm)
+	}
+	metrics.OMMCacheRestoreTotal.WithLabelValues(ns, ephName, result).Inc()
+	log.Info("omm-cache: hydrated last-good OMMs after cold start",
+		"satellites", len(omms), "configmap", name, "migrated", legacy)
 	return true
+}
+
+// copyCacheForward writes a legacy-named cache object's contents under the ADR-0007 name.
+// Best-effort: failing here costs one fetch cycle, not correctness.
+func (r *SatelliteEphemerisReconciler) copyCacheForward(
+	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, legacy *corev1.ConfigMap,
+) {
+	log := logf.FromContext(ctx)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   eph.Namespace,
+			Name:        ommCacheConfigMapName(eph),
+			Labels:      map[string]string{ommCacheLabelKey: ommCacheLabelValue},
+			Annotations: maps.Clone(legacy.Annotations),
+		},
+		Data: map[string]string{ommCacheDataKey: legacy.Data[ommCacheDataKey]},
+	}
+	if err := controllerutil.SetControllerReference(eph, cm, r.Scheme); err != nil {
+		log.V(1).Info("omm-cache: owner ref failed; leaving the legacy object in place", "err", err.Error())
+		return
+	}
+	if err := r.Create(ctx, cm); err != nil && !apierrors.IsAlreadyExists(err) {
+		log.V(1).Info("omm-cache: migrating to the hashed name failed; retrying on the next persist",
+			"err", err.Error())
+		return
+	}
+	log.Info("omm-cache: migrated to the collision-resistant name (ADR-0007)",
+		"from", legacy.Name, "to", cm.Name)
 }
 
 // conditionalCacheSeeder is implemented by a GPFetcher that can restore cache validators

--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -97,8 +97,9 @@ func ommCacheConfigMapName(eph *ntnv1alpha1.SatelliteEphemeris) string {
 	return prefix + "-" + h + ommCacheConfigMapSuffix
 }
 
-// legacyOMMCacheConfigMapName is the pre-ADR-0007 name. Read once on restore so an upgrade does
-// not throw away a cache that is still valid; never written.
+// legacyOMMCacheConfigMapName is the pre-ADR-0007 name: read on restore so an upgrade does not
+// throw away a cache that is still valid, never written. Nothing creates these any more, so the
+// only ones in existence predate the upgrade.
 func legacyOMMCacheConfigMapName(ephName string) string {
 	if len(ephName)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
 		ephName = ephName[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
@@ -232,9 +233,15 @@ func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 	if r.hydrateFromCacheObject(ctx, req, eph, fetchKey, ommCacheConfigMapName(eph), false) {
 		return true
 	}
-	// Nothing under the ADR-0007 name. An upgraded operator still has a perfectly good cache
-	// under the old one, and discarding it would cost exactly the outage continuity this feature
-	// exists for. Read it once; the next persist writes the new name.
+	// Nothing usable under the ADR-0007 name. An upgraded operator still has a perfectly good
+	// cache under the old one, and discarding it would cost exactly the outage continuity this
+	// feature exists for.
+	//
+	// This costs a second uncached GET per reconcile that runs cold, which is deliberate: the
+	// window is process-start to the first successful fetch, and the only way to hold it open is
+	// for fetches to keep failing — by which point one ConfigMap GET is noise next to the failing
+	// HTTP fetch beside it. Caching "no legacy object here" would trade that for state to get
+	// wrong.
 	return r.hydrateFromCacheObject(ctx, req, eph, fetchKey, legacyOMMCacheConfigMapName(eph.Name), true)
 }
 

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -287,9 +287,19 @@ func TestOMMCache_PersistSkipsOversizePayload(t *testing.T) {
 // landed on ONE ConfigMap: the UID annotation stopped a wrong restore, but the losers kept
 // overwriting an object their own restore then refused, silently losing restart continuity.
 func TestOMMCache_ConfigMapNameIsCollisionResistant(t *testing.T) {
-	long := strings.Repeat("x", 260) // legal: names are bounded at 253, this is the truncating case
-	a := newOMMCacheEph(long+"-alpha", "uid-a")
-	b := newOMMCacheEph(long+"-bravo", "uid-b")
+	// 250 chars: a name the apiserver ACCEPTS (DNS-1123 subdomain caps at 253) that is still long
+	// enough to truncate, since the legacy scheme cut at 253-len("-omm-cache") = 243. Using a
+	// 266-char name here would prove the property for an object that can never exist, and would
+	// make the bug read as theoretical when it is reachable with a perfectly valid CR.
+	stem := strings.Repeat("x", 244)
+	a := newOMMCacheEph(stem+"-alpha", "uid-a")
+	b := newOMMCacheEph(stem+"-bravo", "uid-b")
+	for _, eph := range []*ntnv1alpha1.SatelliteEphemeris{a, b} {
+		if errs := validation.IsDNS1123Subdomain(eph.Name); len(errs) > 0 {
+			t.Fatalf("this test's own CR name %d chars is not a legal object name (%v) — the collision "+
+				"it demonstrates would be unreachable in production", len(eph.Name), errs)
+		}
+	}
 
 	if legacyOMMCacheConfigMapName(a.Name) != legacyOMMCacheConfigMapName(b.Name) {
 		t.Fatal("the legacy scheme no longer collides on these inputs, so this test proves nothing " +
@@ -312,7 +322,7 @@ func TestOMMCache_ConfigMapNameIsCollisionResistant(t *testing.T) {
 	}
 
 	for _, eph := range []*ntnv1alpha1.SatelliteEphemeris{a, b, newOMMCacheEph("eph-a", "uid-s"),
-		newOMMCacheEph(strings.Repeat("y", 242)+".", "uid-dot")} {
+		newOMMCacheEph(strings.Repeat("y", 242)+".z", "uid-dot")} {
 		name := ommCacheConfigMapName(eph)
 		if len(name) > maxConfigMapNameLen {
 			t.Errorf("name for %q is %d chars, over the %d limit", eph.Name, len(name), maxConfigMapNameLen)
@@ -509,6 +519,19 @@ func TestOMMCache_MigratesFromLegacyName(t *testing.T) {
 		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"}); !ok || after != before+1 {
 		t.Errorf("migrated counter %v -> %v (found=%v); a silent migration is one nobody can audit",
 			before, after, ok)
+	}
+
+	// The migrated object must stand on its own. Copying the payload without every annotation the
+	// restore gates read would produce an object that looks migrated and is then refused on the
+	// NEXT cold start — the migration would have moved the data and lost the ability to use it,
+	// and the legacy object it superseded is the only reason that would not be fatal.
+	r.ommCache.Delete(key)
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatal("the migrated object is not restorable on its own")
+	}
+	if now, _ := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"}); now != before+1 {
+		t.Error("the second restore migrated again; it should have hydrated from the object just written")
 	}
 }
 

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -539,3 +539,62 @@ func TestOMMCache_LegacyNameStillIdentityGated(t *testing.T) {
 		t.Errorf("refused_identity counter %v -> %v (found=%v)", before, after, ok)
 	}
 }
+
+// TestOMMCache_MigrationLeavesLegacyObject locks the claim made in the changelog and the runbook:
+// the controller never deletes the legacy object. It holds no `delete` verb on configmaps, so
+// code that tried would fail at runtime in a path whose errors are deliberately swallowed —
+// silently, on the exact upgrade this migration exists to make safe. The owner reference is what
+// removes it, together with the CR.
+func TestOMMCache_MigrationLeavesLegacyObject(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-keep", "uid-keep")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	fetchKey := fetchInputKey(eph.Spec)
+	seedLegacyCache(t, ctx, cli, eph, fetchKey, eph.UID)
+
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}}, eph, fetchKey) {
+		t.Fatal("legacy cache was not restored")
+	}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace,
+		Name: legacyOMMCacheConfigMapName(eph.Name)}, &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("the legacy object was removed; the controller has no delete verb for that: %v", err)
+	}
+}
+
+// TestOMMCache_HashedNameWinsOverLegacy proves precedence. Both objects can exist for one
+// reconcile after an upgrade, and they can disagree: the hashed one is what persist keeps current,
+// so reading the legacy one instead would serve a stale element set and keep serving it.
+func TestOMMCache_HashedNameWinsOverLegacy(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-prec", "uid-prec")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	fetchKey := fetchInputKey(eph.Spec)
+
+	// Legacy holds an old fetch; the hashed name holds a newer one.
+	seedLegacyCache(t, ctx, cli, eph, fetchKey, eph.UID) // fetchedAt = now-90m
+	fresh := time.Now().Add(-5 * time.Minute).UTC().Truncate(time.Millisecond)
+	r.persistOMMCache(ctx, eph, ommResultAt(fresh), fetchKey)
+
+	before, _ := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"})
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatal("restore returned false with a valid hashed-name cache present")
+	}
+	got, ok := r.cachedOMMResult(key)
+	if !ok {
+		t.Fatal("cache still cold")
+	}
+	if !got.result.FetchedAt.Equal(fresh) {
+		t.Errorf("restored FetchedAt = %s, want the hashed-name object's %s — the legacy object won",
+			got.result.FetchedAt, fresh)
+	}
+	if after, _ := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"}); after != before {
+		t.Errorf("counted a migration (%v -> %v) when the hashed name already had the data", before, after)
+	}
+}

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -12,16 +12,20 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +33,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	"github.com/thc1006/ntn-operators/pkg/metrics"
 )
 
 // ommCacheScheme is makeScheme + corev1 (the cache lives in a ConfigMap).
@@ -76,7 +81,7 @@ func TestOMMCache_PersistRestoreRoundTrip(t *testing.T) {
 
 	// The ConfigMap must exist and carry the identity/integrity metadata.
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, cm); err != nil {
 		t.Fatalf("persist did not create the cache ConfigMap: %v", err)
 	}
 	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue {
@@ -158,7 +163,7 @@ func TestOMMCache_RestoreRejectsInvalid(t *testing.T) {
 
 			r.persistOMMCache(ctx, base, ommResultAt(fetchedAt), fetchKey)
 			cm := &corev1.ConfigMap{}
-			cmKey := types.NamespacedName{Namespace: base.Namespace, Name: ommCacheConfigMapName(base.Name)}
+			cmKey := types.NamespacedName{Namespace: base.Namespace, Name: ommCacheConfigMapName(base)}
 			if err := cli.Get(ctx, cmKey, cm); err != nil {
 				t.Fatalf("get cache cm: %v", err)
 			}
@@ -210,7 +215,7 @@ func TestOMMCache_PersistNoopOnIdenticalDigest(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
 	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
 	ctx := context.Background()
-	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}
 	fetchKey := fetchInputKey(eph.Spec)
 
 	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
@@ -242,7 +247,7 @@ func TestOMMCache_PersistSetsOwnerRefForGC(t *testing.T) {
 
 	r.persistOMMCache(ctx, eph, ommResultAt(time.Now().UTC()), fetchInputKey(eph.Spec))
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, cm); err != nil {
 		t.Fatalf("get cm: %v", err)
 	}
 	if len(cm.OwnerReferences) != 1 {
@@ -271,21 +276,50 @@ func TestOMMCache_PersistSkipsOversizePayload(t *testing.T) {
 	r.persistOMMCache(ctx, eph, result, fetchInputKey(eph.Spec))
 
 	cm := &corev1.ConfigMap{}
-	err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm)
+	err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, cm)
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("oversize payload must not create a ConfigMap; got err=%v", err)
 	}
 }
 
-// TestOMMCache_ConfigMapNameTruncation proves the derived name always fits the k8s name limit.
-func TestOMMCache_ConfigMapNameTruncation(t *testing.T) {
-	short := ommCacheConfigMapName("eph-a")
-	if short != "eph-a"+ommCacheConfigMapSuffix {
-		t.Fatalf("short name = %q", short)
+// TestOMMCache_ConfigMapNameIsCollisionResistant is the ADR-0007 name invariant. The previous
+// scheme truncated to fit 253 chars, so every SatelliteEphemeris sharing a 243-character prefix
+// landed on ONE ConfigMap: the UID annotation stopped a wrong restore, but the losers kept
+// overwriting an object their own restore then refused, silently losing restart continuity.
+func TestOMMCache_ConfigMapNameIsCollisionResistant(t *testing.T) {
+	long := strings.Repeat("x", 260) // legal: names are bounded at 253, this is the truncating case
+	a := newOMMCacheEph(long+"-alpha", "uid-a")
+	b := newOMMCacheEph(long+"-bravo", "uid-b")
+
+	if legacyOMMCacheConfigMapName(a.Name) != legacyOMMCacheConfigMapName(b.Name) {
+		t.Fatal("the legacy scheme no longer collides on these inputs, so this test proves nothing " +
+			"about the bug it exists for — pick names that share a 243-character prefix")
 	}
-	long := ommCacheConfigMapName(strings.Repeat("x", 300))
-	if len(long) > maxConfigMapNameLen {
-		t.Fatalf("truncated name len = %d, exceeds %d", len(long), maxConfigMapNameLen)
+	if ommCacheConfigMapName(a) == ommCacheConfigMapName(b) {
+		t.Errorf("two long names still map to one ConfigMap %q: one of them can never persist",
+			ommCacheConfigMapName(a))
+	}
+
+	// Same name, different object: a delete/recreate must not inherit its predecessor's cache.
+	recreated := newOMMCacheEph(a.Name, "uid-a-recreated")
+	if ommCacheConfigMapName(a) == ommCacheConfigMapName(recreated) {
+		t.Error("a recreated CR reuses the old object's name; the UID gate is then the only guard")
+	}
+
+	// Same object, twice: the name has to be stable or restore can never find what persist wrote.
+	if ommCacheConfigMapName(a) != ommCacheConfigMapName(newOMMCacheEph(a.Name, a.UID)) {
+		t.Error("name is not deterministic")
+	}
+
+	for _, eph := range []*ntnv1alpha1.SatelliteEphemeris{a, b, newOMMCacheEph("eph-a", "uid-s"),
+		newOMMCacheEph(strings.Repeat("y", 242)+".", "uid-dot")} {
+		name := ommCacheConfigMapName(eph)
+		if len(name) > maxConfigMapNameLen {
+			t.Errorf("name for %q is %d chars, over the %d limit", eph.Name, len(name), maxConfigMapNameLen)
+		}
+		if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+			t.Errorf("name %q is not a valid object name: %v", name, errs)
+		}
 	}
 }
 
@@ -344,7 +378,7 @@ func TestReconcile_ColdStartRestoresAndPropagatesDuringOutage(t *testing.T) {
 		t.Fatalf("warm phase never contacted upstream")
 	}
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, cm); err != nil {
 		t.Fatalf("warm phase did not persist the cache ConfigMap: %v", err)
 	}
 
@@ -401,4 +435,107 @@ func getResourceVersion(t *testing.T, cli client.Client, key types.NamespacedNam
 		t.Fatalf("get cm %s: %v", key, err)
 	}
 	return cm.ResourceVersion
+}
+
+// seedLegacyCache writes a pre-ADR-0007 (truncated-name) cache object for eph.
+func seedLegacyCache(t *testing.T, ctx context.Context, cli client.Client,
+	eph *ntnv1alpha1.SatelliteEphemeris, fetchKey string, uid types.UID) *corev1.ConfigMap {
+	t.Helper()
+	omms := ommCachePayload(ommResultAt(time.Now().Add(-90*time.Minute)), eph)
+	data, err := json.Marshal(omms)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: eph.Namespace,
+			Name:      legacyOMMCacheConfigMapName(eph.Name),
+			Labels:    map[string]string{ommCacheLabelKey: ommCacheLabelValue},
+			Annotations: map[string]string{
+				ommCacheAnnFetchKey:  fetchKey,
+				ommCacheAnnFetchedAt: time.Now().Add(-90 * time.Minute).UTC().Format(time.RFC3339Nano),
+				ommCacheAnnDigest:    ommDigest(data),
+				ommCacheAnnUID:       string(uid),
+				ommCacheAnnCount:     strconv.Itoa(len(omms)),
+			},
+		},
+		Data: map[string]string{ommCacheDataKey: string(data)},
+	}
+	if err := cli.Create(ctx, cm); err != nil {
+		t.Fatalf("seed legacy cache: %v", err)
+	}
+	return cm
+}
+
+// TestOMMCache_MigratesFromLegacyName proves an upgrade keeps its cache. Renaming the object
+// without reading the old one would discard exactly the outage continuity this feature exists
+// for — and would do it silently, at the worst possible moment (a cold start).
+func TestOMMCache_MigratesFromLegacyName(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-mig", "uid-mig")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	fetchKey := fetchInputKey(eph.Spec)
+	legacy := seedLegacyCache(t, ctx, cli, eph, fetchKey, eph.UID)
+
+	before, _ := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"})
+
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatal("a valid legacy-named cache was not restored; an upgrade loses restart continuity")
+	}
+	if _, ok := r.cachedOMMResult(key); !ok {
+		t.Fatal("restore reported success but the in-memory cache is still cold")
+	}
+
+	// The migration must complete now, not at the next fetch (~2 h away): a second restart in
+	// between would otherwise be back to a cold start.
+	got := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, got); err != nil {
+		t.Fatalf("legacy cache was read but never copied to the hashed name: %v", err)
+	}
+	if got.Data[ommCacheDataKey] != legacy.Data[ommCacheDataKey] {
+		t.Error("migrated payload differs from the legacy one")
+	}
+	if got.Annotations[ommCacheAnnUID] != string(eph.UID) || got.Annotations[ommCacheAnnFetchKey] != fetchKey {
+		t.Error("migrated object lost its identity annotations, so its own restore would refuse it")
+	}
+	if len(got.OwnerReferences) == 0 {
+		t.Error("migrated object has no owner reference; nothing garbage-collects it")
+	}
+	if after, ok := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "migrated"}); !ok || after != before+1 {
+		t.Errorf("migrated counter %v -> %v (found=%v); a silent migration is one nobody can audit",
+			before, after, ok)
+	}
+}
+
+// TestOMMCache_LegacyNameStillIdentityGated proves the legacy name gets no easier ride. Under the
+// old scheme a truncation collision surfaces exactly here: the object exists, but it belongs to a
+// different CR.
+func TestOMMCache_LegacyNameStillIdentityGated(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-gate", "uid-gate")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	fetchKey := fetchInputKey(eph.Spec)
+	seedLegacyCache(t, ctx, cli, eph, fetchKey, "somebody-elses-uid")
+
+	before, _ := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "refused_identity"})
+
+	if r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatal("restored a legacy object owned by a different CR")
+	}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph)}, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Errorf("a refused legacy object was still copied forward (err=%v)", err)
+	}
+	if after, ok := counterValue(t, metrics.OMMCacheRestoreTotal,
+		prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name, "result": "refused_identity"}); !ok || after != before+1 {
+		t.Errorf("refused_identity counter %v -> %v (found=%v)", before, after, ok)
+	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -273,6 +273,45 @@ var (
 	)
 )
 
+var (
+	// OMMCachePersistTotal counts durable OMM-cache writes by outcome. Persistence is
+	// deliberately best-effort — a failure must not fail live reconciliation (ADR-0007) — which
+	// is exactly why it needs a counter: without one, the cache can be failing to write for
+	// weeks and the first symptom is a restart that has nothing to propagate.
+	// result: success | failed | skipped_oversize | skipped_marshal.
+	OMMCachePersistTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ntn_operators_omm_cache_persist_total",
+			Help: "Durable OMM cache writes, by outcome.",
+		},
+		[]string{"namespace", "ephemeris", "result"},
+	)
+
+	// OMMCacheRestoreTotal counts cold-start restores by outcome. A plain miss is NOT counted:
+	// every first-ever reconcile misses, so it would drown the refusals, which are the signal.
+	// result: hydrated | migrated | refused_digest | refused_identity | refused_parse.
+	// Sustained refused_identity on the legacy name is how a pre-ADR-0007 truncation collision
+	// shows itself.
+	OMMCacheRestoreTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ntn_operators_omm_cache_restore_total",
+			Help: "Durable OMM cache restores after a cold start, by outcome.",
+		},
+		[]string{"namespace", "ephemeris", "result"},
+	)
+
+	// OMMCacheRestoredAgeSeconds is how old the restored element set was at restore time.
+	// Restoring does not make data fresh: the freshness gates still apply, so a large value
+	// predicts that propagation is about to stop, and does so before it does.
+	OMMCacheRestoredAgeSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ntn_operators_omm_cache_restored_age_seconds",
+			Help: "Age of the OMM set at the moment it was restored from the durable cache.",
+		},
+		[]string{"namespace", "ephemeris"},
+	)
+)
+
 func init() {
 	metrics.Registry.MustRegister(
 		FailoverTotal,
@@ -291,6 +330,9 @@ func init() {
 		ReaderQueryDuration,
 		ReaderErrorsTotal,
 		ReaderStaleUsedTotal,
+		OMMCachePersistTotal,
+		OMMCacheRestoreTotal,
+		OMMCacheRestoredAgeSeconds,
 		EphemerisMapperIndexErrorTotal,
 	)
 	// Note: logging here is intentionally omitted because init() runs

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -1173,12 +1173,28 @@ func (e *haEnv) waitEpochAdvances(t *testing.T, beyond int64, timeout time.Durat
 }
 
 // cacheConfigMapDigest returns the durable cache ConfigMap's payload digest, ok=false if absent.
+//
+// Found by the marker label and owner, NEVER by name. The name is an implementation detail that
+// has already changed once — ADR-0007 replaced <cr>-omm-cache with a hash-suffixed form — and this
+// test hardcoding it meant the rename compiled, passed `make test`, passed vet, and only failed
+// here, because this file is behind the e2e_ha build tag. Label lookup is also what the runbook
+// tells an operator to do, so the test now exercises the documented path.
 func (e *haEnv) cacheConfigMapDigest() (string, bool) {
-	cm, err := e.cs.CoreV1().ConfigMaps(outageNS).Get(e.ctx, satephName+"-omm-cache", metav1.GetOptions{})
+	list, err := e.cs.CoreV1().ConfigMaps(outageNS).List(e.ctx, metav1.ListOptions{
+		LabelSelector: "ntn.operators.dev/omm-cache=true",
+	})
 	if err != nil {
 		return "", false
 	}
-	return cm.Annotations["ntn.operators.dev/omm-digest"], true
+	for _, cm := range list.Items {
+		// One namespace can hold caches for several CRs; take the one owned by ours.
+		for _, ref := range cm.OwnerReferences {
+			if ref.Kind == "SatelliteEphemeris" && ref.Name == satephName {
+				return cm.Annotations["ntn.operators.dev/omm-digest"], true
+			}
+		}
+	}
+	return "", false
 }
 
 // TestHAOutageContinuityAcrossFailover is the MANDATED acceptance test for the durable OMM cache:
@@ -1207,7 +1223,7 @@ func TestHAOutageContinuityAcrossFailover(t *testing.T) {
 		_ = e.cs.AppsV1().Deployments(outageNS).Delete(bg, mockName, metav1.DeleteOptions{})
 		_ = e.cs.CoreV1().Services(outageNS).Delete(bg, mockName, metav1.DeleteOptions{})
 		_ = e.cs.CoreV1().ConfigMaps(outageNS).Delete(bg, mockFixtureCM, metav1.DeleteOptions{})
-		// The <name>-omm-cache ConfigMap is owner-ref'd to the CR, so GC removes it with the CR.
+		// The cache ConfigMap is owner-ref'd to the CR, so GC removes it with the CR.
 	})
 
 	// WARM: leader fetches, persists the durable cache, propagates.
@@ -1215,7 +1231,8 @@ func TestHAOutageContinuityAcrossFailover(t *testing.T) {
 		"SatelliteEphemeris to warm — a stall here usually means the chart lacks "+
 			"--ephemeris-allowed-private-hosts=celestrak-mock.default.svc.cluster.local")
 	if _, ok := e.cacheConfigMapDigest(); !ok {
-		t.Fatalf("durable cache ConfigMap %s-omm-cache absent after warm — persist not wired or RBAC-denied", satephName)
+		t.Fatalf("no durable cache ConfigMap labelled ntn.operators.dev/omm-cache=true and owned by "+
+			"SatelliteEphemeris/%s after warm — persist not wired, RBAC-denied, or the owner ref is missing", satephName)
 	}
 	t.Logf("warm: epoch=%d, durable cache present", warm)
 


### PR DESCRIPTION
ADR-0007 is **accepted** and mandates a hash-suffixed name. The code still shipped pure truncation. This closes that gap.

## The bug is an availability bug, not a cosmetic one

`ommCacheConfigMapName` cut the CR name to fit the 253-character limit:

```go
if len(ephName)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
    ephName = ephName[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
}
```

So every `SatelliteEphemeris` sharing a 243-character prefix maps onto **one** ConfigMap.

The owner-UID annotation stops a wrong *restore*, and that is exactly why this reads as harmless. It is not. The annotation does nothing about the **contention**: the losers keep overwriting an object whose UID their own restore then refuses. Their restart and leader-failover continuity is gone, and there is nothing in the status, the events or the logs to say so — the feature reports success the whole time.

## Changes

**Name** — `<readable prefix>-<128-bit hash of namespace/name/UID>-omm-cache`. Hashing the UID in also means a delete/recreate lands on a *different* object rather than inheriting its predecessor's; the annotation gate stays as defense in depth.

**An upgrade keeps its cache.** Renaming without reading the old object would discard exactly the outage continuity this feature exists for, silently, at a cold start. A cold restore now reads the legacy name once, applies the **identical** digest / UID / fetch-identity gates, and copies it forward immediately rather than waiting for the next fetch (~2 h) — a second restart in between would otherwise be back to a cold start. The legacy object is never deleted: the controller holds no `delete` verb, and its owner reference garbage-collects it with the CR.

**Observability.** Persisting is best-effort by design — a write failure must not fail live reconciliation — which is why it needed signals. Without them the cache can fail to write for weeks and the first symptom is a restart with nothing to propagate, *during* the upstream outage the cache exists for.

| Metric | Notes |
|---|---|
| `ntn_operators_omm_cache_persist_total{result}` | `success` / `failed` / `skipped_oversize` / `skipped_marshal` |
| `ntn_operators_omm_cache_restore_total{result}` | `hydrated` / `migrated` / `refused_digest` / `refused_identity` / `refused_parse` |
| `ntn_operators_omm_cache_restored_age_seconds` | restoring does not make data fresh; a large value predicts propagation stopping *before* it does |

All three are released on CR deletion via `DeletePartialMatch`, matching the existing #179/#180 cleanup — the restored-age gauge in particular would otherwise keep reporting an age for a CR that no longer exists, which reads as a *stale* cache rather than as *no* cache.

Plus alerts `NTNOMMCachePersistFailing` and `NTNOMMCacheRestoreRefused`, each with a runbook section (every alert in the chart has one — checked).

**The persist alert is windowed at 24h and gated with `unless`**, because persist runs once per successful *fetch* and `refreshInterval` defaults to 4h with a 2h floor. A window measured in minutes usually contains no persist attempt at all, so it would report "no failures" from having observed nothing. `unless` on a successful write in the same window is what makes it a statement about the *cache* rather than about one write: a transient conflict the next fetch fixes stays silent, a cache genuinely not being written does not.

Two things are deliberately **not** alerted. A plain restore **miss**: every first-ever reconcile misses, so it would drown the refusals. And **`refused_identity`**: restore runs on every reconcile while the cache is cold, so a delete/recreate or any `spec.source` edit increments it once per reconcile until the next successful fetch — an alert would fire hardest exactly when the operator is behaving correctly. Both stay as counters; the runbook carries the query, including how sustained `refused_identity` under the *legacy* name is precisely how the truncation collision surfaces in the field.

## Mutation-verified

A guard that cannot fail is decoration. Each mutation makes exactly one new test fail:

| Mutation | Result |
|---|---|
| Name reverted to pure truncation | `…ConfigMapNameIsCollisionResistant` fails |
| Legacy fallback removed from `restoreOMMCache` | `…MigratesFromLegacyName` fails |
| `copyCacheForward` call removed | `…MigratesFromLegacyName` fails |
| Identity gate skipped for legacy objects | `…LegacyNameStillIdentityGated` fails |
| Legacy name tried *before* the hashed one | `…HashedNameWinsOverLegacy` fails |
| Migration deletes the legacy object | `…MigrationLeavesLegacyObject` fails |
| Metric-series cleanup dropped | `…DeletedReleasesOMMCacheSeries` fails |
| Digest dropped from the copied annotations | `…MigratesFromLegacyName` fails |

The collision test also asserts up front that the **legacy** scheme still collides on its inputs, so it can never quietly stop testing the bug it exists for, and that its own CR names are valid `IsDNS1123Subdomain` — see below. Generated names are checked the same way, not just against a length bound: truncating before appending `-<hash>` can expose a trailing `-` or `.`, which would produce an object name the apiserver rejects.

## Found by reviewing this PR, not by writing it

Recorded because each one shipped green at some point in this branch's history.

| Found by | Defect |
|---|---|
| CI | `TestHAOutageContinuityAcrossFailover` hardcoded the old ConfigMap name. It is behind the `e2e_ha` build tag and the reference was a runtime *string*, so the rename passed `make test`, `go vet ./...` and `golangci-lint`. The test now finds the object by marker label + owner reference — what the runbook tells an operator to do — and both halves are asserted in `make test`. `go vet` is now run under every build tag in the repo. |
| Self-review | The restore alert fired hardest during **normal** operation: restore runs per reconcile while cold, so a delete/recreate produced a burst of `refused_identity`. Scoped to the unambiguous corruption reasons. |
| Self-review | The persist alert **could not fire**: a 30-minute window on an event that happens once per 2–4h fetch. See the `unless` design above. |
| Self-review | The three new metrics leaked a series per deleted CR, against an existing repo-wide cleanup pattern. |
| Adversarial review | The collision test built its CRs from a 260-character stem — **266-character objects the apiserver would reject**. The property was proven for input that cannot exist, and the comment calling those names "legal" was wrong. Truncation began above 243 and names may reach 253, so the collision is reachable with a *valid* CR; the test now uses 250 and fails loudly if its own inputs stop being legal names. |
| Adversarial review | `copyCacheForward` cloned **every** annotation on the legacy object. The payload is already bounded at 900 KiB under a 1 MiB object limit, so a large foreign annotation could push the create over it — failing inside a deliberately swallowed path. It now copies only the annotations this cache defines, and the migration test restores from the object it just wrote, so a copy that drops a gate annotation fails instead of producing an object that looks migrated and is refused on the next cold start. |

Attacks that **failed**, checked so they are not re-litigated: no Makefile target regenerates `dist/chart`, so the hand-maintained alert is safe; `SatelliteEphemeris` has no finalizer, so there is no terminating-CR window that could create an orphan; a `spec.source` edit cannot resurrect the previous source's data through either name (the fetch-identity gate holds on both); the manager needs no new `list` verb (the E2E lists with its own credentials); and the hash input `ns/name/uid` cannot be ambiguous, since none of the three may contain `/`.

## Deliberately not in this PR

**Storage mode (`ommCache.mode: ConfigMap|Secret|Disabled`).** ADR-0007 also requires it, but it is an operator-config surface plus RBAC changes for Secrets, and it is orthogonal to the collision. Separate CL.

## Verification

`make test`, `golangci-lint run ./...` (0 issues), `helm lint --set prometheus.enable=true`, `make adr-lint` (11 ADRs), and `go vet` under **every** build tag (none / `e2e` / `e2e_ha` / `e2e_wss`) — all green.

CI green on all six checks, including the `Helm lint + deploy` job that runs both E2E suites: `TestHAOutageContinuityAcrossFailover` **PASS (332s)** — the full path of warm → persist → total upstream outage → SIGKILL the leader → the new leader restores last-good OMMs from the object it located by label and owner, and keeps advancing the epoch.