### PR TITLE
fix(ntnslice): FailoverReady True reports ConstellationMemberAvailable (ADR-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`FailoverReady=True` now reports Reason `ConstellationMemberAvailable`, not the overstated
+  `SatelliteAvailable`.** The condition *type* is unchanged (`FailoverReady`), so anything keyed on the
+  type is unaffected; only the Reason string on the `True` case changes. A fresh, deliverable
+  constellation member being overhead is a **contact opportunity**, not delivered slice service —
+  actual service still needs the (absent) slice-to-cell binding, so `SatelliteAvailable` overstated it.
+  The Message now reads "A fresh deliverable constellation member has an active pass window (contact
+  opportunity, not slice service)". A dashboard or alert that matches on the Reason string
+  `SatelliteAvailable` must be updated to `ConstellationMemberAvailable`. See ADR-0008.
+
 - **`AntennaReady` no longer claims `True` for an antenna nobody measured.** The condition was set
   unconditionally to `True` / `AntennaOperational` / "Antenna system operational" whenever the backing
   Node existed — the code comment said `// AntennaReady: simulated as True when node exists.` Nothing

--- a/docs/adr/0008-constellation-pool-availability.md
+++ b/docs/adr/0008-constellation-pool-availability.md
@@ -7,7 +7,8 @@ last_verified: 2026-07-31
 deciders: [thc1006]
 supersedes: []
 superseded_by: []
-implementation: []
+implementation:
+  - "https://github.com/thc1006/ntn-operators/pull/346"
 tracking: []
 ---
 

--- a/internal/controller/ntnslice_controller.go
+++ b/internal/controller/ntnslice_controller.go
@@ -341,8 +341,11 @@ func (r *NTNSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			c = metav1.Condition{Status: metav1.ConditionUnknown, Reason: "SatelliteReadFailed",
 				Message: "Satellite availability unknown: transient SatelliteEphemeris read error; holding current path"}
 		case satelliteAvailable:
-			c = metav1.Condition{Status: metav1.ConditionTrue, Reason: "SatelliteAvailable",
-				Message: "Satellite pass window active"}
+			// Contact OPPORTUNITY, not delivered slice service: a fresh deliverable member is
+			// overhead (see checkSatelliteAvailability), but service still needs the absent
+			// slice-to-cell binding. "SatelliteAvailable" overstated that (ADR-0008).
+			c = metav1.Condition{Status: metav1.ConditionTrue, Reason: "ConstellationMemberAvailable",
+				Message: "A fresh deliverable constellation member has an active pass window (contact opportunity, not slice service)"}
 		default:
 			msg := satelliteDetail
 			if msg == "" {

--- a/internal/controller/ntnslice_controller_test.go
+++ b/internal/controller/ntnslice_controller_test.go
@@ -348,6 +348,29 @@ var _ = Describe("NTNSlice Controller", func() {
 		return eph
 	}
 
+	Context("Opportunity condition Reason (ADR-0008)", func() {
+		BeforeEach(func() { createSlice() })
+		AfterEach(func() { deleteSlice() })
+
+		It("sets FailoverReady=True with Reason ConstellationMemberAvailable, not the overstated SatelliteAvailable", func() {
+			eph := createEphemerisWithPass(true)
+			DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), eph) })
+
+			_, err := newReconciler().Reconcile(context.Background(), reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &ntnv1alpha1.NTNSlice{}
+			Expect(k8sClient.Get(context.Background(), typeNamespacedName, updated)).To(Succeed())
+
+			cond := meta.FindStatusCondition(updated.Status.Conditions, ntnv1alpha1.ConditionFailoverReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			// ADR-0008: a member overhead is a CONTACT OPPORTUNITY, not delivered slice service.
+			Expect(cond.Reason).To(Equal("ConstellationMemberAvailable"))
+			Expect(cond.Message).To(ContainSubstring("contact opportunity, not slice service"))
+		})
+	})
+
 	Context("Switchback: satellite pass ends while on satellite", func() {
 		BeforeEach(func() { createSlice() })
 		AfterEach(func() { deleteSlice() })


### PR DESCRIPTION
## What

Implements ADR-0008's Reason correction: `FailoverReady=True` emitted Reason **`SatelliteAvailable`**, which overstated a constellation-pool **contact opportunity** as delivered slice service. A member being overhead is not the same as the slice being served — that still needs the (absent) slice-to-cell binding. The condition **type stays `FailoverReady`** (no API/monitoring break); only the Reason + Message on the `True` case change.

- `ntnslice_controller.go`: True-case Reason → **`ConstellationMemberAvailable`**, Message *"A fresh deliverable constellation member has an active pass window (contact opportunity, not slice service)"*. This is exactly what `checkSatelliteAvailability` gates on (active window AOS<now<LOS + fresh/deliverable element set via `sourceEpochFresh` + `PassesPredicted=True`), so "fresh deliverable" is accurate, not a new overstatement.
- **First test covering the True case** (`Opportunity condition Reason (ADR-0008)`) asserting Status/Reason/Message. Mutation-verified: reverting the Reason string fails exactly this spec.
- **CHANGELOG (Changed)**: the ADR mandates it — a dashboard or alert keyed on the Reason string `SatelliteAvailable` must update to `ConstellationMemberAvailable`.

**No CRD schema change** (Reason string only). No other site emits the old Reason (grepped).

## Verify
- `make lint` (golangci-lint v2.12.2) 0 issues; `make adr-lint` OK (11 ADRs); full controller suite (166 specs) + pkg + api green.

Implements ADR-0008.
