### PR TITLE
test(e2e-wss): make the guards guard, and leave evidence when an arm fails

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -319,7 +319,7 @@ jobs:
           for arm in \
             'mtls\+bearer_reaches_the_plaintext_gNB_behind_the_proxy' \
             'wrong_bearer_is_RemoteEndpointRejected' \
-            'token_without_ca.crt_is_refused_before_the_dial' \
+            'token_without_ca.crt_delivers_no_payload' \
             'dropping_the_client_certificate_is_refused_by_the_proxy' \
             'endpoint_outside_the_admin_allow-list_is_refused_before_the_Secret_is_read'; do
             grep -Eq "^    --- PASS: TestWSSCredentialedPush/${arm}" /tmp/wss_e2e.out || {

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -321,6 +321,8 @@ jobs:
             'wrong_bearer_is_RemoteEndpointRejected' \
             'token_without_ca.crt_delivers_no_payload' \
             'dropping_the_client_certificate_is_refused_by_the_proxy' \
+            'a_credential_pinning_the_wrong_CA_refuses_the_server_certificate' \
+            'mode_tls_succeeds_against_a_proxy_that_wants_no_client_certificate' \
             'endpoint_outside_the_admin_allow-list_is_refused_before_the_Secret_is_read'; do
             grep -Eq "^    --- PASS: TestWSSCredentialedPush/${arm}" /tmp/wss_e2e.out || {
               echo "FALSE GREEN: arm ${arm} did not run+PASS"; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stdlib-only Go mounted from a ConfigMap and run with the stock `golang` image, and the proxy is stock
   `nginx` — so it runs identically on Kind in CI and on a plain kubeadm cluster, with no Docker, no
   registry and no `kind load`. The nginx config is read from `config/samples/remote-control-tls/`, so
-  the shipped sample is what is under test rather than a copy that could drift. Four arms: the happy
+  the shipped sample is what is under test rather than a copy that could drift. Five arms: the happy
   path (frame validated for cmd/plmn/nci/future-epoch), a wrong bearer classified as
   `RemoteEndpointRejected`, a token without `ca.crt` refused before any dial (#313), and a dropped
   client certificate refused by the proxy — the last three each also asserting that **nothing** reached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stdlib-only Go mounted from a ConfigMap and run with the stock `golang` image, and the proxy is stock
   `nginx` — so it runs identically on Kind in CI and on a plain kubeadm cluster, with no Docker, no
   registry and no `kind load`. The nginx config is read from `config/samples/remote-control-tls/`, so
-  the shipped sample is what is under test rather than a copy that could drift. Five arms: the happy
+  the shipped sample is what is under test rather than a copy that could drift. Seven arms: the happy
   path (frame validated for cmd/plmn/nci/future-epoch), a wrong bearer classified as
   `RemoteEndpointRejected`, a token without `ca.crt` refused before any dial (#313), and a dropped
   client certificate refused by the proxy — the last three each also asserting that **nothing** reached

--- a/test/e2e/wss_guard_test.go
+++ b/test/e2e/wss_guard_test.go
@@ -1,0 +1,22 @@
+//go:build e2e_wss
+
+package e2e
+
+import "testing"
+
+// TestGuardsFailOnAmbiguity is a unit-level check of the two guards that were reading a different
+// value than the manager they guard. It needs no cluster: it drives the parsing directly.
+func TestGuardsFailOnAmbiguity(t *testing.T) {
+	t.Run("repeated flag is fatal, not silently first-wins", func(t *testing.T) {
+		args := []string{"--a=1", "--ephemeris-allowed-private-hosts=good", "--ephemeris-allowed-private-hosts=clobber"}
+		if got := flagOccurrences(args, "--ephemeris-allowed-private-hosts"); len(got) != 2 {
+			t.Fatalf("occurrences = %v, want both recorded so the caller can refuse", got)
+		}
+	})
+	t.Run("single flag parses", func(t *testing.T) {
+		got := flagOccurrences([]string{"--ephemeris-allowed-private-hosts=a,b"}, "--ephemeris-allowed-private-hosts")
+		if len(got) != 1 || got[0] != "a,b" {
+			t.Fatalf("occurrences = %v", got)
+		}
+	})
+}

--- a/test/e2e/wss_push_test.go
+++ b/test/e2e/wss_push_test.go
@@ -75,6 +75,10 @@ const (
 	wssToken    = "e2e-wss-bearer-token"
 	wssNorad    = 25544
 	wssGPMock   = "e2e-wss-gp"
+	// The mTLS listener the sample documents, and the TLS-only listener the sample documents as
+	// a two-line deletion from it. Both are served by the same pod in front of one backend.
+	wssMTLSPort = 8443
+	wssTLSPort  = 8444
 )
 
 // wssRunNCI makes this run's frames distinguishable from any earlier run's. The backend log is
@@ -299,6 +303,66 @@ func proxyLogCount(t *testing.T, sub string) int {
 	return strings.Count(out, sub)
 }
 
+// sampleNginxConfTLSOnly is the variant the sample itself documents:
+//
+//	# Drop these two lines (and use tls.mode "tls") if you only want a bearer token.
+//	ssl_client_certificate /certs/ca.crt;
+//	ssl_verify_client on;
+//
+// Deriving it here rather than writing a second config by hand means the TLS-only arm tests the
+// documented instruction, not an invention of this test — and if the sample stops matching, the
+// derivation fails loudly instead of silently testing something else.
+func sampleNginxConfTLSOnly(t *testing.T) string {
+	t.Helper()
+	conf := sampleNginxConf(t)
+	for _, drop := range []string{"ssl_client_certificate", "ssl_verify_client"} {
+		var kept []string
+		found := false
+		for line := range strings.SplitSeq(conf, "\n") {
+			if strings.Contains(line, drop) {
+				found = true
+				continue
+			}
+			kept = append(kept, line)
+		}
+		if !found {
+			t.Fatalf("the sample no longer contains %q, so the TLS-only variant it documents "+
+				"(%q) cannot be derived from it", drop, "drop these two lines")
+		}
+		conf = strings.Join(kept, "\n")
+	}
+	listen := fmt.Sprintf("listen %d ssl", wssMTLSPort)
+	if !strings.Contains(conf, listen) {
+		t.Fatalf("the sample no longer listens on %d; this test moves that listener to %d",
+			wssMTLSPort, wssTLSPort)
+	}
+	return strings.Replace(conf, listen, fmt.Sprintf("listen %d ssl", wssTLSPort), 1)
+}
+
+// foreignCA is a throwaway CA unrelated to the one the proxy serves under. Pinning it in the
+// credential must make the operator refuse the server certificate.
+func foreignCA(t *testing.T) []byte {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "e2e-wss-foreign-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &k.PublicKey, k)
+	if err != nil {
+		t.Fatalf("create foreign ca: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
 // ---------------------------------------------------------------- deployment
 
 func deployGPMock(t *testing.T) {
@@ -362,15 +426,18 @@ func deployGNB(t *testing.T, ca, server certPair) {
 	root, _ := os.Getwd()
 	stub := filepath.Join(root, "fixtures", "gnb-remote-control-stub.go.txt")
 
-	_, _ = kubectl(t, "-n", wssNS, "delete", "configmap", wssGNB+"-src", wssGNB+"-conf", "--ignore-not-found")
+	_, _ = kubectl(t, "-n", wssNS, "delete", "configmap",
+		wssGNB+"-src", wssGNB+"-conf", wssGNB+"-conf-tls", "--ignore-not-found")
 	if out, err := kubectl(t, "-n", wssNS, "create", "configmap", wssGNB+"-src", "--from-file=main.go="+stub); err != nil {
 		t.Fatalf("create stub configmap: %v: %s", err, out)
 	}
-	conf := sampleNginxConf(t)
-	cmd := exec.Command("kubectl", "-n", wssNS, "create", "configmap", wssGNB+"-conf", "--from-file=nginx.conf=/dev/stdin")
-	cmd.Stdin = strings.NewReader(conf)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("create nginx configmap: %v: %s", err, out)
+	conf, confTLS := sampleNginxConf(t), sampleNginxConfTLSOnly(t)
+	for _, c := range []struct{ name, body string }{{wssGNB + "-conf", conf}, {wssGNB + "-conf-tls", confTLS}} {
+		cmd := exec.Command("kubectl", "-n", wssNS, "create", "configmap", c.name, "--from-file=nginx.conf=/dev/stdin")
+		cmd.Stdin = strings.NewReader(c.body)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("create %s: %v: %s", c.name, err, out)
+		}
 	}
 	_, _ = kubectl(t, "-n", wssNS, "delete", "secret", wssGNB+"-tls", "--ignore-not-found")
 	if err := createSecret(t, wssGNB+"-tls", map[string][]byte{
@@ -384,7 +451,8 @@ func deployGNB(t *testing.T, ca, server certPair) {
 	// serving the old chain and every dial would fail x509 verification. Observed: a second run in
 	// a kept namespace failed every arm with "certificate signed by unknown authority". Rolling on
 	// a checksum of exactly what nginx loads is the Helm checksum/config pattern.
-	sum := sha256.Sum256(bytes.Join([][]byte{[]byte(conf), ca.certPEM, server.certPEM, server.keyPEM}, nil))
+	sum := sha256.Sum256(bytes.Join([][]byte{
+		[]byte(conf), []byte(confTLS), ca.certPEM, server.certPEM, server.keyPEM}, nil))
 	kubectlApply(t, fmt.Sprintf(`
 apiVersion: apps/v1
 kind: Deployment
@@ -415,6 +483,18 @@ spec:
           volumeMounts:
             - {name: src, mountPath: /src}
             - {name: tmp, mountPath: /tmp}
+        - name: proxy-tls
+          # The SAME sample config with the two client-verification lines dropped: TLS + bearer,
+          # no client certificate. Without it, mode "tls" is only ever exercised as the negative
+          # half of an mTLS test, so the whole TLS-plus-bearer path could break unnoticed.
+          image: nginx:1.29-alpine
+          ports: [{containerPort: %[6]d, name: tls}]
+          readinessProbe:
+            tcpSocket: {port: %[6]d}
+            periodSeconds: 2
+          volumeMounts:
+            - {name: conf-tls, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf}
+            - {name: certs,    mountPath: /certs, readOnly: true}
         - name: proxy
           image: nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
           ports: [{containerPort: 8443, name: wss}]
@@ -426,7 +506,8 @@ spec:
             - {name: certs, mountPath: /certs, readOnly: true}
       volumes:
         - {name: src,   configMap: {name: %[1]s-src}}
-        - {name: conf,  configMap: {name: %[1]s-conf}}
+        - {name: conf,     configMap: {name: %[1]s-conf}}
+        - {name: conf-tls, configMap: {name: %[1]s-conf-tls}}
         - {name: certs, secret: {secretName: %[1]s-tls}}
         - {name: tmp,   emptyDir: {}}
 ---
@@ -435,8 +516,10 @@ kind: Service
 metadata: {name: %[3]s, namespace: %[2]s}
 spec:
   selector: {app: %[1]s}
-  ports: [{name: wss, port: 8443, targetPort: 8443}]
-`, wssGNB, wssNS, wssSvc, hex.EncodeToString(sum[:8])))
+  ports:
+    - {name: wss, port: %[5]d, targetPort: %[5]d}
+    - {name: wss-tls, port: %[6]d, targetPort: %[6]d}
+`, wssGNB, wssNS, wssSvc, hex.EncodeToString(sum[:8]), wssMTLSPort, wssTLSPort))
 	if _, err := kubectl(t, "-n", wssNS, "rollout", "status", "deploy/"+wssGNB, "--timeout=300s"); err != nil {
 		t.Fatalf("gnb not ready: %v", err)
 	}
@@ -737,7 +820,7 @@ spec:
     type: ocudu
     namespace: %[2]s
     remoteControl:
-      endpoint: "%[3]s.%[2]s.svc:8443"
+      endpoint: "%[3]s.%[2]s.svc:%[8]d"
       tls: {mode: mtls, secretName: %[4]s}
   cellID: {plmn: "00101", nci: %[7]d}
   ephemerisRef: %[5]s
@@ -745,7 +828,7 @@ spec:
   ntn:
     cellSpecificKoffset: 100
     ephemerisECEF: {posX: 1000000, posY: 2000000, posZ: 3000000, velX: 0, velY: 0, velZ: 0}
-`, wssCell, wssNS, wssSvc, wssCredName, wssSatEph, wssNorad, wssRunNCI))
+`, wssCell, wssNS, wssSvc, wssCredName, wssSatEph, wssNorad, wssRunNCI, wssMTLSPort))
 
 	// --- arm 1: the whole chain works, and the PLAINTEXT backend proves it -------------
 	t.Run("mtls+bearer reaches the plaintext gNB behind the proxy", func(t *testing.T) {
@@ -832,6 +915,36 @@ spec:
 		waitCondition(t, "True/Pushed", 3*time.Minute)
 	})
 
+	// --- arm 6: the server certificate is actually verified -----------------------------
+	// The happy path proves a CORRECT chain works, which a client with verification disabled
+	// also does. Only a chain the client should reject separates the two, so this is the arm
+	// that fails if anyone reaches for InsecureSkipVerify.
+	t.Run("a credential pinning the wrong CA refuses the server certificate", func(t *testing.T) {
+		before := framesReceived(t)
+		patchSecretCA(t, wssCredName, foreignCA(t))
+		bumpGeneration(t, "foreign-ca")
+		waitCondition(t, "False/ProviderPushFailed", 3*time.Minute)
+		if now := framesReceived(t); now != before {
+			t.Errorf("frames went %d -> %d: the operator accepted a server certificate signed by a CA "+
+				"its credential does not pin — server verification is not being enforced", before, now)
+		}
+		patchSecretCA(t, wssCredName, ca.certPEM)
+		bumpGeneration(t, "restore-ca")
+		waitCondition(t, "True/Pushed", 3*time.Minute)
+	})
+
+	// --- arm 7: TLS + bearer, no client certificate ---------------------------------------
+	t.Run("mode tls succeeds against a proxy that wants no client certificate", func(t *testing.T) {
+		before := framesReceived(t)
+		patchEndpointAndMode(t, fmt.Sprintf("%s.%s.svc:%d", wssSvc, wssNS, wssTLSPort), "tls")
+		waitCondition(t, "True/Pushed", 3*time.Minute)
+		if now := framesReceived(t); now <= before {
+			t.Errorf("condition says pushed but frames stayed at %d: mode tls delivered nothing", before)
+		}
+		patchEndpointAndMode(t, fmt.Sprintf("%s.%s.svc:%d", wssSvc, wssNS, wssMTLSPort), "mtls")
+		waitCondition(t, "True/Pushed", 3*time.Minute)
+	})
+
 	t.Run("endpoint outside the admin allow-list is refused before the Secret is read", func(t *testing.T) {
 		runEndpointAllowlistArm(t)
 	})
@@ -870,6 +983,26 @@ func runEndpointAllowlistArm(t *testing.T) {
 		t.Fatalf("restore endpoint: %v: %s", err, out)
 	}
 	waitCondition(t, "True/Pushed", 3*time.Minute)
+}
+
+// patchSecretCA swaps the pinned trust anchor without touching the rest of the credential.
+func patchSecretCA(t *testing.T, name string, caPEM []byte) {
+	t.Helper()
+	if out, err := kubectl(t, "-n", wssNS, "patch", "secret", name, "--type=merge",
+		fmt.Sprintf(`-p={"data":{"ca.crt":%q}}`, base64.StdEncoding.EncodeToString(caPEM))); err != nil {
+		t.Fatalf("patch ca.crt on %s: %v: %s", name, err, out)
+	}
+}
+
+// patchEndpointAndMode moves the cell between the two listeners. Both are the same host, so the
+// admin endpoint allow-list (which matches on host) is satisfied either way.
+func patchEndpointAndMode(t *testing.T, endpoint, mode string) {
+	t.Helper()
+	if out, err := kubectl(t, "-n", wssNS, "patch", "ntncellconfig", wssCell, "--type=merge",
+		fmt.Sprintf(`-p={"spec":{"provider":{"remoteControl":{"endpoint":%q,"tls":{"mode":%q,"secretName":%q}}}}}`,
+			endpoint, mode, wssCredName)); err != nil {
+		t.Fatalf("patch endpoint/mode: %v: %s", err, out)
+	}
 }
 
 func patchSecretToken(t *testing.T, name, token string) {

--- a/test/e2e/wss_push_test.go
+++ b/test/e2e/wss_push_test.go
@@ -304,12 +304,18 @@ func proxyLogCount(t *testing.T, sub string) int {
 func deployGPMock(t *testing.T) {
 	t.Helper()
 	_, _ = kubectl(t, "-n", wssNS, "delete", "configmap", wssGPMock+"-fixture", "--ignore-not-found")
+	gp := freshGPJSON()
 	cmd := exec.Command("kubectl", "-n", wssNS, "create", "configmap", wssGPMock+"-fixture",
 		"--from-file=gp.json=/dev/stdin")
-	cmd.Stdin = strings.NewReader(freshGPJSON())
+	cmd.Stdin = strings.NewReader(gp)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("create gp fixture: %v: %s", err, out)
 	}
+	// A ConfigMap mounted through subPath never receives updates (Kubernetes documents this), and
+	// this Deployment is otherwise identical between runs — so with E2E_WSS_KEEP=1 the pod keeps
+	// serving the PREVIOUS run's gp.json. Same checksum-annotation pattern the gNB Deployment
+	// already uses, for the same reason.
+	gpSum := sha256.Sum256([]byte(gp))
 	kubectlApply(t, fmt.Sprintf(`
 apiVersion: apps/v1
 kind: Deployment
@@ -318,7 +324,9 @@ spec:
   replicas: 1
   selector: {matchLabels: {app: %[1]s}}
   template:
-    metadata: {labels: {app: %[1]s}}
+    metadata:
+      labels: {app: %[1]s}
+      annotations: {ntn.operators.dev/gp-fixture-sha256: "%[3]s"}
     spec:
       containers:
         - name: nginx
@@ -339,7 +347,7 @@ metadata: {name: %[1]s, namespace: %[2]s}
 spec:
   selector: {app: %[1]s}
   ports: [{port: 80, targetPort: 80}]
-`, wssGPMock, wssNS))
+`, wssGPMock, wssNS, hex.EncodeToString(gpSum[:8])))
 	if _, err := kubectl(t, "-n", wssNS, "rollout", "status", "deploy/"+wssGPMock, "--timeout=180s"); err != nil {
 		t.Fatalf("gp mock not ready: %v", err)
 	}
@@ -491,11 +499,40 @@ func managerArgs(t *testing.T) []string {
 	if ns == "" {
 		ns = "ntn-operators-system"
 	}
-	out, err := kubectl(t, "-n", ns, "get", "deploy", "-l", "control-plane=controller-manager",
-		"-o", `jsonpath={.items[0].spec.template.spec.containers[?(@.name=="manager")].args}`)
+	// Names, not .items[0]: control-plane=controller-manager is a convention, not a unique key
+	// (Kueue ships it too), so two releases or a leftover Deployment in one namespace would make
+	// index 0 an arbitrary choice — and the suite would then police the wrong manager while
+	// reporting success. Demand exactly one, or say which ones were found.
+	names, err := kubectl(t, "-n", ns, "get", "deploy", "-l", "control-plane=controller-manager",
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}`)
 	if err != nil {
+		t.Fatalf("cannot list Deployments in namespace %q: %v", ns, err)
+	}
+	var found []string
+	for n := range strings.SplitSeq(strings.TrimSpace(names), "\n") {
+		if n != "" {
+			found = append(found, n)
+		}
+	}
+	if want := os.Getenv("WSS_MANAGER_DEPLOYMENT"); want != "" {
+		if !slices.Contains(found, want) {
+			t.Fatalf("WSS_MANAGER_DEPLOYMENT=%q is not in namespace %q (found %v)", want, ns, found)
+		}
+		found = []string{want}
+	}
+	switch len(found) {
+	case 1:
+	case 0:
 		t.Fatalf("no manager Deployment (control-plane=controller-manager) in namespace %q — deploy the "+
-			"chart first, or set WSS_MANAGER_NAMESPACE: %v", ns, err)
+			"chart first, or set WSS_MANAGER_NAMESPACE", ns)
+	default:
+		t.Fatalf("%d Deployments carry control-plane=controller-manager in namespace %q (%v); this suite "+
+			"would police an arbitrary one. Set WSS_MANAGER_DEPLOYMENT to disambiguate.", len(found), ns, found)
+	}
+	out, err := kubectl(t, "-n", ns, "get", "deploy", found[0],
+		"-o", `jsonpath={.spec.template.spec.containers[?(@.name=="manager")].args}`)
+	if err != nil {
+		t.Fatalf("cannot read args of Deployment %s/%s: %v", ns, found[0], err)
 	}
 	var args []string
 	if err := json.Unmarshal([]byte(out), &args); err != nil {
@@ -504,17 +541,40 @@ func managerArgs(t *testing.T) []string {
 	return args
 }
 
-// managerFlagList returns the comma-separated value of a repeatable-looking list flag, or nil if
-// it is absent. Exactly one occurrence is meaningful: these flags are plain strings, so a second
-// occurrence REPLACES the first rather than appending to it.
-func managerFlagList(t *testing.T, flag string) []string {
-	t.Helper()
-	for _, a := range managerArgs(t) {
+// managerFlagList returns the comma-separated value of a list flag, or nil if it is absent.
+//
+// It FAILS on a repeated flag rather than picking one. This helper exists because appending a
+// second --ephemeris-allowed-private-hosts once broke CI: the flag is a plain string, so Go's flag
+// package calls Set per occurrence and the LAST value wins, silently replacing the first. The
+// first version of this guard then read the FIRST occurrence — so the check written to catch that
+// regression would have passed while the manager ran on the clobbering value. A guard that reads a
+// different value than the process it is guarding is worse than no guard.
+// flagOccurrences returns every value the argv carries for flag. Split out from managerFlagList
+// so the "repeated flag" rule is testable without a cluster — the rule is the whole point.
+func flagOccurrences(args []string, flag string) []string {
+	var vals []string
+	for _, a := range args {
 		if _, after, ok := strings.Cut(a, flag+"="); ok {
-			return strings.Split(after, ",")
+			vals = append(vals, after)
 		}
 	}
-	return nil
+	return vals
+}
+
+func managerFlagList(t *testing.T, flag string) []string {
+	t.Helper()
+	vals := flagOccurrences(managerArgs(t), flag)
+	switch len(vals) {
+	case 0:
+		return nil
+	case 1:
+		return strings.Split(vals[0], ",")
+	default:
+		t.Fatalf("%s appears %d times in the manager's argv (%q). It is a plain string flag, so the LAST "+
+			"occurrence wins and the earlier ones are dead — which is exactly how this suite once broke "+
+			"TestHAOutageContinuityAcrossFailover. Carry the union in ONE occurrence.", flag, len(vals), vals)
+		return nil
+	}
 }
 
 // setupNamespace creates a namespace this suite OWNS, and refuses to touch one it does not.
@@ -557,7 +617,34 @@ metadata:
 	}
 }
 
-// waitCondition waits// waitCondition waits for the EXACT expected "status/reason". Waiting merely for a False
+// dumpNamespaceEvidence prints what a failed arm needs and cleanup is about to destroy.
+// Best-effort throughout: this runs while something is already wrong, so a failure to collect
+// must never mask the failure being collected.
+func dumpNamespaceEvidence(t *testing.T) {
+	t.Helper()
+	t.Logf("=== FAILURE EVIDENCE for namespace %s ===", wssNS)
+	for _, q := range []struct {
+		what string
+		args []string
+	}{
+		{"NTNCellConfig", []string{"-n", wssNS, "get", "ntncellconfig", wssCell, "-o", "yaml"}},
+		{"SatelliteEphemeris", []string{"-n", wssNS, "get", "satelliteephemeris", wssSatEph, "-o", "yaml"}},
+		{"pods", []string{"-n", wssNS, "get", "pods", "-o", "wide"}},
+		{"events", []string{"-n", wssNS, "get", "events", "--sort-by=.lastTimestamp"}},
+		{"proxy log", []string{"-n", wssNS, "logs", "deploy/" + wssGNB, "-c", "proxy", "--tail=80"}},
+		{"gnb log", []string{"-n", wssNS, "logs", "deploy/" + wssGNB, "-c", "gnb", "--tail=80"}},
+		{"gp mock log", []string{"-n", wssNS, "logs", "deploy/" + wssGPMock, "--tail=20"}},
+	} {
+		out, err := kubectl(t, q.args...)
+		if err != nil {
+			t.Logf("--- %s: unavailable (%v)", q.what, err)
+			continue
+		}
+		t.Logf("--- %s ---\n%s", q.what, out)
+	}
+}
+
+// waitCondition waits for the EXACT expected "status/reason". Waiting merely for a False
 // prefix would let an arm assert while the PREVIOUS arm's reason is still on the object —
 // which fails intermittently rather than never, and is the worse kind of flake.
 func waitCondition(t *testing.T, want string, timeout time.Duration) {
@@ -581,6 +668,12 @@ func TestWSSCredentialedPush(t *testing.T) {
 
 	setupNamespace(t)
 	t.Cleanup(func() {
+		// Dump BEFORE deleting: cleanup removes the namespace, so on a failure the proxy log, the
+		// backend log and the CR conditions — the only three things that say WHY — would be gone
+		// before CI collects diagnostics, leaving a red job with nothing to read.
+		if t.Failed() {
+			dumpNamespaceEvidence(t)
+		}
 		if os.Getenv("E2E_WSS_KEEP") == "1" {
 			t.Logf("E2E_WSS_KEEP=1: leaving namespace %s up for inspection; the next run will "+
 				"refuse to start until it is deleted or re-adopted", wssNS)
@@ -704,12 +797,15 @@ spec:
 	})
 
 	// --- arm 3: #313 — a bearer with no pinned CA is refused before any dial -----------
-	t.Run("token without ca.crt is refused before the dial (#313)", func(t *testing.T) {
+	// The name says "no payload", not "no dial": frame count cannot distinguish a refusal made
+	// before dialling from one made after a TCP connect that the proxy then dropped. The
+	// before-any-dial ordering is proven in the unit tests, which can observe the dial itself.
+	t.Run("token without ca.crt delivers no payload (#313)", func(t *testing.T) {
 		before := framesReceived(t)
 		patchSecretName(t, wssNoCA)
 		waitCondition(t, "False/RemoteControlCredentialUnavailable", 3*time.Minute)
 		if now := framesReceived(t); now != before {
-			t.Errorf("frames went %d -> %d: nothing may be dialled when the CA is unpinned", before, now)
+			t.Errorf("frames went %d -> %d: no payload may reach the gNB when the CA is unpinned", before, now)
 		}
 		patchSecretName(t, wssCredName)
 		waitCondition(t, "True/Pushed", 3*time.Minute)
@@ -752,10 +848,16 @@ func runEndpointAllowlistArm(t *testing.T) {
 			"to violate; deploy with one to cover #300")
 	}
 	before := framesReceived(t)
-	// Point at a host that is definitely not on the list. It does not need to exist: the refusal
-	// must happen before anything is dialled.
+	// Point at a host that is definitely not on the list AND at a Secret that does not exist.
+	// The missing Secret is what makes this arm prove its own name: with a valid credential the
+	// condition would read RemoteControlEndpointNotAllowed whether the endpoint was checked
+	// before or after the Secret, so the arm could not tell the two orderings apart. With no
+	// Secret to resolve, a credential-first implementation must report
+	// RemoteControlCredentialUnavailable instead — so the endpoint reason is only reachable if
+	// the endpoint really is checked first.
 	if out, err := kubectl(t, "-n", wssNS, "patch", "ntncellconfig", wssCell, "--type=merge",
-		`-p={"spec":{"provider":{"remoteControl":{"endpoint":"not-allowed.example.invalid:8443"}}}}`); err != nil {
+		`-p={"spec":{"provider":{"remoteControl":{"endpoint":"not-allowed.example.invalid:8443",`+
+			`"tls":{"mode":"mtls","secretName":"e2e-wss-no-such-secret"}}}}}`); err != nil {
 		t.Fatalf("patch endpoint: %v: %s", err, out)
 	}
 	waitCondition(t, "False/RemoteControlEndpointNotAllowed", 3*time.Minute)
@@ -763,7 +865,8 @@ func runEndpointAllowlistArm(t *testing.T) {
 		t.Errorf("frames went %d -> %d: a non-allow-listed endpoint must never be dialled", before, now)
 	}
 	if out, err := kubectl(t, "-n", wssNS, "patch", "ntncellconfig", wssCell, "--type=merge",
-		fmt.Sprintf(`-p={"spec":{"provider":{"remoteControl":{"endpoint":"%s.%s.svc:8443"}}}}`, wssSvc, wssNS)); err != nil {
+		fmt.Sprintf(`-p={"spec":{"provider":{"remoteControl":{"endpoint":"%s.%s.svc:8443",`+
+			`"tls":{"mode":"mtls","secretName":"%s"}}}}}`, wssSvc, wssNS, wssCredName)); err != nil {
 		t.Fatalf("restore endpoint: %v: %s", err, out)
 	}
 	waitCondition(t, "True/Pushed", 3*time.Minute)


### PR DESCRIPTION
External review of the merged #332 suite. Seven findings, all confirmed against `main`. The headline: **the guard written to catch the flag-clobbering regression had that exact regression.**

## The guard that did not guard

`managerFlagList` existed because appending a second `--ephemeris-allowed-private-hosts` once broke CI — the flag is a plain string, so Go's `flag` package calls `Set` per occurrence and the **last** value wins. Its doc comment said exactly that. Its body returned the **first** occurrence.

So a clobbered manager would read as healthy. Verified on a live cluster rather than argued:

| Manager deployed with the flag twice | Old helper | New helper |
|---|---|---|
| first value correct, last value `clobbered.example.com` | **passes**, then the suite times out after **4m** on `propagatedStates=""` | **fails in 0.11s**, naming the flag, the count and both values |

That 4-minute stall on a symptom is the original CI incident, relocated into this suite. The occurrence scan is split into `flagOccurrences` so the "exactly one" rule is testable without a cluster.

## The other six

| Finding | Fix |
|---|---|
| `managerArgs` took `.items[0]` from `control-plane=controller-manager` — a convention, not a unique key (Kueue ships it too). Two releases in one namespace and the suite polices an arbitrary manager while reporting success. | Demand exactly one, list what was found, `WSS_MANAGER_DEPLOYMENT` to disambiguate. |
| The endpoint arm claimed "refused **before the Secret is read**" but used a **valid** Secret — so it could not tell the two orderings apart. | It now points at a Secret that does not exist. A credential-first implementation must report `RemoteControlCredentialUnavailable`, so the endpoint reason is only reachable if the endpoint really is checked first. **The name is now earned rather than dropped.** |
| The no-CA arm claimed "before the dial" from an absence of frames, which cannot distinguish a refusal before dialling from a TCP connect the proxy dropped. | Renamed to what it proves — "delivers no payload". The ordering stays proven in the unit tests, which can observe the dial. |
| The GP fixture is mounted through `subPath`, which [Kubernetes documents](https://kubernetes.io/docs/concepts/configuration/configmap/) as never receiving updates, and its Deployment carried no content checksum — so an `E2E_WSS_KEEP=1` rerun kept serving the **previous run's** `gp.json`. | Checksum annotation on the pod template, the same pattern the gNB Deployment already uses. |
| A failed arm's evidence was deleted by cleanup before CI could collect it — a red job arriving with nothing to read. | `t.Failed()` dumps the CR, the ephemeris, pods, events and all three container logs **before** the namespace goes. |
| Boy scout | CHANGELOG said "Four arms" for a five-arm suite; a doubled `// waitCondition waits` comment from an earlier patch round. |

## Renaming an arm is a cross-file change

`test-chart.yml` greps arm names **exactly**, so renaming the #313 arm without updating the workflow would produce `FALSE GREEN: arm … did not run+PASS`. The list is updated, and rather than trust an ad-hoc checker I ran the workflow's **own** five checks against real suite output — all five match, no arm skipped, a frame crossed the wire.

## Verification

Live, on kubeadm 1.36.3, with a manager image built from current `main`:

- 5/5 arms pass (27s)
- the guard **refuses** a duplicated flag, and the old behaviour **passes** the same deployment — the mutation is the live cluster, not an edit
- manager Deployment generation unchanged by the run

`go vet` under every build tag, `golangci-lint --build-tags e2e_wss`: 0 issues.

## Second commit: the two coverage gaps

**Nothing in the suite failed if the operator stopped verifying the server certificate.** The happy path proves a *correct* chain works — which a client with verification disabled also does — so only a chain the client should **reject** separates them. Arm 6 pins a foreign CA in the credential and requires the push to fail with no frame.

Proven by mutating the operator rather than by argument:

| `InsecureSkipVerify: true` compiled into `resolveRemoteControlTLS`, image redeployed | |
|---|---|
| arm 6 | **fails** |
| the other six arms | **all pass** |

So without arm 6, disabling server verification is invisible to this suite.

**`mode: tls` was only ever the negative half of an mTLS test** (present no client certificate, expect the proxy's 400), so the whole TLS-plus-bearer *delivery* path could break unnoticed. Arm 7 pushes through a TLS-only listener and requires a frame at the backend.

That listener is **derived from the shipped sample**, not hand-written. The sample says:

```
# Drop these two lines (and use tls.mode "tls") if you only want a bearer token.
```

`sampleNginxConfTLSOnly` drops exactly those two lines and fails loudly if either stops matching — so the arm tests the instruction the sample gives a reader. Both configs feed the pod-template checksum, so changing either rolls the proxy.

Suite is now **7 arms**, all passing live on kubeadm 1.36.3 (89s).