### PR TITLE
docs(adr): harden ADR-0011 grant contract (reconcile ordering, grant-writer authz, secret UID, list bounds)

### DIFF
--- a/docs/adr/0010-v1alpha2-secure-defaults-and-duration-validation.md
+++ b/docs/adr/0010-v1alpha2-secure-defaults-and-duration-validation.md
@@ -9,8 +9,8 @@ supersedes: []
 superseded_by: []
 implementation: []
 tracking:
+  - "https://github.com/thc1006/ntn-operators/issues/331"
   - "https://github.com/thc1006/ntn-operators/issues/214"
-  - "https://github.com/thc1006/ntn-operators/issues/315"
   - "https://github.com/thc1006/ntn-operators/issues/311"
   - "https://github.com/thc1006/ntn-operators/issues/299"
 ---

--- a/docs/adr/0011-remote-control-credential-grant.md
+++ b/docs/adr/0011-remote-control-credential-grant.md
@@ -30,13 +30,16 @@ that a point-in-time requester check cannot provide.
 Admission can prove that the actor submitting a CR may read a Secret at that
 moment. It cannot:
 
-- re-evaluate a stored CR after RBAC is withdrawn;
+- surface a durable, owner-controlled signal to stop using a credential after
+  the fact (it does not re-run the original author's SubjectAccessReview, and
+  this ADR does not add author-identity or author-RBAC tracking);
 - let the credential owner bind use to one gNB;
 - trigger reconcile when consent is withdrawn.
 
-A Secret informer would require broad list/watch access and still would not
-model owner intent. A separate consent object is watchable without increasing
-Secret permissions.
+The grant therefore provides Secret-owner-driven consent and revocation, not
+re-evaluation of the CR author's RBAC. A Secret informer would require broad
+list/watch access and still would not model owner intent. A separate consent
+object is watchable without increasing Secret permissions.
 
 ## Decision drivers
 
@@ -76,10 +79,35 @@ spec:
 
 - Grant and Secret are in the same namespace.
 - Cross-namespace reference is not introduced by this ADR.
-- Name is required; UID prevents delete/recreate name reuse when set.
-- target matching uses canonical host and port after syntax normalization but
-  before DNS resolution.
+- `allowedConsumers[].name` is required; its optional `uid` prevents
+  delete/recreate name reuse when set.
+- `secretRef` is name-bound. A Secret deleted and recreated under the same name
+  inherits the grant unless the optional `secretRef.uid` is set (mirroring the
+  consumer UID), so name reuse is a decision rather than an accident.
+- `allowedModes` uses ADR-0010's transport mode enum (`tls`, `mtls`,
+  `plaintext`). The grant is a v1alpha1 resource and authorizes both v1alpha1
+  and converted-v1alpha2 pushes; it is independent of the CR's transport
+  encoding version.
+- target matching uses one shared canonicalizer for host and port, applied
+  identically in admission, controller matching and tests: case-folded host,
+  trailing dot stripped, explicit port required, IPv6 in canonical form. Matching
+  is after syntax normalization but before DNS resolution.
 - the admin destination allow-list remains an outer bound.
+
+### Authorizing the grant writer
+
+"Owner-issued" is not a Kubernetes primitive: the API server knows a principal's
+verbs, not a Secret's owner. Any principal able to create or patch a grant in
+the namespace could otherwise self-issue one, so the secure profile requires,
+alongside `--require-credential-grant`, an admission control on the grant writer:
+
+- a ValidatingAdmissionPolicy requiring the principal creating or patching a
+  grant to hold `get` on the referenced Secret, and/or
+- a dedicated RBAC role for grant write that is not implied by `NTNCellConfig`
+  edit access.
+
+This is distinct from the default-off `credentialRefPolicy` (#309), which
+authorizes the `NTNCellConfig` writer against the Secret, not the grant writer.
 
 ### Enforcement
 
@@ -116,6 +144,27 @@ into the runtime authorization marker.
 This does not claim instant Secret-content rotation unless the deployment
 updates the grant revision or a future narrowly-authorized Secret watch exists.
 
+### Reconcile ordering
+
+Grant authorization must not reuse the ephemeris push dedup. The push path
+early-returns on `isEphemerisPushUpToDate` before the credential is resolved
+(#298), so an enqueue from a grant event alone would hit that dedup and skip the
+grant check until the next epoch marker (~3m). Two consequences follow.
+
+- Grant authorization is evaluated on a separate authorization marker (consumer,
+  target, mode and, when set, `credentialRevision`) checked independently of the
+  push marker. A grant delete, narrow or revision bump invalidates that
+  authorization marker and re-runs the check without waiting for a new epoch.
+- The credential digest is not folded into the push marker. #298 records why:
+  the push marker is load-bearing for dedup, gNB-restart recovery and
+  crash-idempotency (#230), and a benign CA-bundle rotation would otherwise force
+  a spurious ephemeris re-push.
+
+No credential is presented while the push dedup holds (#298), so the enforced
+guarantee is precise: a withdrawn grant refuses the next permitted push and
+flips `CredentialGrantAuthorized` to false rather than interrupting a push
+already in flight.
+
 ## Invariants
 
 - No grant contains token, key, certificate or CA bytes.
@@ -124,6 +173,12 @@ updates the grant revision or a future narrowly-authorized Secret watch exists.
 - UID mismatch denies when UID is specified.
 - disabling grant enforcement is an explicit admin choice and observable.
 - grant denial occurs before Secret read/dial.
+- authorization uses a marker independent of the ephemeris push dedup.
+- a single grant must match the full tuple; permissions are never assembled
+  across grants.
+- `allowedConsumers`, `allowedTargets` and `allowedModes` are bounded lists
+  (MinItems 1, capped MaxItems, set semantics); an empty list is deny-all and
+  wildcards are not supported.
 
 ## Alternatives
 
@@ -157,10 +212,16 @@ endpoint and mode and targets cross-namespace references.
 ## Test plan
 
 - exact tuple allow/deny;
-- UID mismatch and delete/recreate;
-- grant deletion/narrowing immediately reconciles healthy deduplicated cell;
+- consumer UID mismatch and delete/recreate;
+- Secret delete/recreate under the same name, with and without `secretRef.uid`;
+- grant deletion/narrowing flips `CredentialGrantAuthorized` on a healthy,
+  push-deduplicated cell via the separate authorization marker, not the push
+  marker;
+- grant-writer authorization: a principal without `get` on the Secret cannot
+  create the grant;
 - target and mode mismatch;
 - admin allow-list intersection;
+- empty allow-list is deny-all, not wildcard;
 - Secret never read on denial;
 - cache-sync/readiness behavior;
 - rotation with and without revision bump;
@@ -175,3 +236,5 @@ endpoint and mode and targets cross-namespace references.
   https://gateway-api.sigs.k8s.io/api-types/referencegrant/
 - Kubernetes authorization:
   https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+- ValidatingAdmissionPolicy:
+  https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/


### PR DESCRIPTION
## What

Hardens the on-main **ADR-0011** (owner-issued credential grant, still `proposed`/unimplemented) and does one **ADR-0010** tracking fix. Docs-only.

## Why

A detailed review targeted PRs **#328/#330**, but those are closed and the **#337** bundle already rewrote both ADRs — so most of the review is moot against `main` (ExternalName CVE miscitations, VAP-type-checking-on-CRD, Gateway API over-claim, ServiceReference DEFER-vs-MUST, legacy-plaintext-vs-schema, three-way allow-list contradiction, multiple-grant semantics, "unbounded stall"). The headline **numbering** demand is the reverse of settled `main` (0010 = transport, 0011 = grant) and is **not** changed.

The findings that *do* still bite the on-main ADR-0011 are pinned here, before anyone builds the grant:

1. **Reconcile ordering (verified against code + #298).** `pushRuntimeEphemeris` early-returns on `isEphemerisPushUpToDate` **before** `resolveRemoteControlTLS`, so an enqueue-only grant watch would skip the grant check until the next ~3m epoch marker. The ADR now states grant authz runs on a **separate authorization marker** (independent of the push dedup), and explicitly does **not** fold the credential digest into the push marker (#298: it is load-bearing for dedup / gNB-restart / #230 crash-idempotency; a benign CA rotation would force a spurious re-push). The guarantee is reframed precisely: refuse the *next permitted push* and flip `CredentialGrantAuthorized`, not interrupt an in-flight push (no credential is on the wire while dedup holds, per #298).
2. **Grant-writer authorization.** "Owner-issued" is not a Kubernetes primitive; the secure profile needs a VAP requiring the grant writer to hold `get` on the referenced Secret, and/or dedicated RBAC — distinct from the default-off `credentialRefPolicy` (#309), which authorizes the `NTNCellConfig` writer, not the grant writer.
3. **Secret identity.** `secretRef` is name-bound; pin Secret delete/recreate via an optional `secretRef.uid` (mirrors the consumer UID).
4. **Framing.** The grant is Secret-owner-driven revocation, not re-evaluation of the original CR author's RBAC.
5. **Cross-ADR alignment.** `allowedModes` uses ADR-0010's transport enum; the grant is version-independent of the CR's transport encoding.
6. **Contract hygiene.** Shared endpoint canonicalizer (case/trailing-dot/explicit-port/IPv6); list bounds + empty = deny-all, no wildcard.

**ADR-0010:** tracking swaps the closed dup **#315** for the on-point open **#331**.

## Verification

`make adr-lint` green (11 ADRs, metadata valid, index + internal anchors resolve). No file renames / title / status changes, so the README index is unaffected. Every code/issue claim traces to the controller source and #298.
