### PR TITLE
docs(adr): track ADR-0008 remaining scope in #348

### DIFF
--- a/docs/adr/0008-constellation-pool-availability.md
+++ b/docs/adr/0008-constellation-pool-availability.md
@@ -9,7 +9,8 @@ supersedes: []
 superseded_by: []
 implementation:
   - "https://github.com/thc1006/ntn-operators/pull/346"
-tracking: []
+tracking:
+  - "https://github.com/thc1006/ntn-operators/issues/348"
 ---
 
 # ADR 0008 — Model satellite-path contact opportunity at constellation-pool level


### PR DESCRIPTION
Fills ADR-0008 `tracking:` with #348. #346 implemented only the `FailoverReady` True-case Reason; ADR-0008 also decides the idle/stale reason renames (`NoActiveContact`/`PredictionUnavailable`/`AllCandidatesStale`), a `SliceServiceAvailable` condition, and candidate-status provenance — all still unbuilt. #348 tracks them so `implementation: [#346]` is not misread as complete. Docs-only. Refs #348.