### PR TITLE
feat(ephemeris): opt-in source-host allow-list for CelesTrak fetches (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **New opt-in `--ephemeris-allowed-source-hosts` allow-list confines CelesTrak ephemeris fetches to
+  admin-sanctioned hosts (#227).** A `SatelliteEphemeris` `spec.source.url` is CR-author-controlled, so
+  for a CelesTrak source the operator would otherwise `GET` from any host the author names (the SSRF-safe
+  dialer already blocks private IPs, but not arbitrary public hosts). The new flag gates the source host
+  before any dial — empty (default) permits all, backward compatible, mirroring
+  `--remote-control-allowed-endpoint-hosts`. A refused fetch reports `SourceHostNotAllowed` and, if a
+  matching cache exists, keeps SIB19 alive from it. SpaceTrack is **not** gated: its contact host is the
+  fixed, admin-configured API base (not `spec.source.url`), so it is already sanctioned. Defense-in-depth /
+  source integrity — not a fix for a credential path (Space-Track credentials only ever go to the hardcoded base).
+
 - **The `remoteControl` endpoint allow-list now gates plaintext pushes too, not only credentialed ones.**
   `--remote-control-allowed-endpoint-hosts` previously refused only a *credentialed* (`remoteControl.tls`)
   push to a non-allowlisted host (closing bearer exfiltration); a *plaintext* `ws://` push escaped it, so

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,6 +165,13 @@ func main() {
 			"Set this only to enable internal CelesTrak mirrors (e.g. air-gapped "+
 			"deployments) or E2E test mock servers. Production clusters with public "+
 			"CelesTrak access should leave this empty.")
+
+	var ephemerisAllowedSourceHosts string
+	flag.StringVar(&ephemerisAllowedSourceHosts, "ephemeris-allowed-source-hosts", "",
+		"Comma-separated hostnames a CelesTrak SatelliteEphemeris source URL may be fetched "+
+			"from (defense-in-depth source integrity, #227). Empty (default) permits any host; "+
+			"set it to confine ephemeris fetches to admin-sanctioned sources. SpaceTrack's host "+
+			"is the fixed API base and is not gated by this flag.")
 	var remoteControlAllowedHosts string
 	flag.StringVar(&remoteControlAllowedHosts, "remote-control-allowed-endpoint-hosts", "",
 		"Comma-separated list of hostnames any NTNCellConfig "+
@@ -263,6 +270,7 @@ func main() {
 		Recorder:                mgr.GetEventRecorder("satelliteephemeris-controller"),
 		Fetcher:                 ephemeris.NewCelesTrakFetcher(gpHTTPClient),
 		SpaceTrackFetcher:       spaceTrackFetcher,
+		SourceHostAllowlist:     netutil.ParseEndpointAllowlist(ephemerisAllowedSourceHosts),
 		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "SatelliteEphemeris")

--- a/internal/controller/satelliteephemeris_controller.go
+++ b/internal/controller/satelliteephemeris_controller.go
@@ -77,6 +77,10 @@ type SatelliteEphemerisReconciler struct {
 	Fetcher                 ephemeris.GPFetcher          // CelesTrak fetcher
 	SpaceTrackFetcher       *ephemeris.SpaceTrackFetcher // SpaceTrack fetcher (nil = disabled)
 
+	// SourceHostAllowlist restricts which hosts a CelesTrak source URL may be fetched from
+	// (#227 defense-in-depth / admin source integrity). Empty = permit-all (backward compatible).
+	SourceHostAllowlist netutil.EndpointAllowlist
+
 	// Now returns the current time; nil defaults to time.Now(). Injected in tests to make two
 	// clock-dependent behaviours deterministic: the propagation epoch (sampled at PROPAGATION time,
 	// not reconcile-start) and the fetch-retry backoff window (cacheServe's suppression gate and the
@@ -897,9 +901,13 @@ func (r *SatelliteEphemerisReconciler) acquireOMMs(
 	if c, ok := r.matchingCache(req.NamespacedName, eph); ok {
 		log.Info("fetcher/credential setup failed; serving cached OMMs for SIB19 continuity",
 			"err", fetcherErr.Error(), "cacheAge", now.Sub(c.result.FetchedAt).String())
+		serveReason := reasonSetupFailedServingCache
+		if errors.Is(fetcherErr, errSourceHostNotAllowed) {
+			serveReason = reasonSourceHostNotAllowed
+		}
 		return ommFetchOutcome{
 			result: c.result, servedCacheOnError: true,
-			cacheServeErr: fetcherErr, serveReason: reasonSetupFailedServingCache,
+			cacheServeErr: fetcherErr, serveReason: serveReason,
 		}, nil, nil
 	}
 
@@ -912,10 +920,14 @@ func (r *SatelliteEphemerisReconciler) acquireOMMs(
 func (r *SatelliteEphemerisReconciler) handleSetupFailure(
 	ctx context.Context, eph *ntnv1alpha1.SatelliteEphemeris, fetcherErr error, clamp *clampWarn,
 ) (ctrl.Result, error) {
+	reason := "FetcherSetupFailed"
+	if errors.Is(fetcherErr, errSourceHostNotAllowed) {
+		reason = reasonSourceHostNotAllowed // a policy refusal, not a credential/setup failure
+	}
 	meta.SetStatusCondition(&eph.Status.Conditions, metav1.Condition{
 		Type:               ntnv1alpha1.ConditionGPDataFetched,
 		Status:             metav1.ConditionFalse,
-		Reason:             "FetcherSetupFailed",
+		Reason:             reason,
 		Message:            fetcherErr.Error(),
 		ObservedGeneration: eph.Generation,
 	})
@@ -1744,6 +1756,10 @@ type ommFetchOutcome struct {
 const (
 	reasonFetchFailedServingCache = "FetchFailedServingCache"
 	reasonSetupFailedServingCache = "FetcherSetupFailedServingCache"
+	// reasonSourceHostNotAllowed marks a fetch refused because the source host is not in the
+	// operator's --ephemeris-allowed-source-hosts allow-list (#227) — a policy refusal distinct
+	// from a credential/setup failure, so an admin can alert on it specifically.
+	reasonSourceHostNotAllowed = "SourceHostNotAllowed"
 )
 
 // obtainOMMs resolves the OMM data for this reconcile (Step 4b/5). It returns the
@@ -1872,6 +1888,17 @@ func classifyFetchError(fetchErr error, effectiveInterval time.Duration) (reason
 // existence or key shape. #222 review blocker 3.
 var errSpaceTrackCredentialUnavailable = errors.New("Space-Track credentials unavailable or not authorized")
 
+// errSourceHostNotAllowed marks a fetch refused up front because the CelesTrak source host is
+// not in the operator's --ephemeris-allowed-source-hosts allow-list. Returned by fetcherForSource
+// BEFORE any dial, so a non-sanctioned source is never contacted.
+var errSourceHostNotAllowed = errors.New("ephemeris source host is not in the operator allow-list")
+
+// Supported spec.source.type values.
+const (
+	sourceTypeCelesTrak  = "CelesTrak"
+	sourceTypeSpaceTrack = "SpaceTrack"
+)
+
 // fetcherForSource returns the appropriate GPFetcher for the source type.
 // For SpaceTrack, it also loads credentials from the referenced Secret.
 func (r *SatelliteEphemerisReconciler) fetcherForSource(
@@ -1879,14 +1906,25 @@ func (r *SatelliteEphemerisReconciler) fetcherForSource(
 ) (ephemeris.GPFetcher, error) {
 	log := logf.FromContext(ctx)
 	log.V(1).Info("selecting fetcher", "sourceType", eph.Spec.Source.Type)
+
+	// Source-host allow-list (#227): refuse to CONTACT a non-sanctioned host before any dial.
+	// CelesTrak's source host is CR-author-controlled and fetched directly; SpaceTrack's contact
+	// host is the admin-hardcoded base (cmd/main.go), so it is already sanctioned and not gated
+	// here. Empty allow-list = permit-all (backward compatible), mirroring the remoteControl gate.
+	if eph.Spec.Source.Type == sourceTypeCelesTrak {
+		if err := r.SourceHostAllowlist.Check(eph.Spec.Source.URL); err != nil {
+			return nil, fmt.Errorf("%w: %v", errSourceHostNotAllowed, err)
+		}
+	}
+
 	switch eph.Spec.Source.Type {
-	case "CelesTrak":
+	case sourceTypeCelesTrak:
 		if r.Fetcher == nil {
 			return nil, fmt.Errorf("CelesTrak fetcher is not configured")
 		}
 		return r.Fetcher, nil
 
-	case "SpaceTrack":
+	case sourceTypeSpaceTrack:
 		if r.SpaceTrackFetcher == nil {
 			return nil, fmt.Errorf("SpaceTrack fetcher is not configured")
 		}

--- a/internal/controller/satelliteephemeris_source_allowlist_test.go
+++ b/internal/controller/satelliteephemeris_source_allowlist_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ntnv1alpha1 "github.com/thc1006/ntn-operators/api/v1alpha1"
+	"github.com/thc1006/ntn-operators/pkg/netutil"
+)
+
+func ephWithSource(srcType, url string) *ntnv1alpha1.SatelliteEphemeris {
+	return &ntnv1alpha1.SatelliteEphemeris{
+		Spec: ntnv1alpha1.SatelliteEphemerisSpec{
+			Source: ntnv1alpha1.EphemerisSource{Type: srcType, URL: url},
+		},
+	}
+}
+
+func TestFetcherForSource_SourceHostAllowlist(t *testing.T) {
+	const celestrak = "https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=json"
+
+	t.Run("CelesTrak host not in allow-list is refused before any dial", func(t *testing.T) {
+		r := &SatelliteEphemerisReconciler{
+			Fetcher:             &mockGPFetcher{}, // present, but must not be returned
+			SourceHostAllowlist: netutil.ParseEndpointAllowlist("space-track.org"),
+		}
+		f, err := r.fetcherForSource(context.Background(), ephWithSource("CelesTrak", celestrak))
+		if !errors.Is(err, errSourceHostNotAllowed) {
+			t.Fatalf("expected errSourceHostNotAllowed, got %v", err)
+		}
+		if f != nil {
+			t.Errorf("no fetcher must be returned on a policy refusal, got %T", f)
+		}
+	})
+
+	t.Run("CelesTrak host in allow-list is permitted", func(t *testing.T) {
+		r := &SatelliteEphemerisReconciler{
+			Fetcher:             &mockGPFetcher{},
+			SourceHostAllowlist: netutil.ParseEndpointAllowlist("celestrak.org"),
+		}
+		f, err := r.fetcherForSource(context.Background(), ephWithSource("CelesTrak", celestrak))
+		if err != nil {
+			t.Fatalf("allow-listed host must be permitted, got %v", err)
+		}
+		if f == nil {
+			t.Error("expected the configured fetcher, got nil")
+		}
+	})
+
+	t.Run("empty allow-list permits any host (backward compatible)", func(t *testing.T) {
+		r := &SatelliteEphemerisReconciler{Fetcher: &mockGPFetcher{}} // zero-value allow-list
+		if _, err := r.fetcherForSource(context.Background(), ephWithSource("CelesTrak", celestrak)); err != nil {
+			t.Fatalf("empty allow-list must permit any host, got %v", err)
+		}
+	})
+
+	t.Run("SpaceTrack is not gated by the source-host allow-list", func(t *testing.T) {
+		// SpaceTrack's contact host is the admin-hardcoded API base, so the CelesTrak-scoped
+		// gate must not fire even when the source URL host is absent from the allow-list.
+		r := &SatelliteEphemerisReconciler{
+			SpaceTrackFetcher:   nil, // disabled → a DIFFERENT error, never the host refusal
+			SourceHostAllowlist: netutil.ParseEndpointAllowlist("celestrak.org"),
+		}
+		_, err := r.fetcherForSource(context.Background(),
+			ephWithSource("SpaceTrack", "https://www.space-track.org/basicspacedata/query/..."))
+		if errors.Is(err, errSourceHostNotAllowed) {
+			t.Fatalf("SpaceTrack must not be gated by the source-host allow-list, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes one of #227's deferred items: an admin allow-list confining **CelesTrak** ephemeris fetches to sanctioned hosts.

## Why
`SatelliteEphemeris.spec.source.url` is CR-author-controlled. For a CelesTrak source the operator `GET`s from whatever host the author names — the SSRF-safe dialer blocks private IPs but not arbitrary **public** hosts. This adds defense-in-depth / source integrity (for the sovereign beachhead: only fetch orbital data from admin-sanctioned sources), mirroring the merged `--remote-control-allowed-endpoint-hosts` (#300).

## What
- **`--ephemeris-allowed-source-hosts`** (comma-separated; empty = permit-all, backward compatible), reusing `netutil.EndpointAllowlist.Check`.
- `fetcherForSource` refuses a non-sanctioned CelesTrak host **before any dial** (`errSourceHostNotAllowed`); the existing setup-failure fallback keeps SIB19 alive from cache when one exists, and the condition reports **`SourceHostNotAllowed`**.
- **SpaceTrack is deliberately not gated**: its contact host is the admin-hardcoded API base (`cmd/main.go`), not `spec.source.url`, so it's already sanctioned. This is also why the change is **not** a credential-path fix — Space-Track credentials only ever go to the fixed base (verified).

## Verify
- Additive: the `acquireOMMs` cache-continuity logic is unchanged; only an early refusal + a distinct reason label.
- Unit test: refuse-before-fetch / allow-listed / empty=permit-all / SpaceTrack-not-gated. **Mutation-verified** (defeat the check, drop the CelesTrak scoping — each fails a guard).
- Full controller suite (166 specs incl. continuity) + ephemeris + netutil green; `make lint` 0 issues.

Refs #227 (remaining items: rate limiter, cross-CR singleflight, per-hop timeout).