### PR TITLE
fix(ocudu): bound + sanitize the gNB reply error before Condition/Event/log

### DIFF
--- a/pkg/provider/ocudu/wsclient.go
+++ b/pkg/provider/ocudu/wsclient.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/coder/websocket"
 
@@ -36,7 +38,44 @@ const (
 	wsDialTimeout = 5 * time.Second
 	// wsMaxPayload mirrors OCUDU's remote_control 16 KB frame cap.
 	wsMaxPayload = 16 * 1024
+	// maxRemoteErrorBytes caps gNB-supplied error text embedded in Condition/Event/log.
+	maxRemoteErrorBytes = 1024
 )
+
+// sanitizeRemoteError makes the untrusted gNB reply's {"error":...} text safe to embed in
+// a Condition message, Kubernetes Event, and log. A compromised gNB or proxy could
+// otherwise inject control, bidirectional-override, or zero-width runes to corrupt or
+// spoof `kubectl describe`/Event output (Trojan-Source style), or pad ~16 KiB toward the
+// reply cap. It maps Unicode Cc (control) to a space, drops Cf (format — covers bidi
+// overrides and zero-width joiners), collapses whitespace, and hard-caps the length.
+// Returns "(no detail)" when the input is empty or fully stripped.
+func sanitizeRemoteError(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	truncated := false
+	for _, r := range s {
+		if b.Len() >= maxRemoteErrorBytes {
+			truncated = true
+			break
+		}
+		switch {
+		case unicode.IsControl(r):
+			b.WriteByte(' ')
+		case unicode.In(r, unicode.Cf):
+			// bidi overrides + zero-width runes carry no visible glyph: drop them.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Join(strings.Fields(b.String()), " ")
+	if truncated {
+		out += " (truncated)"
+	}
+	if out == "" {
+		return "(no detail)"
+	}
+	return out
+}
 
 // ntnConfigUpdateEnvelope is the JSON frame OCUDU's remote_control WebSocket
 // server expects: {"cmd":"ntn_config_update","cells":[...]}. Values are PHYSICAL
@@ -445,7 +484,7 @@ func pushNTNConfigUpdate(
 		return &wsError{wsUnreachable, fmt.Sprintf("unparseable reply from %s: %q", endpoint, reply[:min(len(reply), 200)])}
 	}
 	if r.Error != "" {
-		return &wsError{wsRejected, fmt.Sprintf("gNB rejected ntn_config_update: %s", r.Error)}
+		return &wsError{wsRejected, fmt.Sprintf("gNB rejected ntn_config_update: %s", sanitizeRemoteError(r.Error))}
 	}
 
 	return nil

--- a/pkg/provider/ocudu/wsclient_sanitize_test.go
+++ b/pkg/provider/ocudu/wsclient_sanitize_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocudu
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Unsafe/invisible runes are built from numeric code points so this test's own source
+// carries no literal control, bidi, or zero-width characters to mistype or to trip a
+// bidi linter.
+var (
+	rlo   = string(rune(0x202e)) // RIGHT-TO-LEFT OVERRIDE (bidi, Cf)
+	zwsp  = string(rune(0x200b)) // ZERO WIDTH SPACE (Cf)
+	zwj   = string(rune(0x200d)) // ZERO WIDTH JOINER (Cf)
+	bom   = string(rune(0xfeff)) // ZERO WIDTH NO-BREAK SPACE / BOM (Cf)
+	wj    = string(rune(0x2060)) // WORD JOINER (Cf)
+	hanZi = string(rune(0x4e16)) // 世 — a 3-byte printable rune
+)
+
+func TestSanitizeRemoteError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "invalid epoch", "invalid epoch"},
+		{"empty", "", "(no detail)"},
+		{"only control and format", "\x00\n\t" + zwsp + rlo, "(no detail)"},
+		{"newlines and tabs collapse to space", "line1\nline2\ttab", "line1 line2 tab"},
+		{"nul becomes space", "bad\x00cell", "bad cell"},
+		{"bidi override dropped", "safe" + rlo + "gndiffer", "safegndiffer"},
+		{"zero-width runes dropped", "a" + zwsp + "b" + zwj + "c" + bom + "d" + wj + "e", "abcde"},
+		{"printable multibyte kept", hanZi + "-epoch", hanZi + "-epoch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeRemoteError(tt.in)
+			if got != tt.want {
+				t.Fatalf("sanitizeRemoteError(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			assertSanitized(t, got)
+		})
+	}
+}
+
+func TestSanitizeRemoteError_HardCapsLength(t *testing.T) {
+	// 4 KiB of attacker text (well within the 16 KiB reply cap) must be bounded.
+	got := sanitizeRemoteError(strings.Repeat("A", 4096))
+	if !strings.HasSuffix(got, " (truncated)") {
+		t.Fatalf("oversized input must be marked truncated: %q...", got[:min(len(got), 48)])
+	}
+	body := strings.TrimSuffix(got, " (truncated)")
+	// Allow at most one over-bound rune (the loop checks the cap before each rune).
+	if len(body) > maxRemoteErrorBytes+utf8.UTFMax {
+		t.Fatalf("bounded body = %d bytes, want <= %d", len(body), maxRemoteErrorBytes+utf8.UTFMax)
+	}
+	assertSanitized(t, got)
+}
+
+func TestSanitizeRemoteError_TruncationIsRuneSafe(t *testing.T) {
+	// 3-byte runes filling past the cap: a naive byte cut would split one and produce
+	// invalid UTF-8. Truncation must land on a rune boundary.
+	got := sanitizeRemoteError(strings.Repeat(hanZi, maxRemoteErrorBytes))
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated output is not valid UTF-8: %q", got)
+	}
+	assertSanitized(t, got)
+}
+
+// assertSanitized fails if out is invalid UTF-8 or retains any control (Cc) or format
+// (Cf — bidi/zero-width) rune, i.e. anything that could corrupt or spoof a Condition,
+// Event, or kubectl-describe rendering.
+func assertSanitized(t *testing.T, out string) {
+	t.Helper()
+	if !utf8.ValidString(out) {
+		t.Fatalf("output is not valid UTF-8: %q", out)
+	}
+	for _, r := range out {
+		if unicode.IsControl(r) || unicode.In(r, unicode.Cf) {
+			t.Fatalf("output retains unsafe rune %U in %q", r, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

The gNB WebSocket reply's `{"error":...}` field was interpolated **raw** into the `wsRejected` error at `wsclient.go:448` (`fmt.Sprintf("gNB rejected ntn_config_update: %s", r.Error)`), and that text flows unchanged into three operator-facing surfaces:

- the `EphemerisPushed` **Condition** message (`message := pushErr.Error()`),
- the `EphemerisPushFailed` **Event** (`Eventf(…, "%s", message)`),
- the failure **log** (`log.Error(pushErr, …)`).

The only existing bound is the 16 KiB reply cap (`SetReadLimit(wsMaxPayload)`), so a **compromised gNB or proxy** could inject control, bidirectional-override, or zero-width runes to corrupt/spoof `kubectl describe` + Event rendering (Trojan-Source style), or pad ~16 KiB toward the cap. (JSON log escaping only protects the log surface; Condition/Event are rendered as plain text.)

## Fix

`sanitizeRemoteError` at the single WS sink: maps Unicode **Cc** (control) → space, drops **Cf** (format — bidi overrides + zero-width joiners), collapses whitespace, and hard-caps at **1 KiB** rune-safely (marked `(truncated)`). One place fixes all three surfaces.

**Deliberately unchanged**: the `reason` label (enum) and metrics were never attacker-controlled; the unparseable-reply path (`:445`) is already bounded (`[:200]`) and `%q`-quoted.

## Verify
- Table test: control / bidi (RLO) / zero-width (ZWSP, ZWJ, BOM, WJ) / oversize / rune-safe truncation; asserts the output retains **no** Cc/Cf rune and is valid UTF-8. The test builds unsafe runes from code points so its own source carries none (no `bidichk` risk).
- **Mutation-verified**: keep-Cf, remove-cap, and keep-control each make a guard test fail.
- `make lint` (golangci-lint v2.12.2) 0 issues; `go vet` clean; full `ocudu` package green.

Hygiene hardening — not a release blocker (the 16 KiB cap already prevents unbounded amplification).