### PR TITLE
docs(adr): pin v1alpha2 scaffolding ownership in ADR-0013 compat (follow-up to #353)

### DIFF
--- a/docs/adr/0013-transactional-data-plane-actuation.md
+++ b/docs/adr/0013-transactional-data-plane-actuation.md
@@ -1566,11 +1566,19 @@ A future 5GC actuator is not part of these PRs.
 - Requires an explicit actuator reference for enforcement.
 - Does not convert a legacy Boolean into a hard continuity requirement.
 - Does not synthesize successful applied status.
+- Reuses the shared `v1alpha2` scaffolding owned by ADR 0010 (#214); it is not a
+  separate version rollout.
 
 ### Storage migration
 
-Serving and storage-version changes follow the API-version migration ADR.
-Conversion does not itself rewrite stored objects.
+ADR 0010 (tracked in #214) is the single owner of the `v1alpha2` scaffolding:
+the version bump, the conversion webhook, and the storage-version migration.
+This ADR does not introduce a second or parallel `v1alpha2` rollout; its
+actuation surface (`PathActuation` and the new `NTNSlice` v1alpha2 fields) is an
+additive consumer of that scaffolding. Because `PathActuation` is a `v1alpha2`
+kind, actuation MUST NOT be enabled before `v1alpha2` is served. Serving and
+storage-version changes follow ADR 0010; conversion does not itself rewrite
+stored objects.
 
 ### Downgrade
 


### PR DESCRIPTION
## What

Follow-up to #353 (ADR-0013, merged). Adds the v1alpha2 scaffolding-ownership note to ADR-0013's compat section. Docs-only.

## Why

ADR-0010 and ADR-0013 both define `v1alpha2` changes, and `PathActuation` is a `v1alpha2` kind — so ADR-0013's actuation implementation is **hard-gated** on `v1alpha2` being served. Without naming an owner, two implementation PRs could each try to scaffold `v1alpha2` (version bump, conversion webhook, storage migration) and collide.

This states that **ADR-0010 (#214) is the single owner** of the `v1alpha2` scaffolding and ADR-0013 is an additive consumer, so actuation must not be enabled before `v1alpha2` is served.

## Note

This change was originally pushed onto the #353 branch, but #353 merged at the prior commit while the push was in flight, so it landed after the merge and never reached `main`. This PR re-lands it cleanly off current `main` (the ADR-0013 file on `main` is byte-identical to the merged head, so the cherry-pick applied without conflict).

## Verification

`make adr-lint` green (12 ADRs, metadata + index + anchors valid). ADR-0010 genuinely owns the v1alpha2 conversion (§D) and storage migration (§F); #214 is the v1alpha2-conversion-plan issue; `PathActuation` is declared `apiVersion: ntn.operators.dev/v1alpha2`, so the hard-gate statement is factual.
