### PR TITLE
test(norad): six-digit NORAD (100000+) regression gate

### DIFF
--- a/internal/controller/runtime_push_test.go
+++ b/internal/controller/runtime_push_test.go
@@ -38,9 +38,14 @@ func TestSelectPropagatedState(t *testing.T) {
 	states := []ntnv1alpha1.PropagatedState{
 		{NoradID: 100, ECEF: ntnv1alpha1.EphemerisECEF{PosX: 1}},
 		{NoradID: 200, ECEF: ntnv1alpha1.EphemerisECEF{PosX: 2}},
+		{NoradID: 100000, ECEF: ntnv1alpha1.EphemerisECEF{PosX: 3}}, // CelesTrak 100000+ six-digit catalog
 	}
 	if got := selectPropagatedState(states, new(200)); got == nil || got.NoradID != 200 {
 		t.Fatalf("by-noradID selection failed: %+v", got)
+	}
+	// A six-digit NORAD (CelesTrak exhausted the 5-digit space in 2026-07) must select cleanly.
+	if got := selectPropagatedState(states, new(100000)); got == nil || got.NoradID != 100000 {
+		t.Fatalf("six-digit NORAD selection failed: %+v", got)
 	}
 	if got := selectPropagatedState(states, nil); got == nil || got.NoradID != 100 {
 		t.Fatalf("nil selector should pick first: %+v", got)

--- a/internal/controller/satelliteephemeris_ommcache_persist_test.go
+++ b/internal/controller/satelliteephemeris_ommcache_persist_test.go
@@ -126,6 +126,31 @@ func TestOMMCache_PersistRestoreRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSixDigitNORAD_CachePersistRestore proves the durable OMM cache round-trips a 6-digit NORAD
+// (CelesTrak issues 100000+ since 2026-07): the int catalog marshals to JSON and parses back intact.
+func TestSixDigitNORAD_CachePersistRestore(t *testing.T) {
+	sch := ommCacheScheme(t)
+	eph := newOMMCacheEph("eph-6d", "uid-6d")
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(eph).Build()
+	r := &SatelliteEphemerisReconciler{Client: cli, Scheme: sch, Recorder: events.NewFakeRecorder(50)}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: eph.Namespace, Name: eph.Name}
+
+	omm := issOMMForTest()
+	omm.NoradCatID = 100000
+	fetchedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	fetchKey := fetchInputKey(eph.Spec)
+	r.persistOMMCache(ctx, eph, ephemeris.GPFetchResult{OMMs: []sgp4.OMM{omm}, SatelliteCount: 1, FetchedAt: fetchedAt}, fetchKey)
+
+	if !r.restoreOMMCache(ctx, ctrl.Request{NamespacedName: key}, eph, fetchKey) {
+		t.Fatalf("restore of a 6-digit-NORAD cache failed")
+	}
+	got, ok := r.cachedOMMResult(key)
+	if !ok || len(got.result.OMMs) != 1 || got.result.OMMs[0].NoradCatID != 100000 {
+		t.Fatalf("6-digit NORAD did not round-trip through the cache: %+v", got)
+	}
+}
+
 // TestOMMCache_RestoreRejectsInvalid proves restore refuses corrupt or wrong-owner/source data,
 // so a tampered or orphaned ConfigMap never poisons the cache.
 func TestOMMCache_RestoreRejectsInvalid(t *testing.T) {

--- a/pkg/ephemeris/six_digit_norad_test.go
+++ b/pkg/ephemeris/six_digit_norad_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package ephemeris
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akhenakh/sgp4"
+)
+
+// TestSixDigitNORAD is the regression gate for CelesTrak's 100000+ catalog numbers (the 5-digit
+// space was exhausted in 2026-07). It proves a 6-digit NORAD flows through the whole ephemeris
+// path as an int, with no hidden 5-char TLE-string truncation: OMM->TLE keeps the full catalog,
+// SGP4 propagation succeeds, the NORAD filter matches exactly, and pass windows carry the full ID.
+func TestSixDigitNORAD(t *testing.T) {
+	const bigNORAD = 100000
+	omm := issOMM()
+	omm.NoradCatID = bigNORAD
+	omm.ObjectName = "SIX-DIGIT-SAT"
+
+	epoch, err := time.Parse("2006-01-02T15:04:05.000000", omm.EpochStr)
+	if err != nil {
+		t.Fatalf("parse epoch: %v", err)
+	}
+
+	// 1. ToTLE keeps the 6-digit catalog as an int; a 69-char TLE round-trip would truncate cols 3-7.
+	tle, err := omm.ToTLE()
+	if err != nil {
+		t.Fatalf("ToTLE for 6-digit NORAD: %v", err)
+	}
+	if tle.SatelliteNumber != bigNORAD {
+		t.Fatalf("ToTLE truncated the catalog number: got %d, want %d", tle.SatelliteNumber, bigNORAD)
+	}
+
+	// 2. Propagation succeeds (SGP4 uses the orbital elements, not the catalog number).
+	if _, err := PropagateToECEF(omm, epoch.Add(10*time.Minute)); err != nil {
+		t.Fatalf("PropagateToECEF for 6-digit NORAD: %v", err)
+	}
+
+	// 3. The NORAD filter matches the full 6-digit ID and rejects a truncated 5-digit near-miss.
+	if got := FilterOMMs([]sgp4.OMM{omm}, []int{bigNORAD}); len(got) != 1 || got[0].NoradCatID != bigNORAD {
+		t.Fatalf("FilterOMMs did not match the 6-digit NORAD: %+v", got)
+	}
+	if got := FilterOMMs([]sgp4.OMM{omm}, []int{10000}); len(got) != 0 {
+		t.Fatalf("FilterOMMs matched a truncated 5-digit id: got %d results", len(got))
+	}
+
+	// 4. Pass prediction reports the full 6-digit NORAD on every produced window.
+	passes, err := PredictPasses(context.Background(), []sgp4.OMM{omm}, []GroundStation{montrealStation},
+		0, 24*time.Hour, []int{bigNORAD}, epoch)
+	if err != nil {
+		t.Fatalf("PredictPasses for 6-digit NORAD: %v", err)
+	}
+	if len(passes) == 0 {
+		t.Fatalf("no pass windows for the 6-digit satellite over 24h")
+	}
+	for _, p := range passes {
+		if p.NoradID != bigNORAD {
+			t.Fatalf("pass result reported NORAD %d, want %d", p.NoradID, bigNORAD)
+		}
+	}
+}


### PR DESCRIPTION
## Why

CelesTrak exhausted the 5-digit catalog space in 2026-07 and now issues **100000+**. The classic 69-char TLE format only has a 5-char catalog field (columns 3-7), so a naive OMM→TLE-string round-trip would truncate a 6-digit ID. This adds a regression gate.

## Finding: already correct

The system is **OMM-JSON-int-native**:
- `OMM.ToTLE()` sets `SatelliteNumber` as an **int** (no TLE-string round-trip).
- SGP4 propagates from the orbital elements, not the catalog number.
- Every consumer (`FilterOMMs`, `selectPropagatedState`, status `NoradID`, the durable cache, logs) reads `omm.NoradCatID` (int).

Verified adversarially: **no `ParseTLE`/TLE-string ingestion anywhere** in repo code, and **NORAD is never a Prometheus label** (only a structured-log int field) — so no truncation or cardinality path exists.

## Tests

- `pkg/ephemeris/TestSixDigitNORAD` — `ToTLE` preserves the 6-digit catalog, `PropagateToECEF` succeeds, `FilterOMMs` matches exactly (and rejects a truncated 5-digit near-miss), `PredictPasses` reports the full ID.
- `controller/TestSelectPropagatedState` — extended with a 6-digit member selection.
- `controller/TestSixDigitNORAD_CachePersistRestore` — durable OMM cache round-trips a 6-digit NORAD.

Full ephemeris + controller suites, `go vet`, `gofmt`, `golangci-lint` all green.