### PR TITLE
docs(adr-0011): resolve the grant contract's contradictions before it is built

### DIFF
--- a/docs/adr/0011-remote-control-credential-grant.md
+++ b/docs/adr/0011-remote-control-credential-grant.md
@@ -81,17 +81,40 @@ spec:
 - Cross-namespace reference is not introduced by this ADR.
 - `allowedConsumers[].name` is required; its optional `uid` prevents
   delete/recreate name reuse when set.
+- `apiGroup` and `kind` are constrained by CEL to exactly
+  `ntn.operators.dev` / `NTNCellConfig`, the only consumer that exists. They are
+  kept as fields so a second consumer is an additive change, but left open they
+  would advertise a generic ReferenceGrant-style lookup the controller does not
+  implement — and an operator would find that out from a grant that silently
+  authorizes nothing.
 - `secretRef` is name-bound. A Secret deleted and recreated under the same name
   inherits the grant unless the optional `secretRef.uid` is set (mirroring the
   consumer UID), so name reuse is a decision rather than an accident.
-- `allowedModes` uses ADR-0010's transport mode enum (`tls`, `mtls`,
-  `plaintext`). The grant is a v1alpha1 resource and authorizes both v1alpha1
-  and converted-v1alpha2 pushes; it is independent of the CR's transport
+- `allowedModes` is restricted to `tls` and `mtls` — **not** ADR-0010's full
+  transport enum. ADR-0010 §A says `plaintext` forbids TLS and credential fields,
+  so a grant naming `plaintext` would authorize the use of a credential that mode
+  cannot carry: an entry with no meaning, which a reader would reasonably take to
+  mean the Secret owner had consented to something. If consent to a plaintext
+  *destination* is ever wanted, that is transport policy (ADR-0010 §E), not a
+  credential grant, and it belongs on a resource whose subject is the destination
+  rather than the Secret. The grant is a v1alpha1 resource and authorizes both
+  v1alpha1 and converted-v1alpha2 pushes; it is independent of the CR's transport
   encoding version.
-- target matching uses one shared canonicalizer for host and port, applied
-  identically in admission, controller matching and tests: case-folded host,
-  trailing dot stripped, explicit port required, IPv6 in canonical form. Matching
-  is after syntax normalization but before DNS resolution.
+- target matching **requires canonical input** rather than sharing a canonicalizer.
+  A single shared implementation is not achievable: admission is CEL, which can
+  neither call the Go canonicalizer nor mutate the value, so "applied identically
+  in admission and controller" was a promise the implementation could not keep, and
+  a divergence between the two would be a matching bug in the authorization path.
+  CEL *can* reject non-canonical input, which is the half that is implementable:
+  - host lower-case, no trailing dot;
+  - port explicit and numeric;
+  - IPv6 in RFC 5952 form, bracketed;
+  - two entries canonicalizing to the same target are rejected as duplicates.
+
+  The controller normalizes defensively before comparing — objects predating the
+  rule exist — but the schema is the authority, so a value that reaches the
+  controller has already been shown canonical. Matching is after this syntax
+  normalization and before DNS resolution.
 - the admin destination allow-list remains an outer bound.
 
 ### Authorizing the grant writer
@@ -101,10 +124,26 @@ verbs, not a Secret's owner. Any principal able to create or patch a grant in
 the namespace could otherwise self-issue one, so the secure profile requires,
 alongside `--require-credential-grant`, an admission control on the grant writer:
 
-- a ValidatingAdmissionPolicy requiring the principal creating or patching a
-  grant to hold `get` on the referenced Secret, and/or
-- a dedicated RBAC role for grant write that is not implied by `NTNCellConfig`
-  edit access.
+- **required**: a ValidatingAdmissionPolicy using the CEL `authorizer` library to
+  require the principal creating or patching a grant to hold `get` on
+  `spec.secretRef.name` in that namespace;
+- **additionally**: a dedicated RBAC role for grant write that is not implied by
+  `NTNCellConfig` edit access.
+
+These are not alternatives, and the earlier "and/or" made them read as such. RBAC
+answers *may this principal write grants in this namespace* — it cannot answer
+*may this principal read the specific Secret this grant points at*, which is the
+entire content of the word "owner-issued". With RBAC alone, anyone who may write
+any grant may issue one for a Secret they cannot read, and the resource's central
+claim is false.
+
+Verification cannot rest on the policy's own status: Kubernetes VAP **type
+checking does not apply to matched custom resources or to a CRD `paramKind`**, so
+an absent type warning proves nothing about whether the field paths in the
+expression are right. A renamed field would silently match nothing and fail open.
+The test plan therefore requires live API-server dry-run against a restricted
+ServiceAccount — positive and negative — plus a field-rename mutation that must
+break it, and an install check that the policy *and* its binding exist.
 
 This is distinct from the default-off `credentialRefPolicy` (#309), which
 authorizes the `NTNCellConfig` writer against the Secret, not the grant writer.
@@ -123,7 +162,46 @@ full tuple.
 Do not implement “enforce only when a grant exists for this Secret”; an attacker
 could omit the grant.
 
-Refusal occurs before Secret read and uses a uniform low-information condition.
+Refusal occurs before the Secret's **credential data** is read, and uses a uniform
+low-information condition.
+
+The earlier wording — "before Secret read" — could not be implemented alongside
+`secretRef.uid`: verifying a UID means asking the API server about that Secret. The
+two are reconciled by splitting the read:
+
+1. fetch **metadata only** (`PartialObjectMetadata`), which returns `metadata` and
+   omits `data`, and compare `uid` when the grant sets it;
+2. evaluate the full tuple — consumer, target, mode, revision — against the grants;
+3. only if all of it passes, perform the full `Get` for the credential bytes.
+
+So no credential material is read for a push the grant denies, which is the
+property that matters; and the invariant now states that rather than an absolute
+that the UID check contradicts.
+
+### Condition semantics and failing closed
+
+`CredentialGrantAuthorized=True` while `--require-credential-grant=false` would
+read as "this push was authorized by a grant" when nothing checked one. The
+condition therefore reports:
+
+| State | Condition |
+|---|---|
+| flag off | `Unknown` / `EnforcementDisabled` — observable without claiming authorization |
+| flag on, tuple permitted | `True` / `GrantAuthorized` |
+| flag on, no matching grant | `False`, uniform low-information reason (§ Enforcement) |
+
+When the flag is on but the check **cannot** run, the manager fails closed rather
+than degrading to unenforced: readiness is false (or startup fails) if the grant
+CRD is absent, its informer cache has not synced, the manager lacks `list`/`watch`
+on grants, or the required grant-writer policy and binding are not installed. An
+operator who asked for enforcement and silently got none is worse off than one
+whose rollout stops — they believe a boundary exists.
+
+`secretRef.uid` and `allowedConsumers[].uid` stay **optional** in the schema, but
+the secure profile documents that a grant without them is **name-bound**: a Secret
+or consumer deleted and recreated under the same name inherits it. That is a
+legitimate compatibility mode, not a default to leave ambiguous, so the preflight
+report lists name-bound grants and the profile's guidance is to set both.
 
 ### Watch/index design
 
@@ -151,10 +229,41 @@ early-returns on `isEphemerisPushUpToDate` before the credential is resolved
 (#298), so an enqueue from a grant event alone would hit that dedup and skip the
 grant check until the next epoch marker (~3m). Two consequences follow.
 
-- Grant authorization is evaluated on a separate authorization marker (consumer,
-  target, mode and, when set, `credentialRevision`) checked independently of the
-  push marker. A grant delete, narrow or revision bump invalidates that
-  authorization marker and re-runs the check without waiting for a new epoch.
+- Grant authorization is evaluated on a separate authorization marker checked
+  independently of the push marker.
+
+  Its derivation must be exact, because the obvious one is wrong: consumer, target,
+  mode and revision are properties of the **CR**, and none of them changes when a
+  grant is deleted or narrowed. A marker built from those alone would compare equal
+  after a revocation, so the reconcile the watch correctly enqueued would skip the
+  check it was enqueued for — the failure this section exists to prevent, moved one
+  level down.
+
+  ```text
+  authzDigest = digest(
+      canonical consumer tuple,
+      canonical destination,
+      mode,
+      credentialRevision (when set),
+      sorted set of every grant CURRENTLY matching the tuple, each as
+          (grant UID, grant generation, spec digest)
+  )
+  ```
+
+  The grant set is what makes deletion observable: removing one changes the set,
+  therefore the digest. Two rules follow.
+
+  - A reconcile triggered by a grant event **re-enumerates matching grants and
+    recomputes the digest before comparing**. It never treats the persisted digest
+    as current — that value is a cache of the last authorized state, not evidence
+    about now.
+  - Including grant `generation` and spec digest (not just UID) is what makes a
+    *narrowing* visible: the set membership is unchanged, the spec is not.
+
+  This derivation is what simultaneously gives: two matching grants, deleting one
+  still permits; deleting the only match denies immediately; editing an unrelated
+  grant does not re-push; narrowing consumer, target or mode denies immediately;
+  and a revision bump re-reads the credential.
 - The credential digest is not folded into the push marker. #298 records why:
   the push marker is load-bearing for dedup, gNB-restart recovery and
   crash-idempotency (#230), and a benign CA-bundle rotation would otherwise force
@@ -170,15 +279,36 @@ already in flight.
 - No grant contains token, key, certificate or CA bytes.
 - Deleting/narrowing a grant enqueues previously authorized consumers.
 - grant authorization and admin destination allow-list are intersected.
-- UID mismatch denies when UID is specified.
+- UID mismatch denies when UID is specified, and the comparison uses a
+  metadata-only read.
 - disabling grant enforcement is an explicit admin choice and observable.
-- grant denial occurs before Secret read/dial.
-- authorization uses a marker independent of the ephemeris push dedup.
+- grant denial occurs before the Secret's credential data is read, and before any
+  dial.
+- authorization uses a marker independent of the ephemeris push dedup, derived
+  from the currently matching grant set and recomputed before it is trusted.
+- a grant naming a mode that cannot carry a credential is not representable.
+- enforcement that cannot run fails closed rather than reporting authorization.
 - a single grant must match the full tuple; permissions are never assembled
   across grants.
-- `allowedConsumers`, `allowedTargets` and `allowedModes` are bounded lists
-  (MinItems 1, capped MaxItems, set semantics); an empty list is deny-all and
-  wildcards are not supported.
+- `allowedConsumers`, `allowedTargets` and `allowedModes` are bounded lists with
+  `MinItems: 1`, so an empty list is **admission-invalid** — not deny-all. The two
+  cannot both be true, and rejecting at admission is the better half: a grant that
+  authorizes nothing is a mistake worth catching at write time, and "empty means
+  deny" is a rule a reader has to know rather than one the API enforces. Wildcards
+  are not supported.
+- List topology is stated per field rather than as a blanket "set semantics", which
+  Kubernetes defines for **scalar** lists and which does not give object lists the
+  uniqueness it implies:
+
+  | Field | `listType` | Key / uniqueness | `MaxItems` |
+  |---|---|---|---|
+  | `allowedModes` | `set` | scalar, native | 2 — the enum has two members |
+  | `allowedTargets` | `map`, `listMapKeys: [host, port]` | both required, so the key is total | 16 |
+  | `allowedConsumers` | `atomic` + CEL uniqueness on `name` | `uid` is optional, so it cannot be part of a map key without making two entries for one name — one with a uid, one without — legal and ambiguous | 32 |
+
+  `allowedConsumers` stays `atomic` rather than requiring `uid` so a GitOps author
+  can write the grant before the consumer exists; the CEL rule supplies the
+  uniqueness the map key would have.
 
 ## Alternatives
 
@@ -214,6 +344,29 @@ endpoint and mode and targets cross-namespace references.
 - exact tuple allow/deny;
 - consumer UID mismatch and delete/recreate;
 - Secret delete/recreate under the same name, with and without `secretRef.uid`;
+- UID comparison uses a metadata-only read: with a denying grant, no full Secret
+  GET is issued (assert on the API-server audit or a counting client, not on the
+  absence of a condition);
+- authzDigest changes when the only matching grant is deleted, and when a matching
+  grant is narrowed with its consumer/target/mode left otherwise identical — the
+  two cases a CR-derived marker cannot see;
+- a reconcile enqueued by a grant event recomputes the digest before comparing:
+  mutate it to trust the persisted value and the deletion case must fail;
+- grant-writer VAP against a live API server with a restricted ServiceAccount,
+  positive and negative, plus a field-rename mutation that must break it — VAP type
+  checking does not cover CRDs, so the policy's own status cannot stand in;
+- policy installed without its binding: writes are admitted, so the install check
+  must fail;
+- `allowedModes: [plaintext]` is rejected by the schema;
+- non-canonical targets (upper-case host, trailing dot, missing port, unbracketed
+  IPv6) are rejected at admission, and two entries canonicalizing to one target are
+  rejected as duplicates;
+- empty `allowedConsumers`/`allowedTargets`/`allowedModes` is admission-invalid,
+  not silently deny-all;
+- two `allowedConsumers` entries with the same name — one with `uid`, one without —
+  are rejected by the CEL uniqueness rule;
+- enforcement enabled with the CRD absent, cache unsynced, RBAC missing, or the
+  grant-writer policy absent: readiness false in each case, never unenforced;
 - grant deletion/narrowing flips `CredentialGrantAuthorized` on a healthy,
   push-deduplicated cell via the separate authorization marker, not the push
   marker;


### PR DESCRIPTION
Eight findings from an external review, all verified against the ADR on `main`. **Two were outright self-contradictions in the text.** The ADR is `proposed`, so these are decidable now — after an implementation PR lands, whichever lands first decides them by accident, and these choices affect wire authorization and API compatibility.

## The two that contradicted themselves

**`MinItems: 1` and "an empty list is deny-all"** cannot both be true — `MinItems: 1` makes empty *invalid*. Empty is now admission-invalid, which is the better half: a grant that authorizes nothing is a mistake worth catching at write time, and "empty means deny" is a rule a reader has to know rather than one the API enforces.

**"Refusal occurs before Secret read"** could not hold alongside `secretRef.uid` — verifying a UID means asking the API server about that Secret. Split into three steps: metadata-only `PartialObjectMetadata` for the UID → full tuple evaluation → credential-data `Get` only if it all passes. The invariant now states the property that matters ("before the Secret's **credential data** is read") instead of an absolute the schema contradicts.

## The marker could not see the thing it exists to see

The authorization marker was *consumer, target, mode, revision*. Every one of those is a property of the **CR** — none changes when a grant is deleted or narrowed. So the marker compares equal after a revocation, and the reconcile the watch correctly enqueued would skip the check it was enqueued for: the exact failure this section exists to prevent, one level down.

```text
authzDigest = digest(
    canonical consumer tuple, canonical destination, mode,
    credentialRevision (when set),
    sorted set of every grant CURRENTLY matching the tuple, each as
        (grant UID, grant generation, spec digest)
)
```

The grant *set* is what makes deletion observable; `generation` + spec digest is what makes a *narrowing* observable when set membership is unchanged. And a grant-triggered reconcile must **re-enumerate and recompute before comparing** — the persisted digest is a cache of the last authorized state, not evidence about now.

## "and/or" hid that one option cannot do the job

Grant-writer authorization said *a VAP **and/or** a dedicated RBAC role*. RBAC answers "may this principal write grants in this namespace". It cannot answer "may this principal read the **specific** Secret this grant points at" — which is the entire content of the word *owner-issued*. With RBAC alone, anyone who may write any grant may issue one for a Secret they cannot read, and the resource's central claim is false.

The authorizer VAP is now **required**; the RBAC role is additional hardening.

Verification cannot rest on the policy's own status either: **VAP type checking does not apply to matched custom resources or to a CRD `paramKind`**, so an absent type warning proves nothing about the field paths — a renamed field matches nothing and fails open. Live API-server dry-run against a restricted ServiceAccount (positive and negative), a field-rename mutation that must break it, and an install check that the policy **and its binding** exist.

## The rest

| Finding | Resolution |
|---|---|
| `allowedModes` included `plaintext`, but ADR-0010 says plaintext forbids TLS/credential fields — so such a grant authorizes a credential that mode cannot carry | Restricted to `tls`, `mtls`. Consent to a plaintext *destination* is transport policy, and belongs on a resource whose subject is the destination, not the Secret |
| Blanket "set semantics" — Kubernetes defines that for **scalar** lists and it gives object lists none of the uniqueness it implies | Per field: modes `set`; targets `map` on `[host, port]`; consumers `atomic` + CEL uniqueness on `name` — **atomic rather than requiring `uid`** so a GitOps author can write the grant before the consumer exists. Real `MaxItems` (2 / 16 / 32), not "capped" |
| "one shared canonicalizer in admission, controller and tests" | Not implementable — admission is CEL, which can neither call the Go canonicalizer nor mutate. Changed to **requiring canonical input**, which CEL *can* enforce, with defensive normalization in the controller |
| Generic `apiGroup`/`kind` advertised a ReferenceGrant-style lookup the controller does not implement | Pinned by CEL to the one consumer that exists; kept as fields so a second is additive |
| No condition semantics when enforcement is off | `Unknown` / `EnforcementDisabled`. `True` would read as "a grant authorized this" when nothing checked one |
| Nothing said what happens when enforcement is on but cannot run | **Fails closed**: readiness false if the CRD, informer cache, RBAC or required policy is missing. Silently unenforced is worse than a stopped rollout — the operator believes a boundary exists |

## Test plan

Every decision above has a corresponding entry, including the ones designed to fail if the implementation drifts: mutate the digest to trust its persisted value and the deletion case must fail; install the policy without its binding and the install check must fail; `allowedModes: [plaintext]` must be rejected by the schema.

## Verification

`make adr-lint`: OK (12 ADRs).
