### PR TITLE
docs(adr): make the index lint catch tracking drift, and fix the two it finds

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,9 +25,9 @@ Governance is machine-checked:
 | [0005](0005-cluster-orchestration.md) | Place `ntn-operators` above provider-native per-cell control | accepted | — | #162 · impl #177/#189 |
 | [0006](0006-decouple-propagation-from-pass-prediction.md) | Decouple propagation heartbeat from pass prediction | accepted | — | #234 · impl #256 |
 | [0007](0007-durable-omm-cache.md) | Durable last-good OMM cache for restart and leader failover | accepted | — | hash-name migration follow-up |
-| [0008](0008-constellation-pool-availability.md) | Model satellite-path contact opportunity at constellation-pool level | accepted | — | impl #350 (reasons + `status.contactCandidate`) · slice-to-cell binding follow-up |
+| [0008](0008-constellation-pool-availability.md) | Model satellite-path contact opportunity at constellation-pool level | accepted | — | #348 · impl #350 (reasons + `status.contactCandidate`) |
 | [0009](0009-remote-control-credential-boundary.md) | Layered authorization boundary for remote-control credentials | accepted | superseded-in-part by **0011** | #251, #299 |
-| [0010](0010-v1alpha2-secure-defaults-and-duration-validation.md) | v1alpha2 secure-by-default transport and duration admission validation | proposed | — | #214, #315, #311, #299 |
+| [0010](0010-v1alpha2-secure-defaults-and-duration-validation.md) | v1alpha2 secure-by-default transport and duration admission validation | proposed | — | #331 · #214, #311, #299 |
 | [0011](0011-remote-control-credential-grant.md) | Owner-issued grant for remote-control credentials | proposed | supersedes **0009** admission-only end state | #251, #298, #329 (closed by #332) |
 | [0012](0012-ground-station-antenna-health-probe.md) | Evidence-based ground-station antenna health and readiness | proposed | supersedes node-exists→`AntennaReady=True` | #68 · #335 removed the fabricated `True`; the probe itself is unimplemented |
 | [0013](0013-transactional-data-plane-actuation.md) | Transactional data-plane actuation for `NTNSlice` path changes | proposed | relates 0005/0008/0010; v1alpha2 recommendation-vs-applied split, reframes #69 continuity as an actuator capability | #49, #69, #137, #141, #162 |

--- a/docs/adr/REVIEW_FINDINGS.md
+++ b/docs/adr/REVIEW_FINDINGS.md
@@ -30,8 +30,6 @@
 - credential grant CRD/controller;
 - structured ground-station hardware agent;
 - policy-capable NetworkPolicy E2E;
-- six-digit NORAD regression coverage;
-- collision-resistant OMM cache migration.
 
 ## Landed since this bundle was written
 
@@ -43,6 +41,11 @@
 - **Fabricated antenna readiness** — #335 changed `AntennaReady` from a node-exists
   `True` to `Unknown/NoAntennaProbe`, which is the correction ADR 0012 requires.
   The evidence-based agent contract itself remains unimplemented (#68).
+- **Six-digit NORAD regression coverage** — #351.
+- **Collision-resistant OMM cache naming and legacy migration** — #345. The
+  storage-mode half of ADR 0007 (`ConfigMap | Secret | Disabled`) is still open.
+- **`sessionContinuity` honesty** — #352 states in the field itself that the build
+  does not enforce it; enforcement remains #69.
 
 ## Claims deliberately not made
 

--- a/hack/check-adr-index.sh
+++ b/hack/check-adr-index.sh
@@ -5,6 +5,7 @@
 #   - the "# ADR NNNN" title matches the filename number
 #   - a "- Status:" line is present
 #   - the ADR is listed in the index (docs/adr/README.md)
+#   - every issue the ADR's own front matter tracks also appears in its index row
 #   - every relative link to another ADR file resolves
 #   - every internal #anchor link resolves to a heading in the target file
 #     (repo-internal only; external URLs are never fetched, so a site being
@@ -52,6 +53,26 @@ for f in "$adr_dir"/[0-9][0-9][0-9][0-9]-*.md; do
   grep -qE '^status:|^- Status:' "$f" || err "$base: missing status (front-matter 'status:' or '- Status:' line)"
 
   grep -qE "(^|[^0-9])$num([^0-9]|\$)" "$readme" || err "$base: ADR $num not listed in $readme"
+
+  # Tracking drift. The index row may say MORE than the front matter — it carries
+  # implementation pointers ("impl #256") the ADR itself has no reason to list — but it
+  # must not say LESS, or the one place a reader is told to start goes stale while every
+  # other check still passes. That is not hypothetical: the index kept pointing at a
+  # closed duplicate for ADR-0010 while the ADR tracked a different issue, and an ADR-0008
+  # edit replaced a tracked follow-up with prose. Containment, not equality, is what makes
+  # this checkable without forbidding the editorial extras that make the index useful.
+  row=$(grep -m1 -E "^\| \[?$num[](]" "$readme" || true)
+  if [[ -n "$row" ]]; then
+    # || true throughout: a row or an ADR with no #refs is legitimate, but an empty grep
+    # exits 1 and, under `set -e -o pipefail`, would abort the whole lint with no message.
+    row_refs=$(printf '%s' "$row" | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u)
+    while IFS= read -r tracked; do
+      [[ -z "$tracked" ]] && continue
+      grep -qxF -- "$tracked" <<<"$row_refs" \
+        || err "$base: front matter tracks #$tracked but the index row does not mention it"
+    done < <(sed -n '/^tracking:/,/^[a-z_-]*:/p' "$f" \
+               | { grep -oE '(issues|pull)/[0-9]+' || true; } | { grep -oE '[0-9]+' || true; } | sort -u)
+  fi
 
   while IFS= read -r target; do
     [[ -z "$target" ]] && continue


### PR DESCRIPTION
`AGENTS.md` sends every reader to `docs/adr/README.md` first:

> **Read `docs/adr/README.md` (the index) at the start of any design or ADR-related work**

Nothing checked that the index still agreed with the ADRs it indexes, so it could go stale while `adr-lint` stayed green. It had, twice.

## The two drifts

| ADR | What the index said | What was wrong |
|---|---|---|
| **0010** | `#214, #315, #311, #299` | **#315 is closed as a duplicate**, and **#331 — the issue the ADR's own front matter tracks — was missing**. A contributor starting from the index would have begun at a closed issue describing a superseded design. |
| **0008** | `impl #350 … · slice-to-cell binding follow-up` | Lost **#348** when an earlier edit of mine replaced the tracked follow-up with prose. Prose is not something anyone can look up. |

Only the first was reported to me. The second was found by the check while writing it.

## Containment, not equality — measured before choosing

The index row legitimately says *more* than the front matter: it carries implementation pointers like `impl #256` that the ADR itself has no reason to list. So the rule is **front matter ⊆ index row**.

I measured both candidate rules across all 12 ADRs before picking:

| Rule | Result |
|---|---|
| set equality | fails **10** legitimate rows (every one carrying an impl PR) |
| containment | passes those 10, flags exactly the **2** real drifts |

```
adr-lint: 0008-constellation-pool-availability.md: front matter tracks #348 but the index row does not mention it
adr-lint: 0010-v1alpha2-secure-defaults-and-duration-validation.md: front matter tracks #331 but the index row does not mention it
```

Mutation-verified: dropping a tracked issue from a row, and pointing a row at the wrong number, are each caught.

## A silent-failure bug found while writing it

The first version exited **1 with no output at all**. Under `set -e -o pipefail`, a `grep` that finds nothing fails its pipeline and aborts the whole lint before `err()` can say anything — so a repo with no tracked issues anywhere would have produced a bare non-zero exit and no diagnosis. The new pipelines are guarded; an ADR or a row with no `#refs` is legitimate.

## REVIEW_FINDINGS.md

Still listed **six-digit NORAD regression coverage** and **collision-resistant OMM cache migration** as open implementation gaps. Both shipped — #351 and #345. A gap list naming work already on `main` is how the next agent rebuilds it.

They move to the landed section along with #352, and ADR-0007's **storage-mode** half (`ConfigMap | Secret | Disabled`) is named as the part that genuinely remains, so removing the line does not quietly close the whole item.

## Verification

`make adr-lint`: **OK (12 ADRs)**. `bash -n` clean.
