### PR TITLE
docs(api): mark sessionContinuity accepted-but-not-enforced (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   These need different operator responses and only one of them — staleness — self-heals on the next
   successful fetch, so collapsing them cost an operator the diagnosis during the exact outage the
   condition exists to report. `True/ConstellationMemberAvailable` was already in place.
+- **`failoverPolicy.sessionContinuity` is now documented as accepted-but-not-enforced.** The field's
+  godoc previously claimed it *"preserves active sessions during failover"*; this build performs **no**
+  runtime session preservation, so active sessions may drop on a path switch regardless of the value.
+  The field is retained for forward compatibility (a future release may honor it, #69) and its
+  admission default stays `true`, but the API doc — and thus `kubectl explain ntnslice.spec.failoverPolicy.sessionContinuity` —
+  no longer overstates it. **Documentation only — no behavior change**; if you relied on this field for
+  session survival, be aware it never took effect. (README already carried this caveat; the schema now does too.)
 
 - **`FailoverReady=True` now reports Reason `ConstellationMemberAvailable`, not the overstated
   `SatelliteAvailable`.** The condition *type* is unchanged (`FailoverReady`), so anything keyed on the

--- a/api/v1alpha1/ntnslice_types.go
+++ b/api/v1alpha1/ntnslice_types.go
@@ -202,7 +202,12 @@ type FailoverPolicy struct {
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('0s') && duration(self) <= duration('24h')",message="switchbackDelay must be a non-negative duration no greater than 24h"
 	SwitchbackDelay metav1.Duration `json:"switchbackDelay,omitempty"`
 
-	// sessionContinuity preserves active sessions during failover.
+	// sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+	// build: no runtime session preservation is performed during a path switch, so active
+	// sessions may drop on failover regardless of this value. It is retained so the intent
+	// stays expressible and a future release can honor it (#69); do not rely on it for
+	// session survival today. The default stays true only to preserve the field's prior
+	// admission behavior — it turns no preservation on.
 	// +kubebuilder:default=true
 	SessionContinuity bool `json:"sessionContinuity,omitempty"`
 

--- a/bundle/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/bundle/manifests/ntn.operators.dev_ntnslices.yaml
@@ -132,8 +132,13 @@ spec:
                         duration('24h')
                   sessionContinuity:
                     default: true
-                    description: sessionContinuity preserves active sessions during
-                      failover.
+                    description: |-
+                      sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+                      build: no runtime session preservation is performed during a path switch, so active
+                      sessions may drop on failover regardless of this value. It is retained so the intent
+                      stays expressible and a future release can honor it (#69); do not rely on it for
+                      session survival today. The default stays true only to preserve the field's prior
+                      admission behavior — it turns no preservation on.
                     type: boolean
                   switchbackDelay:
                     default: 60s

--- a/config/crd/bases/ntn.operators.dev_ntnslices.yaml
+++ b/config/crd/bases/ntn.operators.dev_ntnslices.yaml
@@ -132,8 +132,13 @@ spec:
                         duration('24h')
                   sessionContinuity:
                     default: true
-                    description: sessionContinuity preserves active sessions during
-                      failover.
+                    description: |-
+                      sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+                      build: no runtime session preservation is performed during a path switch, so active
+                      sessions may drop on failover regardless of this value. It is retained so the intent
+                      stays expressible and a future release can honor it (#69); do not rely on it for
+                      session survival today. The default stays true only to preserve the field's prior
+                      admission behavior — it turns no preservation on.
                     type: boolean
                   switchbackDelay:
                     default: 60s

--- a/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
+++ b/dist/chart/templates/crd/ntnslices.ntn.operators.dev.yaml
@@ -135,8 +135,13 @@ spec:
                         duration('24h')
                   sessionContinuity:
                     default: true
-                    description: sessionContinuity preserves active sessions during
-                      failover.
+                    description: |-
+                      sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+                      build: no runtime session preservation is performed during a path switch, so active
+                      sessions may drop on failover regardless of this value. It is retained so the intent
+                      stays expressible and a future release can honor it (#69); do not rely on it for
+                      session survival today. The default stays true only to preserve the field's prior
+                      admission behavior — it turns no preservation on.
                     type: boolean
                   switchbackDelay:
                     default: 60s

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2515,7 +2515,12 @@ bounds it to [0s, 24h].<br/>
         <td><b>sessionContinuity</b></td>
         <td>boolean</td>
         <td>
-          sessionContinuity preserves active sessions during failover.<br/>
+          sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+build: no runtime session preservation is performed during a path switch, so active
+sessions may drop on failover regardless of this value. It is retained so the intent
+stays expressible and a future release can honor it (#69); do not rely on it for
+session survival today. The default stays true only to preserve the field's prior
+admission behavior — it turns no preservation on.<br/>
           <br/>
             <i>Default</i>: true<br/>
         </td>

--- a/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
+++ b/nephio/packages/ntn-operators-crds/ntnslices-crd.yaml
@@ -132,8 +132,13 @@ spec:
                         duration('24h')
                   sessionContinuity:
                     default: true
-                    description: sessionContinuity preserves active sessions during
-                      failover.
+                    description: |-
+                      sessionContinuity is accepted for forward compatibility but is NOT enforced by this
+                      build: no runtime session preservation is performed during a path switch, so active
+                      sessions may drop on failover regardless of this value. It is retained so the intent
+                      stays expressible and a future release can honor it (#69); do not rely on it for
+                      session survival today. The default stays true only to preserve the field's prior
+                      admission behavior — it turns no preservation on.
                     type: boolean
                   switchbackDelay:
                     default: 60s


### PR DESCRIPTION
## What

`failoverPolicy.sessionContinuity`'s godoc claimed it *"preserves active sessions during failover"* — but in public `v1alpha1` **no code reads the field** (verified: zero references outside a single test fixture), so this build performs **no** runtime session preservation and active sessions may drop on a path switch regardless of the value. This makes the API doc honest.

- **godoc** (`api/v1alpha1/ntnslice_types.go`): now states it's accepted for forward compatibility but **not enforced**, that sessions may drop, and points at #69. Flows to the **four CRD copies** (`make manifests bundle nephio-sync`), `kubectl explain`, and the generated **`docs/api-reference.md`** (`make docs`).
- **CHANGELOG** (Changed): documentation-only, no behavior change; users who believed the field did something are warned it never took effect. (README already carried this caveat at line 337; the schema now does too.)

**Scope**: honesty only. The field, its `default=true`, and admission behavior are unchanged. The data-plane implementation is out of scope (tracked in #69).

## Verify
- Zero public readers of `SessionContinuity` (only a test fixture sets it) → "not enforced" is factual.
- `make lint` (golangci-lint v2.12.2) 0 issues; `go build`/`vet` clean.
- Generators idempotent: re-running `make manifests bundle nephio-sync docs` produces no further drift (7 files total).
- Wording is embargo-safe: reveals only that the field is inert + the #69 pointer, none of any future design.

## Note
I did **not** add a controller-set status *condition* for this (the user's D spec mentions "status"): a runtime condition would (a) begin wiring behavior around the field and (b) collide with a future implementation's own condition design. The honest signal is delivered via the schema description (`kubectl explain`) + docs. Happy to add a status condition instead if preferred.
