### PR TITLE
fix(omm-cache): collision-resistant ConfigMap naming + legacy adoption + metrics (ADR-0007)

### DIFF
--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -215,6 +215,8 @@ func (r *SatelliteEphemerisReconciler) Reconcile(ctx context.Context, req ctrl.R
 			ntnmetrics.EphemerisEpochStaleCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.EphemerisPropagationFailedCount.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			ntnmetrics.GPFetchReady.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.OMMCachePersistTotal.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
+			ntnmetrics.OMMCacheRestoreTotal.DeletePartialMatch(prometheus.Labels{"namespace": req.Namespace, "ephemeris": req.Name})
 			r.ommCache.Delete(req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/satelliteephemeris_ommcache_etag_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_etag_test.go
@@ -63,7 +63,7 @@ func TestOMMCache_PersistsAndClearsValidators(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
 	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
 	fetchKey := fetchInputKey(eph.Spec)
-	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}
 
 	t0 := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
 	withVal := ommResultAt(t0)

--- a/internal/controller/satelliteephemeris_ommcache_persist.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist.go
@@ -16,9 +16,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,20 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
 )
+
+func recordOMMPersist(eph *ntnv1alpha1.SatelliteEphemeris, result string) {
+	ntnmetrics.OMMCachePersistTotal.With(prometheus.Labels{
+		"namespace": eph.Namespace, "ephemeris": eph.Name, "result": result,
+	}).Inc()
+}
+
+func recordOMMRestore(eph *ntnv1alpha1.SatelliteEphemeris, result string) {
+	ntnmetrics.OMMCacheRestoreTotal.With(prometheus.Labels{
+		"namespace": eph.Namespace, "ephemeris": eph.Name, "result": result,
+	}).Inc()
+}
 
 // Durable last-good OMM cache: persists tracked OMMs to a controller-owned ConfigMap so a cold
 // process (restart / leader failover) can re-propagate through a sustained upstream outage,
@@ -69,14 +84,39 @@ func (r *SatelliteEphemerisReconciler) readerOrClient() client.Reader {
 	return r.Client
 }
 
-// ommCacheConfigMapName derives the per-CR cache ConfigMap name, bounded to the k8s name limit.
-// Names over the limit are truncated; the restore path UID-gates, so a (pathological) truncation
-// collision between two >243-char names never restores wrong data — see ADR-0007.
-func ommCacheConfigMapName(ephName string) string {
-	if len(ephName)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
-		ephName = ephName[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
+// ommCacheConfigMapName derives a collision-resistant per-CR cache ConfigMap name. The old scheme
+// truncated a long CR name to fit the k8s limit, so two names sharing their first 243 chars mapped
+// to ONE ConfigMap. The two CRs then overwrite each other's payload and owner reference every
+// reconcile (a flip-flop), and the loser's cache is garbage-collected when the owning CR is deleted
+// — a silent failover-continuity loss, beyond the wrong-restore the UID gate already blocked. A
+// 128-bit hash of namespace+name+UID makes the name unique per object; the readable prefix is
+// cosmetic. See ADR-0007.
+func ommCacheConfigMapName(namespace, name, uid string) string {
+	sum := sha256.Sum256([]byte(namespace + "/" + name + "/" + uid))
+	hash := hex.EncodeToString(sum[:16])                                            // 128 bits
+	maxPrefix := maxConfigMapNameLen - len(hash) - len(ommCacheConfigMapSuffix) - 1 // -1 for the '-' before the hash
+	prefix := name
+	if len(prefix) > maxPrefix {
+		prefix = prefix[:maxPrefix]
 	}
-	return ephName + ommCacheConfigMapSuffix
+	if prefix = strings.TrimRight(prefix, "-."); prefix == "" {
+		prefix = "eph"
+	}
+	return prefix + "-" + hash + ommCacheConfigMapSuffix
+}
+
+// ommCacheNameFor is the convenience form used at the call sites.
+func ommCacheNameFor(eph *ntnv1alpha1.SatelliteEphemeris) string {
+	return ommCacheConfigMapName(eph.Namespace, eph.Name, string(eph.UID))
+}
+
+// ommCacheLegacyName is the pre-hash truncated name. Restore checks it once so a cache written by
+// the old scheme is adopted across the upgrade instead of cold-starting. See ADR-0007.
+func ommCacheLegacyName(name string) string {
+	if len(name)+len(ommCacheConfigMapSuffix) > maxConfigMapNameLen {
+		name = name[:maxConfigMapNameLen-len(ommCacheConfigMapSuffix)]
+	}
+	return name + ommCacheConfigMapSuffix
 }
 
 // ommCachePayload is the tracked, capped set propagateStates would use (never the full GP
@@ -112,15 +152,17 @@ func (r *SatelliteEphemerisReconciler) persistOMMCache(
 	data, err := json.Marshal(omms)
 	if err != nil {
 		log.V(1).Info("omm-cache: marshal failed; skipping persist", "err", err.Error())
+		recordOMMPersist(eph, "failure")
 		return
 	}
 	if len(data) > maxOMMCacheBytes {
 		log.Info("omm-cache: payload over bound; skipping restart-continuity persist (warm cache unaffected)",
 			"bytes", len(data), "satellites", len(omms))
+		recordOMMPersist(eph, "oversize_skip")
 		return
 	}
 	digest := ommDigest(data)
-	key := client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	key := client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}
 
 	// Read uncached (APIReader) so configmaps get suffices and we do not start an informer that
 	// caches every ConfigMap in the cluster; writes still go through the cached client. Mirrors
@@ -134,22 +176,31 @@ func (r *SatelliteEphemerisReconciler) persistOMMCache(
 		stampOMMCache(cm, eph, fetchKey, digest, len(omms), string(data), result.FetchedAt, result.ETag, result.LastModified)
 		if err := controllerutil.SetControllerReference(eph, cm, r.Scheme); err != nil {
 			log.V(1).Info("omm-cache: owner ref failed; skipping persist", "err", err.Error())
+			recordOMMPersist(eph, "failure")
 			return
 		}
 		if err := r.Create(ctx, cm); err != nil && !apierrors.IsAlreadyExists(err) {
 			log.V(1).Info("omm-cache: create failed; skipping persist", "err", err.Error())
+			recordOMMPersist(eph, "failure")
+			return
 		}
+		recordOMMPersist(eph, "success")
 	case getErr != nil:
 		log.V(1).Info("omm-cache: get failed; skipping persist", "err", getErr.Error())
+		recordOMMPersist(eph, "failure")
 	default:
 		if cm.Annotations[ommCacheAnnDigest] == digest && cm.Data[ommCacheDataKey] != "" {
-			return // unchanged
+			recordOMMPersist(eph, "success") // already current
+			return
 		}
 		stampOMMCache(cm, eph, fetchKey, digest, len(omms), string(data), result.FetchedAt, result.ETag, result.LastModified)
 		_ = controllerutil.SetControllerReference(eph, cm, r.Scheme) // adopt for GC if pre-existing
 		if err := r.Update(ctx, cm); err != nil {
 			log.V(1).Info("omm-cache: update failed; skipping persist", "err", err.Error())
+			recordOMMPersist(eph, "failure")
+			return
 		}
+		recordOMMPersist(eph, "success")
 	}
 }
 
@@ -194,23 +245,40 @@ func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 		return false // already warm
 	}
 	cm := &corev1.ConfigMap{}
-	if err := r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
-		return false
+	name := ommCacheNameFor(eph)
+	migrated := false
+	err := r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: name}, cm)
+	if apierrors.IsNotFound(err) {
+		// One-time migration bridge: adopt a cache written under the pre-hash truncated name so an
+		// upgrade does not cold-start. The same digest/UID/fetchKey gates below still apply, so a
+		// legacy ConfigMap shared with another CR (the very collision this fix removes) is refused.
+		if legacy := ommCacheLegacyName(eph.Name); legacy != name {
+			if err = r.readerOrClient().Get(ctx, client.ObjectKey{Namespace: eph.Namespace, Name: legacy}, cm); err == nil {
+				migrated = true
+			}
+		}
+	}
+	if err != nil {
+		return false // no cache (or get error) — a cold CR with nothing to restore is normal
 	}
 	data := cm.Data[ommCacheDataKey]
 	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue || data == "" {
+		recordOMMRestore(eph, "refused")
 		return false
 	}
 	if cm.Annotations[ommCacheAnnDigest] != ommDigest([]byte(data)) {
 		log.Info("omm-cache: digest mismatch; ignoring (corrupt or hand-edited)")
+		recordOMMRestore(eph, "refused")
 		return false
 	}
 	if cm.Annotations[ommCacheAnnUID] != string(eph.UID) || cm.Annotations[ommCacheAnnFetchKey] != fetchKey {
-		return false // orphaned by delete-recreate, or a different source — do not restore
+		recordOMMRestore(eph, "refused") // orphaned by delete-recreate, or a different source
+		return false
 	}
 	omms, err := ephemeris.ParseValidOMMs(log, []byte(data))
 	if err != nil || len(omms) == 0 {
 		log.V(1).Info("omm-cache: payload unparseable or fully invalid; ignoring", "err", err)
+		recordOMMRestore(eph, "refused")
 		return false
 	}
 	// Unknown fetch time → zero, i.e. very old, so the next reconcile fetches and only serves
@@ -231,7 +299,13 @@ func (r *SatelliteEphemerisReconciler) restoreOMMCache(
 				cm.Annotations[ommCacheAnnETag], cm.Annotations[ommCacheAnnLastModified])
 		}
 	}
-	log.Info("omm-cache: hydrated last-good OMMs after cold start", "satellites", len(omms))
+	if migrated {
+		log.Info("omm-cache: adopted last-good OMMs from the pre-hash cache name (one-time migration)", "satellites", len(omms))
+		recordOMMRestore(eph, "hydrated_legacy")
+	} else {
+		log.Info("omm-cache: hydrated last-good OMMs after cold start", "satellites", len(omms))
+		recordOMMRestore(eph, "hydrated")
+	}
 	return true
 }
 

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -12,16 +12,20 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/akhenakh/sgp4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +33,7 @@ import (
 
 	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
 	"github.com/thc1006/ntn-operators/pkg/ephemeris"
+	ntnmetrics "github.com/thc1006/ntn-operators/pkg/metrics"
 )
 
 // ommCacheScheme is makeScheme + corev1 (the cache lives in a ConfigMap).
@@ -76,7 +81,7 @@ func TestOMMCache_PersistRestoreRoundTrip(t *testing.T) {
 
 	// The ConfigMap must exist and carry the identity/integrity metadata.
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}, cm); err != nil {
 		t.Fatalf("persist did not create the cache ConfigMap: %v", err)
 	}
 	if cm.Labels[ommCacheLabelKey] != ommCacheLabelValue {
@@ -121,6 +126,71 @@ func TestOMMCache_PersistRestoreRoundTrip(t *testing.T) {
 	}
 }
 
+// TestOMMCache_MetricsRecorded proves persist and restore increment the observability counters, so
+// a silently-degraded failover cache is alertable (ADR-0007).
+func TestOMMCache_MetricsRecorded(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-metric", "uid-metric")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+	fetchKey := fetchInputKey(eph.Spec)
+
+	// Reset any series left by another test for this key so the assertions are absolute.
+	ntnmetrics.OMMCachePersistTotal.DeletePartialMatch(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name})
+	ntnmetrics.OMMCacheRestoreTotal.DeletePartialMatch(prometheus.Labels{"namespace": eph.Namespace, "ephemeris": eph.Name})
+
+	r.persistOMMCache(ctx, eph, ommResultAt(time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)), fetchKey)
+	if got := testutil.ToFloat64(ntnmetrics.OMMCachePersistTotal.WithLabelValues(eph.Namespace, eph.Name, "success")); got != 1 {
+		t.Fatalf("persist success counter = %v, want 1", got)
+	}
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatalf("restore returned false on a valid cold cache")
+	}
+	if got := testutil.ToFloat64(ntnmetrics.OMMCacheRestoreTotal.WithLabelValues(eph.Namespace, eph.Name, "hydrated")); got != 1 {
+		t.Fatalf("restore hydrated counter = %v, want 1", got)
+	}
+}
+
+// TestOMMCache_RestoreMigratesLegacyName proves a cache written under the pre-hash (truncated) name
+// is adopted across the upgrade, so a restart during migration does not cold-start (ADR-0007).
+func TestOMMCache_RestoreMigratesLegacyName(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-legacy", "uid-legacy")
+	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	result := ommResultAt(fetchedAt)
+	fetchKey := fetchInputKey(eph.Spec)
+
+	// A valid cache ConfigMap under the OLD name, stamped exactly as the pre-hash code did.
+	data, err := json.Marshal(ommCachePayload(result, eph))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	legacy := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: eph.Namespace, Name: ommCacheLegacyName(eph.Name)}}
+	stampOMMCache(legacy, eph, fetchKey, ommDigest(data), 1, string(data), fetchedAt, "", "")
+	if legacy.Name == ommCacheNameFor(eph) {
+		t.Fatalf("test invalid: legacy and hashed names coincide for %q", eph.Name)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph, legacy).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+
+	// The hashed name does not exist; restore must fall back to the legacy name and hydrate.
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatalf("restore did not adopt the legacy-named cache")
+	}
+	got, ok := r.cachedOMMResult(key)
+	if !ok || got.result.SatelliteCount != 1 {
+		t.Fatalf("legacy adoption did not populate the in-memory cache")
+	}
+	if !got.result.FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("legacy adoption reset FetchedAt: got %s, want %s", got.result.FetchedAt.UTC(), fetchedAt)
+	}
+}
+
 // TestOMMCache_RestoreRejectsInvalid proves restore refuses corrupt or wrong-owner/source data,
 // so a tampered or orphaned ConfigMap never poisons the cache.
 func TestOMMCache_RestoreRejectsInvalid(t *testing.T) {
@@ -158,7 +228,7 @@ func TestOMMCache_RestoreRejectsInvalid(t *testing.T) {
 
 			r.persistOMMCache(ctx, base, ommResultAt(fetchedAt), fetchKey)
 			cm := &corev1.ConfigMap{}
-			cmKey := types.NamespacedName{Namespace: base.Namespace, Name: ommCacheConfigMapName(base.Name)}
+			cmKey := types.NamespacedName{Namespace: base.Namespace, Name: ommCacheNameFor(base)}
 			if err := cli.Get(ctx, cmKey, cm); err != nil {
 				t.Fatalf("get cache cm: %v", err)
 			}
@@ -210,7 +280,7 @@ func TestOMMCache_PersistNoopOnIdenticalDigest(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
 	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
 	ctx := context.Background()
-	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}
+	cmKey := types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}
 	fetchKey := fetchInputKey(eph.Spec)
 
 	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
@@ -242,7 +312,7 @@ func TestOMMCache_PersistSetsOwnerRefForGC(t *testing.T) {
 
 	r.persistOMMCache(ctx, eph, ommResultAt(time.Now().UTC()), fetchInputKey(eph.Spec))
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}, cm); err != nil {
 		t.Fatalf("get cm: %v", err)
 	}
 	if len(cm.OwnerReferences) != 1 {
@@ -271,21 +341,43 @@ func TestOMMCache_PersistSkipsOversizePayload(t *testing.T) {
 	r.persistOMMCache(ctx, eph, result, fetchInputKey(eph.Spec))
 
 	cm := &corev1.ConfigMap{}
-	err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm)
+	err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}, cm)
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("oversize payload must not create a ConfigMap; got err=%v", err)
 	}
 }
 
-// TestOMMCache_ConfigMapNameTruncation proves the derived name always fits the k8s name limit.
-func TestOMMCache_ConfigMapNameTruncation(t *testing.T) {
-	short := ommCacheConfigMapName("eph-a")
-	if short != "eph-a"+ommCacheConfigMapSuffix {
-		t.Fatalf("short name = %q", short)
+// TestOMMCache_ConfigMapNameCollisionResistant proves the derived name is unique per object, a
+// valid ConfigMap name, and deterministic. The old truncation mapped two long names to one
+// ConfigMap, silently breaking the second CR's persistence (ADR-0007).
+func TestOMMCache_ConfigMapNameCollisionResistant(t *testing.T) {
+	// Two >243-char names sharing their first 250 chars collided under the old truncation.
+	a, b := strings.Repeat("x", 250)+"-alpha", strings.Repeat("x", 250)+"-beta"
+	na := ommCacheConfigMapName("ns", a, "uid-a")
+	nb := ommCacheConfigMapName("ns", b, "uid-b")
+	if na == nb {
+		t.Fatalf("collision: two distinct long names mapped to one ConfigMap %q", na)
 	}
-	long := ommCacheConfigMapName(strings.Repeat("x", 300))
-	if len(long) > maxConfigMapNameLen {
-		t.Fatalf("truncated name len = %d, exceeds %d", len(long), maxConfigMapNameLen)
+	for _, n := range []string{na, nb, ommCacheConfigMapName("ns", "eph-a", "uid")} {
+		if len(n) > maxConfigMapNameLen {
+			t.Fatalf("name len = %d exceeds %d: %q", len(n), maxConfigMapNameLen, n)
+		}
+		if errs := validation.IsDNS1123Subdomain(n); len(errs) != 0 {
+			t.Fatalf("name %q is not a valid ConfigMap name: %v", n, errs)
+		}
+	}
+	// Deterministic: persist and restore must derive the same name.
+	if x, y := ommCacheConfigMapName("ns", a, "uid-a"), ommCacheConfigMapName("ns", a, "uid-a"); x != y {
+		t.Fatalf("non-deterministic: %q != %q", x, y)
+	}
+	// Same namespace+name, different UID (delete-recreate) → different name, so a recreated CR gets
+	// a fresh cache object instead of fighting over the old owner's ConfigMap.
+	if ommCacheConfigMapName("ns", a, "uid-a") == ommCacheConfigMapName("ns", a, "uid-b") {
+		t.Fatalf("same name+ns but different UID must differ")
+	}
+	// Short name keeps a readable prefix.
+	if short := ommCacheConfigMapName("ns", "eph-a", "uid"); !strings.HasPrefix(short, "eph-a-") {
+		t.Fatalf("short name lost its readable prefix: %q", short)
 	}
 }
 
@@ -344,7 +436,7 @@ func TestReconcile_ColdStartRestoresAndPropagatesDuringOutage(t *testing.T) {
 		t.Fatalf("warm phase never contacted upstream")
 	}
 	cm := &corev1.ConfigMap{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheConfigMapName(eph.Name)}, cm); err != nil {
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: eph.Namespace, Name: ommCacheNameFor(eph)}, cm); err != nil {
 		t.Fatalf("warm phase did not persist the cache ConfigMap: %v", err)
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -271,6 +271,31 @@ var (
 			Help: "spec.ephemerisRef indexed-lookup errors in the ephemeris mapper (excludes context cancel/deadline).",
 		},
 	)
+
+	// OMMCachePersistTotal counts durable OMM-cache persist attempts by outcome. A CR that silently
+	// cannot persist its last-good elements — the ConfigMap-name collision ADR-0007 fixes, or an API
+	// error — is otherwise invisible while its failover continuity degrades. Keyed
+	// namespace+ephemeris (like GPSatelliteCount), deleted on CR removal.
+	OMMCachePersistTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ntn_operators_omm_cache_persist_total",
+			Help: "Durable OMM-cache persist attempts by outcome (success, failure, oversize_skip).",
+		},
+		[]string{"namespace", "ephemeris", "result"},
+	)
+
+	// OMMCacheRestoreTotal counts cold-start OMM-cache restore attempts against an EXISTING cache
+	// object (a missing cache and an already-warm cache are normal and not counted). "refused" means
+	// a cache exists but is unusable (digest/owner/source mismatch or corrupt) — failover continuity
+	// is silently broken; "hydrated_legacy" marks a one-time adoption of a pre-hash-named cache.
+	// Keyed namespace+ephemeris, deleted on CR removal.
+	OMMCacheRestoreTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ntn_operators_omm_cache_restore_total",
+			Help: "Cold-start OMM-cache restore outcomes for an existing cache (hydrated, hydrated_legacy, refused).",
+		},
+		[]string{"namespace", "ephemeris", "result"},
+	)
 )
 
 func init() {
@@ -292,6 +317,8 @@ func init() {
 		ReaderErrorsTotal,
 		ReaderStaleUsedTotal,
 		EphemerisMapperIndexErrorTotal,
+		OMMCachePersistTotal,
+		OMMCacheRestoreTotal,
 	)
 	// Note: logging here is intentionally omitted because init() runs
 	// before controller-runtime's logger is configured. Registration


### PR DESCRIPTION
## The bug (silent HA-continuity loss)

The durable OMM-cache ConfigMap name was the CR name **truncated** to 253 chars (`ommCacheConfigMapName(ephName)`), so two names sharing their first 243 chars mapped to **one** ConfigMap. The two CRs then overwrite each other's payload and owner reference every reconcile (flip-flop), and the loser's cache is garbage-collected when the owning CR is deleted. The UID gate blocked a *wrong restore*, but not this continuity loss.

## Fix (ADR-0007)

- **Name** is now `<readable-prefix>-<128-bit sha256(namespace/name/uid)>-omm-cache` — unique per object, deterministic, a valid DNS-1123 subdomain ≤ 253 chars.
- **Legacy adoption**: restore checks the pre-hash name once and adopts a cache written by the old scheme, UID/fetchKey-gated so a collision victim's data is refused — an upgrade does not cold-start.
- **Metrics**: `ntn_operators_omm_cache_persist_total` / `_restore_total` (by outcome, keyed namespace+ephemeris, deleted on CR removal) make a silently degraded cache alertable.

## Verification

- New tests: collision-resistance + real `IsDNS1123Subdomain` validity + determinism + per-UID uniqueness; legacy-name adoption (`TestOMMCache_RestoreMigratesLegacyName`); metric increments (`TestOMMCache_MetricsRecorded`).
- Full controller suite (envtest, 22s), `-race`, `go vet`, `gofmt`, `golangci-lint` (v2.12.2) — all green.

Follow-up (ADR-0007, separate PR): `ommCache` mode `ConfigMap|Secret|Disabled` data-classification.