### PR TITLE
test(e2e): pin WSS + celestrak-mock image tags by digest

### DIFF
--- a/test/e2e/fixtures/celestrak-mock.yaml
+++ b/test/e2e/fixtures/celestrak-mock.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27-alpine
+          image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
           ports:
             - name: http
               containerPort: 80

--- a/test/e2e/wss_push_test.go
+++ b/test/e2e/wss_push_test.go
@@ -322,7 +322,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.29-alpine
+          image: nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
           ports: [{containerPort: 80, name: http}]
           # Ready means the fixture is actually servable, not merely that nginx started.
           readinessProbe:
@@ -391,7 +391,7 @@ spec:
     spec:
       containers:
         - name: gnb
-          image: golang:1.24-alpine
+          image: golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191
           command: ["go","run","/src/main.go"]
           env:
             - {name: GOCACHE, value: /tmp/gocache}
@@ -408,7 +408,7 @@ spec:
             - {name: src, mountPath: /src}
             - {name: tmp, mountPath: /tmp}
         - name: proxy
-          image: nginx:1.29-alpine
+          image: nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
           ports: [{containerPort: 8443, name: wss}]
           readinessProbe:
             tcpSocket: {port: 8443}


### PR DESCRIPTION
Pins the four e2e image references that still used mutable tags, matching the rest of the suite (curl / `ha_test.go` nginx are already digest-pinned).

| File | Tag | Digest |
|---|---|---|
| `wss_push_test.go` ×2 | `nginx:1.29-alpine` | `5616878291a2…` |
| `wss_push_test.go` | `golang:1.24-alpine` | `8bee1901f1e5…` |
| `fixtures/celestrak-mock.yaml` | `nginx:1.27-alpine` | `65645c7bb6a0…` |

Digests resolved via `docker buildx imagetools inspect` (index/multi-arch digest). `nginx:1.27-alpine` resolves to the **same** digest `ha_test.go` already pins — cross-checked, so the fixture and the HA test now agree.

**Why**: a mutable tag lets an upstream re-tag or a Go/Alpine patch change test semantics or flake unrelatedly, and weakens supply-chain reproducibility. Test-only, no behavior change; `go vet -tags e2e_wss` clean.

Context: this is the one actionable residual (§8) from an adversarial review of #332. The review's blocker findings (a runtime manager-patch clobbering the HA allow-list) were against a pre-merge commit; on `main` they're already resolved — `requireManagerAllowsGPHost` is a pure verifier, the CI allow-list carries the union of both hosts, and the WSS fixtures use a dedicated `ntn-e2e-wss` namespace.